### PR TITLE
feat: admission control for engine overload prevention

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,54 @@
+# Admission Control Implementation Progress
+
+## Completed
+
+### 1. AdmissionController (`src/infergrid/router/admission.py`)
+- Implemented concurrency limiting using `asyncio.Lock` + in-flight counter (not raw Semaphore, which cannot support priority ordering)
+- Priority queue with `asyncio.PriorityQueue` using `(priority, sequence_number)` tuples for priority + FIFO ordering
+- Cancelled/timed-out entries are skipped during `release()` drain
+- Prometheus metrics: `queue_depth` gauge, `in_flight` gauge, `admission_wait_seconds` histogram, `rejected_total` counter (by reason), `admitted_total` counter
+- Defined `AdmissionTimeoutError` for clean error propagation
+
+### 2. Configuration (`src/infergrid/common/config.py`)
+- Added `max_concurrent: int = 128` and `admission_queue_size: int = 1024` to `InferGridConfig`
+- Wired through `from_yaml()` and `from_cli_args()`
+
+### 3. Router Integration (`src/infergrid/router/router.py`)
+- `WorkloadRouter.__init__` creates an `AdmissionController` from config
+- `route_request()` calls `acquire()` before engine forwarding and `release()` in `finally` block
+- Priority derived from request length bucket (short=0, medium=1, long=2, xlarge=3)
+- `handle_request()` catches `AdmissionTimeoutError` and returns 503 with queue depth info
+- `snapshot()` includes admission stats
+
+### 4. CLI (`src/infergrid/cli.py`)
+- Added `--max-concurrent` flag to `serve` command (default: 128)
+- Help text explains the scheduling cliff context
+
+### 5. Tests (`tests/unit/test_admission.py`)
+- Below-threshold pass-through
+- Above-threshold queuing
+- Priority ordering (short before xlarge)
+- FIFO within same priority
+- Timeout behavior (returns False, timed-out entries skipped)
+- Stats accuracy
+- Concurrent stress test (100 simultaneous acquires)
+- Fast-path overhead test (<1ms per request)
+- Constructor validation
+
+### 6. Benchmark (`benchmarks/scripts/benchmark_admission.py`)
+- Sends N concurrent requests through direct engine and through InferGrid
+- Compares TTFT distributions
+- Uses existing `AsyncBenchmarkClient` from profiling_utils
+- Saves CSV results, comparison JSON, and prints summary table
+
+## Design Decisions
+
+1. **Lock + counter instead of Semaphore**: `asyncio.Semaphore` cannot support priority ordering. Using a lock-protected counter with a PriorityQueue gives us both concurrency control and priority-based admission.
+
+2. **Slot transfer in release()**: When a queued waiter is admitted, the in-flight count stays the same (slot transfers directly). This prevents a race where the count momentarily drops and another fast-path request sneaks in.
+
+3. **Cancelled entry cleanup**: Timed-out waiters set `cancelled=True` on their queue entry. `release()` skips cancelled entries when draining the queue, so stale entries don't block live waiters.
+
+4. **Admission in route_request, not handle_request**: All paths through `route_request` (including from queue workers) get admission-controlled. The 503 response is handled in `handle_request` which is the HTTP boundary.
+
+5. **Default max_concurrent=128**: Based on profiling data showing the cliff at c=128->c=256 across both vLLM and SGLang on A100 and H100 GPUs.

--- a/benchmarks/scripts/benchmark_admission.py
+++ b/benchmarks/scripts/benchmark_admission.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Benchmark: admission control vs. direct engine access.
+
+Simulates the scheduling cliff scenario observed in profiling:
+    - vLLM A100: c=128->c=256 yields +0.4% throughput but +1434% TTFT
+    - SGLang A100: c=128->c=256 yields -1.2% throughput but +928% TTFT
+
+Sends 256 concurrent requests through two paths:
+    1. Via InferGrid with admission control (max_concurrent=128)
+    2. Directly to the engine (no admission control)
+
+Then compares TTFT distributions to quantify the value of admission control.
+
+Usage:
+    python benchmarks/scripts/benchmark_admission.py \\
+        --engine-url http://localhost:8000 \\
+        --infergrid-url http://localhost:8080 \\
+        --model meta-llama/Llama-3.1-8B-Instruct \\
+        --total-requests 256 \\
+        --max-concurrent 128 \\
+        --output-dir results/admission_benchmark
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+# Add project root to path for imports
+_project_root = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(_project_root))
+sys.path.insert(0, str(_project_root / "profiling" / "scripts"))
+
+from profiling_utils import (
+    AsyncBenchmarkClient,
+    BenchmarkResults,
+    GPUMetricsCollector,
+    RequestGenerator,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Parsed argument namespace.
+    """
+    parser = argparse.ArgumentParser(
+        description="Benchmark admission control vs direct engine access",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--engine-url",
+        type=str,
+        required=True,
+        help="Direct engine URL (e.g. http://localhost:8000)",
+    )
+    parser.add_argument(
+        "--infergrid-url",
+        type=str,
+        required=True,
+        help="InferGrid proxy URL (e.g. http://localhost:8080)",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="meta-llama/Llama-3.1-8B-Instruct",
+        help="Model name for requests",
+    )
+    parser.add_argument(
+        "--total-requests",
+        type=int,
+        default=256,
+        help="Total number of concurrent requests to send (default: 256)",
+    )
+    parser.add_argument(
+        "--max-concurrent",
+        type=int,
+        default=128,
+        help="Max concurrent requests for InferGrid admission control (default: 128)",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=128,
+        help="Max output tokens per request (default: 128)",
+    )
+    parser.add_argument(
+        "--input-tokens",
+        type=int,
+        default=256,
+        help="Approximate input token count per request (default: 256)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="results/admission_benchmark",
+        help="Directory for output files",
+    )
+    parser.add_argument(
+        "--gpu-monitor",
+        action="store_true",
+        default=False,
+        help="Enable GPU metrics collection",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for reproducibility (default: 42)",
+    )
+    return parser.parse_args()
+
+
+async def run_benchmark(
+    base_url: str,
+    model: str,
+    requests: list[dict[str, Any]],
+    concurrency: int,
+    label: str,
+    gpu_collector: GPUMetricsCollector | None = None,
+) -> BenchmarkResults:
+    """Run a benchmark against a single endpoint.
+
+    Args:
+        base_url: Target server URL.
+        model: Model name.
+        requests: List of request dicts.
+        concurrency: Max concurrent requests.
+        label: Human-readable label for logging.
+        gpu_collector: Optional GPU metrics collector.
+
+    Returns:
+        BenchmarkResults with per-request timing data.
+    """
+    logger.info(
+        "Starting %s benchmark: %d requests, concurrency=%d, target=%s",
+        label,
+        len(requests),
+        concurrency,
+        base_url,
+    )
+
+    client = AsyncBenchmarkClient(
+        base_url=base_url,
+        model_name=model,
+        concurrency_level=concurrency,
+        timeout_s=120,
+    )
+
+    start = time.time()
+    results = await client.run(requests, gpu_collector=gpu_collector)
+    elapsed = time.time() - start
+
+    summary = results.summary()
+    logger.info("%s complete in %.1fs:", label, elapsed)
+    logger.info("  Successful: %d / %d", summary.get("num_successful", 0), len(requests))
+    logger.info("  TTFT p50: %.1fms", summary.get("ttft_p50_ms", 0))
+    logger.info("  TTFT p99: %.1fms", summary.get("ttft_p99_ms", 0))
+    logger.info(
+        "  Throughput: %.1f tok/s",
+        summary.get("throughput_tok_per_sec", 0),
+    )
+
+    return results
+
+
+def compare_results(
+    direct_results: BenchmarkResults,
+    admission_results: BenchmarkResults,
+) -> dict[str, Any]:
+    """Compare direct vs admission-controlled results.
+
+    Args:
+        direct_results: Results from direct engine access.
+        admission_results: Results from InferGrid with admission control.
+
+    Returns:
+        Comparison summary dictionary.
+    """
+    direct_summary = direct_results.summary()
+    admission_summary = admission_results.summary()
+
+    def safe_pct_change(old: float, new: float) -> float:
+        if old == 0:
+            return 0.0
+        return ((new - old) / old) * 100
+
+    comparison: dict[str, Any] = {
+        "direct": direct_summary,
+        "admission_controlled": admission_summary,
+        "improvements": {},
+    }
+
+    # TTFT improvement (lower is better, so negative % = improvement)
+    for metric in ["ttft_p50_ms", "ttft_p99_ms"]:
+        direct_val = direct_summary.get(metric, 0)
+        admission_val = admission_summary.get(metric, 0)
+        pct = safe_pct_change(direct_val, admission_val)
+        comparison["improvements"][metric] = {
+            "direct": round(direct_val, 2),
+            "admission": round(admission_val, 2),
+            "change_pct": round(pct, 2),
+            "improved": pct < 0,
+        }
+
+    # Throughput (higher is better)
+    direct_tps = direct_summary.get("throughput_tok_per_sec", 0)
+    admission_tps = admission_summary.get("throughput_tok_per_sec", 0)
+    tps_pct = safe_pct_change(direct_tps, admission_tps)
+    comparison["improvements"]["throughput_tok_per_sec"] = {
+        "direct": round(direct_tps, 2),
+        "admission": round(admission_tps, 2),
+        "change_pct": round(tps_pct, 2),
+    }
+
+    return comparison
+
+
+def print_comparison(comparison: dict[str, Any]) -> None:
+    """Print a formatted comparison table.
+
+    Args:
+        comparison: Comparison dictionary from compare_results().
+    """
+    print("\n" + "=" * 70)
+    print("ADMISSION CONTROL BENCHMARK RESULTS")
+    print("=" * 70)
+
+    improvements = comparison.get("improvements", {})
+
+    header = f"{'Metric':<30} {'Direct':>12} {'Admission':>12} {'Change':>10}"
+    print(header)
+    print("-" * 70)
+
+    for metric, data in improvements.items():
+        label = metric.replace("_", " ").replace("ms", " (ms)").replace("tok per sec", "(tok/s)")
+        direct_val = data.get("direct", 0)
+        admission_val = data.get("admission", 0)
+        change_pct = data.get("change_pct", 0)
+        sign = "+" if change_pct > 0 else ""
+        row = f"{label:<30} {direct_val:>12.1f} {admission_val:>12.1f} {sign}{change_pct:>8.1f}%"
+        print(row)
+
+    print("=" * 70)
+
+    # Highlight TTFT improvement
+    ttft_p99 = improvements.get("ttft_p99_ms", {})
+    if ttft_p99.get("improved"):
+        print(
+            f"\nAdmission control REDUCED p99 TTFT by "
+            f"{abs(ttft_p99['change_pct']):.1f}% "
+            f"({ttft_p99['direct']:.1f}ms -> {ttft_p99['admission']:.1f}ms)"
+        )
+    else:
+        print(
+            f"\nDirect access had LOWER p99 TTFT "
+            f"({ttft_p99.get('direct', 0):.1f}ms vs "
+            f"{ttft_p99.get('admission', 0):.1f}ms). "
+            f"Consider increasing --max-concurrent."
+        )
+
+
+async def main() -> None:
+    """Run the admission control benchmark."""
+    args = parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+    )
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Generate requests
+    generator = RequestGenerator(seed=args.seed)
+    requests = generator.generate_fixed_length(
+        n=args.total_requests,
+        input_len=args.input_tokens,
+        output_len=args.max_tokens,
+    )
+
+    logger.info(
+        "Generated %d requests (input~%d tokens, output~%d tokens)",
+        len(requests),
+        args.input_tokens,
+        args.max_tokens,
+    )
+
+    # Optional GPU monitoring
+    gpu_collector = GPUMetricsCollector() if args.gpu_monitor else None
+
+    # Benchmark 1: Direct engine access (no admission control)
+    logger.info("--- Phase 1: Direct engine access (no admission control) ---")
+    direct_results = await run_benchmark(
+        base_url=args.engine_url,
+        model=args.model,
+        requests=requests,
+        concurrency=args.total_requests,  # All at once
+        label="Direct",
+        gpu_collector=gpu_collector,
+    )
+
+    # Brief pause between benchmarks to let the engine settle
+    logger.info("Waiting 10s for engine to stabilize between benchmarks...")
+    await asyncio.sleep(10)
+
+    # Benchmark 2: Through InferGrid with admission control
+    logger.info("--- Phase 2: InferGrid with admission control ---")
+    admission_results = await run_benchmark(
+        base_url=args.infergrid_url,
+        model=args.model,
+        requests=requests,
+        concurrency=args.total_requests,  # All at once (InferGrid handles queuing)
+        label="Admission-controlled",
+        gpu_collector=gpu_collector,
+    )
+
+    # Save raw results
+    direct_results.to_csv(output_dir / "direct_results.csv")
+    admission_results.to_csv(output_dir / "admission_results.csv")
+
+    if gpu_collector is not None:
+        gpu_collector.to_csv(output_dir / "gpu_metrics.csv")
+
+    # Compare
+    comparison = compare_results(direct_results, admission_results)
+
+    comparison_path = output_dir / "comparison.json"
+    with open(comparison_path, "w") as f:
+        json.dump(comparison, f, indent=2, default=str)
+    logger.info("Comparison saved to %s", comparison_path)
+
+    # Save config
+    config = {
+        "engine_url": args.engine_url,
+        "infergrid_url": args.infergrid_url,
+        "model": args.model,
+        "total_requests": args.total_requests,
+        "max_concurrent": args.max_concurrent,
+        "max_tokens": args.max_tokens,
+        "input_tokens": args.input_tokens,
+        "seed": args.seed,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+    }
+    config_path = output_dir / "benchmark_config.json"
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+
+    print_comparison(comparison)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/infergrid/cli.py
+++ b/src/infergrid/cli.py
@@ -67,6 +67,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Default engine backend (default: vllm)",
     )
     serve_parser.add_argument(
+        "--max-concurrent",
+        type=int,
+        default=128,
+        help=(
+            "Maximum concurrent requests forwarded to the engine. "
+            "Requests beyond this limit are queued with priority ordering. "
+            "Set based on engine profiling -- above the cliff point, TTFT "
+            "degrades dramatically with minimal throughput gain. (default: 128)"
+        ),
+    )
+    serve_parser.add_argument(
         "--config",
         type=str,
         default=None,
@@ -195,6 +206,7 @@ def _cmd_serve(args: argparse.Namespace) -> None:
             gpu_budget=gpu_budget,
             port=args.port,
             engine=args.engine,
+            max_concurrent=args.max_concurrent,
         )
     config.log_level = args.log_level
 

--- a/src/infergrid/common/config.py
+++ b/src/infergrid/common/config.py
@@ -75,6 +75,8 @@ class InferGridConfig:
     models: list[ModelConfig] = field(default_factory=list)
     cache: CacheConfig = field(default_factory=CacheConfig)
     tenant_defaults: TenantDefaults = field(default_factory=TenantDefaults)
+    max_concurrent: int = 128
+    admission_queue_size: int = 1024
     engine_start_timeout_s: int = 300
     health_check_interval_s: int = 10
     log_level: str = "INFO"
@@ -121,6 +123,8 @@ class InferGridConfig:
             models=models,
             cache=cache,
             tenant_defaults=tenant_defaults,
+            max_concurrent=raw.get("max_concurrent", 128),
+            admission_queue_size=raw.get("admission_queue_size", 1024),
             engine_start_timeout_s=raw.get("engine_start_timeout_s", 300),
             health_check_interval_s=raw.get("health_check_interval_s", 10),
             log_level=raw.get("log_level", "INFO"),
@@ -134,6 +138,7 @@ class InferGridConfig:
         gpu_budget: float = 0.80,
         port: int = 8080,
         engine: str = "vllm",
+        max_concurrent: int = 128,
     ) -> InferGridConfig:
         """Build configuration from CLI arguments.
 
@@ -142,6 +147,7 @@ class InferGridConfig:
             gpu_budget: Fraction of GPU memory to use (0.0-1.0).
             port: API server port.
             engine: Default engine backend ("vllm" or "sglang").
+            max_concurrent: Maximum concurrent requests to an engine.
 
         Returns:
             Populated InferGridConfig instance.
@@ -153,4 +159,5 @@ class InferGridConfig:
             port=port,
             gpu_budget_fraction=gpu_budget,
             models=models,
+            max_concurrent=max_concurrent,
         )

--- a/src/infergrid/router/__init__.py
+++ b/src/infergrid/router/__init__.py
@@ -1,5 +1,6 @@
 """InferGrid request routing and model lifecycle management."""
 
+from infergrid.router.admission import AdmissionController, AdmissionTimeoutError
 from infergrid.router.router import (
     BudgetExceededError,
     ModelState,
@@ -8,6 +9,8 @@ from infergrid.router.router import (
 )
 
 __all__ = [
+    "AdmissionController",
+    "AdmissionTimeoutError",
     "BudgetExceededError",
     "ModelState",
     "WorkloadRouter",

--- a/src/infergrid/router/admission.py
+++ b/src/infergrid/router/admission.py
@@ -1,0 +1,309 @@
+"""Admission controller for engine overload prevention.
+
+Limits the number of concurrent requests forwarded to an inference engine
+to keep it below its throughput-saturation cliff point. Requests that
+arrive when the engine is at capacity are queued with priority ordering
+(lower priority value = higher priority) and FIFO tie-breaking.
+
+Profiling context:
+    vLLM A100: c=128->c=256 yields +0.4% throughput but +1434% TTFT
+    SGLang A100: c=128->c=256 yields -1.2% throughput but +928% TTFT
+    The admission controller prevents this cliff by capping concurrency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(order=True)
+class _QueueEntry:
+    """Internal priority queue entry.
+
+    Ordered by (priority, sequence) so that lower priority values
+    are dequeued first, with FIFO ordering among equal priorities.
+
+    Attributes:
+        priority: Lower values are dequeued first.
+        sequence: Monotonic counter for FIFO tie-breaking.
+        event: Signalled when the request is admitted.
+        cancelled: Set to True if the waiter timed out.
+    """
+
+    priority: int
+    sequence: int
+    event: asyncio.Event = field(compare=False, default_factory=asyncio.Event)
+    cancelled: bool = field(compare=False, default=False)
+
+
+class AdmissionTimeoutError(Exception):
+    """Raised when a request times out waiting for admission."""
+
+    def __init__(self, queue_depth: int, in_flight: int) -> None:
+        self.queue_depth = queue_depth
+        self.in_flight = in_flight
+        super().__init__(
+            f"Admission timeout: {in_flight} in-flight, {queue_depth} queued"
+        )
+
+
+class AdmissionController:
+    """Prevents engine overload by controlling request admission rate.
+
+    Uses a concurrency counter protected by an asyncio.Lock, with a
+    PriorityQueue for waiters when the engine is at capacity. This
+    design supports priority ordering (short requests first) while
+    maintaining FIFO order within the same priority level.
+
+    The overhead when not queuing (in-flight < max_concurrent) is a
+    single lock acquire/release, which is sub-microsecond on modern
+    hardware -- well under the 1ms budget.
+
+    Args:
+        max_concurrent: Maximum requests forwarded to the engine at once.
+        queue_size: Maximum number of requests waiting in the admission queue.
+        registry: Optional Prometheus CollectorRegistry for metrics.
+    """
+
+    def __init__(
+        self,
+        max_concurrent: int = 128,
+        queue_size: int = 1024,
+        registry: CollectorRegistry | None = None,
+    ) -> None:
+        if max_concurrent < 1:
+            raise ValueError(f"max_concurrent must be >= 1, got {max_concurrent}")
+        if queue_size < 0:
+            raise ValueError(f"queue_size must be >= 0, got {queue_size}")
+
+        self._max_concurrent = max_concurrent
+        self._queue_size = queue_size
+        self._in_flight = 0
+        self._sequence = 0
+        self._lock = asyncio.Lock()
+        self._waiters: asyncio.PriorityQueue[_QueueEntry] = asyncio.PriorityQueue()
+
+        # Metrics tracking (non-Prometheus, always available)
+        self._total_admitted: int = 0
+        self._total_rejected: int = 0
+        self._total_timed_out: int = 0
+
+        # Prometheus metrics (optional)
+        self._registry = registry
+        if registry is not None:
+            self._prom_queue_depth = Gauge(
+                "infergrid_admission_queue_depth",
+                "Number of requests waiting in the admission queue",
+                registry=registry,
+            )
+            self._prom_in_flight = Gauge(
+                "infergrid_admission_in_flight",
+                "Number of requests currently being processed by the engine",
+                registry=registry,
+            )
+            self._prom_wait_seconds = Histogram(
+                "infergrid_admission_wait_seconds",
+                "Time spent waiting for admission",
+                buckets=(0.001, 0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 5.0, 10.0, 30.0),
+                registry=registry,
+            )
+            self._prom_rejected_total = Counter(
+                "infergrid_admission_rejected_total",
+                "Total requests rejected (queue full or timed out)",
+                labelnames=["reason"],
+                registry=registry,
+            )
+            self._prom_admitted_total = Counter(
+                "infergrid_admission_admitted_total",
+                "Total requests admitted to the engine",
+                registry=registry,
+            )
+        else:
+            self._prom_queue_depth = None
+            self._prom_in_flight = None
+            self._prom_wait_seconds = None
+            self._prom_rejected_total = None
+            self._prom_admitted_total = None
+
+        logger.info(
+            "AdmissionController initialized: max_concurrent=%d, queue_size=%d",
+            max_concurrent,
+            queue_size,
+        )
+
+    @property
+    def max_concurrent(self) -> int:
+        """Maximum concurrent requests allowed."""
+        return self._max_concurrent
+
+    @property
+    def in_flight(self) -> int:
+        """Current number of in-flight requests."""
+        return self._in_flight
+
+    @property
+    def queue_depth(self) -> int:
+        """Current number of requests waiting in the queue.
+
+        NOTE: This may overcount when timed-out waiters have left cancelled
+        entries in the PriorityQueue. Cancelled entries are drained lazily
+        during release(). For accurate live counts, subtract _total_timed_out
+        from the cumulative queue puts, but the qsize approximation is
+        sufficient for metrics and admission decisions.
+        """
+        return self._waiters.qsize()
+
+    async def acquire(self, priority: int = 0, timeout: float = 30.0) -> bool:
+        """Wait for admission to forward a request to the engine.
+
+        If the engine has capacity (in_flight < max_concurrent), the
+        request is admitted immediately. Otherwise it is queued by
+        priority (lower = higher priority) with FIFO tie-breaking.
+
+        Args:
+            priority: Request priority. Lower values are served first.
+                Convention: 0=short, 1=medium, 2=long, 3=xlarge.
+            timeout: Maximum seconds to wait. 0 means no waiting.
+
+        Returns:
+            True if admitted, False if the queue is full or timeout expired.
+        """
+        wait_start = time.monotonic()
+
+        async with self._lock:
+            if self._in_flight < self._max_concurrent:
+                # Fast path: engine has capacity
+                self._in_flight += 1
+                self._total_admitted += 1
+                self._record_admission(wait_start)
+                return True
+
+            # Slow path: engine at capacity, check queue space
+            if self._waiters.qsize() >= self._queue_size:
+                self._total_rejected += 1
+                self._record_rejection("queue_full")
+                return False
+
+            # Enqueue this waiter
+            entry = _QueueEntry(
+                priority=priority,
+                sequence=self._sequence,
+            )
+            self._sequence += 1
+            await self._waiters.put(entry)
+            self._update_queue_depth_metric()
+
+        # Wait outside the lock for admission
+        try:
+            await asyncio.wait_for(entry.event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            entry.cancelled = True
+            self._total_timed_out += 1
+            self._record_rejection("timeout")
+            self._update_queue_depth_metric()
+            return False
+
+        # Admitted via release()
+        wait_elapsed = time.monotonic() - wait_start
+        self._total_admitted += 1
+        self._record_wait(wait_elapsed)
+        return True
+
+    def release(self) -> None:
+        """Release an admission slot after a request completes.
+
+        If there are waiters in the queue, the highest-priority one
+        is admitted immediately (the slot transfers directly). If the
+        queue is empty, the in-flight count is decremented.
+
+        Must be called exactly once for each successful acquire().
+        """
+        # We need to drain cancelled entries and find the next live waiter.
+        # This runs synchronously because PriorityQueue.get_nowait() is
+        # instant and we hold no awaitable state.
+        while True:
+            try:
+                entry = self._waiters.get_nowait()
+            except asyncio.QueueEmpty:
+                # No waiters -- just free the slot
+                self._in_flight -= 1
+                self._update_in_flight_metric()
+                self._update_queue_depth_metric()
+                return
+
+            if entry.cancelled:
+                # Skip cancelled entries (timed-out waiters)
+                continue
+
+            # Transfer the slot to this waiter (in_flight stays the same)
+            entry.event.set()
+            self._update_queue_depth_metric()
+            return
+
+    @property
+    def stats(self) -> dict[str, Any]:
+        """Current admission controller statistics.
+
+        Returns:
+            Dictionary with queue depth, in-flight count, totals, and rates.
+        """
+        total_decisions = self._total_admitted + self._total_rejected + self._total_timed_out
+        admission_rate = (
+            self._total_admitted / total_decisions if total_decisions > 0 else 1.0
+        )
+        rejection_rate = (
+            (self._total_rejected + self._total_timed_out) / total_decisions
+            if total_decisions > 0
+            else 0.0
+        )
+
+        return {
+            "max_concurrent": self._max_concurrent,
+            "queue_size": self._queue_size,
+            "in_flight": self._in_flight,
+            "queue_depth": self.queue_depth,
+            "total_admitted": self._total_admitted,
+            "total_rejected": self._total_rejected,
+            "total_timed_out": self._total_timed_out,
+            "admission_rate": round(admission_rate, 4),
+            "rejection_rate": round(rejection_rate, 4),
+        }
+
+    def _record_admission(self, wait_start: float) -> None:
+        """Record a fast-path admission in Prometheus metrics."""
+        elapsed = time.monotonic() - wait_start
+        if self._prom_admitted_total is not None:
+            self._prom_admitted_total.inc()
+        if self._prom_wait_seconds is not None:
+            self._prom_wait_seconds.observe(elapsed)
+        self._update_in_flight_metric()
+
+    def _record_wait(self, elapsed: float) -> None:
+        """Record a queued admission wait time in Prometheus metrics."""
+        if self._prom_admitted_total is not None:
+            self._prom_admitted_total.inc()
+        if self._prom_wait_seconds is not None:
+            self._prom_wait_seconds.observe(elapsed)
+
+    def _record_rejection(self, reason: str) -> None:
+        """Record a rejection in Prometheus metrics."""
+        if self._prom_rejected_total is not None:
+            self._prom_rejected_total.labels(reason=reason).inc()
+
+    def _update_in_flight_metric(self) -> None:
+        """Sync the Prometheus in-flight gauge."""
+        if self._prom_in_flight is not None:
+            self._prom_in_flight.set(self._in_flight)
+
+    def _update_queue_depth_metric(self) -> None:
+        """Sync the Prometheus queue depth gauge."""
+        if self._prom_queue_depth is not None:
+            self._prom_queue_depth.set(self.queue_depth)

--- a/src/infergrid/router/router.py
+++ b/src/infergrid/router/router.py
@@ -25,6 +25,7 @@ from infergrid.common.metrics import MetricsCollector
 from infergrid.engines.base import EngineAdapter
 from infergrid.engines.sglang_adapter.adapter import SGLangAdapter
 from infergrid.engines.vllm_adapter.adapter import VLLMAdapter
+from infergrid.router.admission import AdmissionController, AdmissionTimeoutError
 from infergrid.tenant.manager import TenantManager
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,14 @@ LENGTH_BUCKETS: list[tuple[str, int]] = [
     ("long", 4096),
     ("xlarge", 2**31),
 ]
+
+
+BUCKET_PRIORITY: dict[str, int] = {
+    "short": 0,
+    "medium": 1,
+    "long": 2,
+    "xlarge": 3,
+}
 
 
 def classify_request_length(max_tokens: int, input_tokens: int = 0) -> str:
@@ -146,6 +155,13 @@ class WorkloadRouter:
         self.metrics = metrics or MetricsCollector()
         self.cache_manager = cache_manager or CacheManager()
         self.tenant_manager = tenant_manager or TenantManager()
+
+        # Admission control -- prevents engine overload
+        self.admission_controller = AdmissionController(
+            max_concurrent=config.max_concurrent,
+            queue_size=config.admission_queue_size,
+            registry=self.metrics._registry,
+        )
 
         # model_id -> ModelState (only for currently loaded models)
         self._models: dict[str, ModelState] = {}
@@ -334,7 +350,8 @@ class WorkloadRouter:
     ) -> Any:
         """Route a single request to the appropriate engine.
 
-        Enforces tenant budgets, tracks metrics, and uses length-bucketed
+        Enforces tenant budgets, applies admission control to prevent
+        engine overload, tracks metrics, and uses length-bucketed
         scheduling for priority ordering.
 
         Args:
@@ -346,6 +363,11 @@ class WorkloadRouter:
 
         Returns:
             The engine's JSON response, or an async stream.
+
+        Raises:
+            BudgetExceededError: If the tenant has exceeded its budget.
+            AdmissionTimeoutError: If the request timed out waiting for
+                admission to the engine.
         """
         start_time = time.monotonic()
 
@@ -357,6 +379,22 @@ class WorkloadRouter:
             ).inc()
             raise BudgetExceededError(
                 f"Tenant {tenant_id!r} has exceeded its request budget"
+            )
+
+        # Determine admission priority from request length bucket
+        max_tokens = payload.get("max_tokens", 256)
+        bucket = classify_request_length(max_tokens)
+        priority = BUCKET_PRIORITY.get(bucket, 1)
+
+        # Admission control -- wait for engine capacity
+        admitted = await self.admission_controller.acquire(
+            priority=priority, timeout=30.0
+        )
+        if not admitted:
+            await self.tenant_manager.release_for_tenant(tenant_id)
+            raise AdmissionTimeoutError(
+                queue_depth=self.admission_controller.queue_depth,
+                in_flight=self.admission_controller.in_flight,
             )
 
         try:
@@ -403,6 +441,7 @@ class WorkloadRouter:
             )
             raise
         finally:
+            self.admission_controller.release()
             await self.tenant_manager.release_for_tenant(tenant_id)
 
     async def enqueue_request(
@@ -523,6 +562,16 @@ class WorkloadRouter:
 
             return web.json_response(result)
 
+        except AdmissionTimeoutError as exc:
+            return web.json_response(
+                {
+                    "error": "server overloaded",
+                    "detail": str(exc),
+                    "queue_depth": exc.queue_depth,
+                    "in_flight": exc.in_flight,
+                },
+                status=503,
+            )
         except BudgetExceededError as exc:
             return web.json_response(
                 {"error": str(exc)}, status=429
@@ -602,6 +651,7 @@ class WorkloadRouter:
         return {
             "loaded_models": self.model_stats(),
             "queue_depths": self.queue_depths(),
+            "admission": self.admission_controller.stats,
             "cache": self.cache_manager.snapshot(),
             "tenants": self.tenant_manager.snapshot(),
             "metrics": self.metrics.snapshot(),

--- a/tests/unit/test_admission.py
+++ b/tests/unit/test_admission.py
@@ -1,0 +1,457 @@
+"""Unit tests for the AdmissionController.
+
+Tests concurrency limiting, priority queue ordering, timeout behavior,
+stats reporting, and concurrent stress scenarios.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from infergrid.router.admission import (
+    AdmissionController,
+    AdmissionTimeoutError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Basic admission / release
+# ---------------------------------------------------------------------------
+
+
+class TestAdmissionBasic:
+    """Tests for basic acquire/release behavior."""
+
+    async def test_below_threshold_passes_immediately(self) -> None:
+        """Requests below max_concurrent are admitted without queuing."""
+        ac = AdmissionController(max_concurrent=4, queue_size=16)
+
+        for _ in range(4):
+            admitted = await ac.acquire(priority=0, timeout=1.0)
+            assert admitted is True
+
+        assert ac.in_flight == 4
+        assert ac.queue_depth == 0
+
+    async def test_at_threshold_queues(self) -> None:
+        """Requests at max_concurrent are queued, not rejected."""
+        ac = AdmissionController(max_concurrent=2, queue_size=16)
+
+        # Fill up capacity
+        assert await ac.acquire(priority=0, timeout=1.0)
+        assert await ac.acquire(priority=0, timeout=1.0)
+
+        # Next request should queue (and timeout since nobody releases)
+        admitted = await ac.acquire(priority=0, timeout=0.05)
+        assert admitted is False
+        assert ac.in_flight == 2
+
+    async def test_release_admits_next_queued(self) -> None:
+        """Releasing a slot admits the next queued request."""
+        ac = AdmissionController(max_concurrent=1, queue_size=16)
+
+        # Fill capacity
+        assert await ac.acquire(priority=0, timeout=1.0)
+        assert ac.in_flight == 1
+
+        # Start a waiter in the background
+        result_holder: list[bool] = []
+
+        async def waiter() -> None:
+            result = await ac.acquire(priority=0, timeout=5.0)
+            result_holder.append(result)
+
+        task = asyncio.create_task(waiter())
+        # Give the waiter time to enqueue
+        await asyncio.sleep(0.01)
+        assert ac.queue_depth == 1
+
+        # Release the slot -- waiter should be admitted
+        ac.release()
+        await asyncio.sleep(0.01)
+        await task
+
+        assert result_holder == [True]
+        assert ac.in_flight == 1  # slot transferred, not freed
+        assert ac.queue_depth == 0
+
+    async def test_release_with_empty_queue_decrements(self) -> None:
+        """Releasing when no waiters exist decrements in-flight count."""
+        ac = AdmissionController(max_concurrent=4, queue_size=16)
+
+        assert await ac.acquire(priority=0, timeout=1.0)
+        assert await ac.acquire(priority=0, timeout=1.0)
+        assert ac.in_flight == 2
+
+        ac.release()
+        assert ac.in_flight == 1
+
+        ac.release()
+        assert ac.in_flight == 0
+
+    async def test_queue_full_rejects(self) -> None:
+        """When the queue is full, new requests are rejected immediately."""
+        ac = AdmissionController(max_concurrent=1, queue_size=1)
+
+        # Fill capacity
+        assert await ac.acquire(priority=0, timeout=1.0)
+
+        # Fill queue (this will timeout since nobody releases)
+        task = asyncio.create_task(ac.acquire(priority=0, timeout=5.0))
+        await asyncio.sleep(0.01)
+
+        # Queue is full, next request should be rejected
+        admitted = await ac.acquire(priority=0, timeout=1.0)
+        assert admitted is False
+
+        # Clean up
+        ac.release()
+        await task
+
+
+# ---------------------------------------------------------------------------
+# Priority ordering
+# ---------------------------------------------------------------------------
+
+
+class TestAdmissionPriority:
+    """Tests for priority-based queue ordering."""
+
+    async def test_priority_ordering(self) -> None:
+        """Lower priority values are admitted before higher ones."""
+        ac = AdmissionController(max_concurrent=1, queue_size=16)
+
+        # Fill capacity
+        assert await ac.acquire(priority=0, timeout=1.0)
+
+        # Queue requests with different priorities
+        admission_order: list[str] = []
+
+        async def waiter(name: str, priority: int) -> None:
+            result = await ac.acquire(priority=priority, timeout=5.0)
+            if result:
+                admission_order.append(name)
+
+        # Start waiters: xlarge first, then short (lower priority number)
+        task_xlarge = asyncio.create_task(waiter("xlarge", 3))
+        await asyncio.sleep(0.005)
+        task_long = asyncio.create_task(waiter("long", 2))
+        await asyncio.sleep(0.005)
+        task_short = asyncio.create_task(waiter("short", 0))
+        await asyncio.sleep(0.005)
+
+        # All three should be queued
+        assert ac.queue_depth == 3
+
+        # Release slots one at a time
+        ac.release()
+        await asyncio.sleep(0.02)
+        ac.release()
+        await asyncio.sleep(0.02)
+        ac.release()
+        await asyncio.sleep(0.02)
+
+        await asyncio.gather(task_xlarge, task_long, task_short)
+
+        # Short (priority 0) should be admitted first
+        assert admission_order == ["short", "long", "xlarge"]
+
+        # Clean up
+        for _ in range(3):
+            ac.release()
+
+    async def test_fifo_within_same_priority(self) -> None:
+        """Requests with the same priority are served in FIFO order."""
+        ac = AdmissionController(max_concurrent=1, queue_size=16)
+
+        # Fill capacity
+        assert await ac.acquire(priority=0, timeout=1.0)
+
+        admission_order: list[str] = []
+
+        async def waiter(name: str) -> None:
+            result = await ac.acquire(priority=1, timeout=5.0)
+            if result:
+                admission_order.append(name)
+
+        # Queue three requests with the same priority
+        task_a = asyncio.create_task(waiter("A"))
+        await asyncio.sleep(0.005)
+        task_b = asyncio.create_task(waiter("B"))
+        await asyncio.sleep(0.005)
+        task_c = asyncio.create_task(waiter("C"))
+        await asyncio.sleep(0.01)
+
+        # Release slots
+        ac.release()
+        await asyncio.sleep(0.02)
+        ac.release()
+        await asyncio.sleep(0.02)
+        ac.release()
+        await asyncio.sleep(0.02)
+
+        await asyncio.gather(task_a, task_b, task_c)
+
+        assert admission_order == ["A", "B", "C"]
+
+        for _ in range(3):
+            ac.release()
+
+
+# ---------------------------------------------------------------------------
+# Timeout behavior
+# ---------------------------------------------------------------------------
+
+
+class TestAdmissionTimeout:
+    """Tests for timeout handling."""
+
+    async def test_timeout_returns_false(self) -> None:
+        """Timed-out requests return False without blocking forever."""
+        ac = AdmissionController(max_concurrent=1, queue_size=16)
+
+        # Fill capacity
+        assert await ac.acquire(priority=0, timeout=1.0)
+
+        # This should timeout
+        start = time.monotonic()
+        admitted = await ac.acquire(priority=0, timeout=0.05)
+        elapsed = time.monotonic() - start
+
+        assert admitted is False
+        assert elapsed < 0.2  # Should timeout roughly at 50ms
+
+        ac.release()
+
+    async def test_timed_out_entry_is_skipped_on_release(self) -> None:
+        """Cancelled entries from timed-out waiters are skipped by release()."""
+        ac = AdmissionController(max_concurrent=1, queue_size=16)
+
+        # Fill capacity
+        assert await ac.acquire(priority=0, timeout=1.0)
+
+        # This request will timeout
+        admitted_slow = await ac.acquire(priority=0, timeout=0.02)
+        assert admitted_slow is False
+
+        # Queue a second waiter that will be patient
+        admission_result: list[bool] = []
+
+        async def patient_waiter() -> None:
+            result = await ac.acquire(priority=0, timeout=5.0)
+            admission_result.append(result)
+
+        task = asyncio.create_task(patient_waiter())
+        await asyncio.sleep(0.01)
+
+        # Release should skip the timed-out entry and admit the patient one
+        ac.release()
+        await asyncio.sleep(0.01)
+        await task
+
+        assert admission_result == [True]
+
+        ac.release()
+
+    async def test_zero_timeout_immediate_rejection_when_full(self) -> None:
+        """timeout=0 means no waiting when the engine is at capacity."""
+        ac = AdmissionController(max_concurrent=1, queue_size=16)
+
+        assert await ac.acquire(priority=0, timeout=1.0)
+
+        # Zero timeout should fail immediately
+        admitted = await ac.acquire(priority=0, timeout=0)
+        assert admitted is False
+
+        ac.release()
+
+
+# ---------------------------------------------------------------------------
+# Stats reporting
+# ---------------------------------------------------------------------------
+
+
+class TestAdmissionStats:
+    """Tests for stats property accuracy."""
+
+    async def test_initial_stats(self) -> None:
+        """Stats should be correct at initialization."""
+        ac = AdmissionController(max_concurrent=64, queue_size=256)
+        stats = ac.stats
+
+        assert stats["max_concurrent"] == 64
+        assert stats["queue_size"] == 256
+        assert stats["in_flight"] == 0
+        assert stats["queue_depth"] == 0
+        assert stats["total_admitted"] == 0
+        assert stats["total_rejected"] == 0
+        assert stats["total_timed_out"] == 0
+        assert stats["admission_rate"] == 1.0  # no decisions yet -> default 1.0
+        assert stats["rejection_rate"] == 0.0
+
+    async def test_stats_after_admits_and_rejections(self) -> None:
+        """Stats should reflect actual admits and rejections."""
+        ac = AdmissionController(max_concurrent=1, queue_size=1)
+
+        # One admit
+        assert await ac.acquire(priority=0, timeout=1.0)
+
+        # One timeout (queue will have this then we overflow)
+        task = asyncio.create_task(ac.acquire(priority=0, timeout=5.0))
+        await asyncio.sleep(0.01)
+
+        # One rejection (queue full)
+        admitted = await ac.acquire(priority=0, timeout=0.01)
+        assert admitted is False
+
+        stats = ac.stats
+        assert stats["in_flight"] == 1
+        assert stats["total_admitted"] == 1
+        assert stats["total_rejected"] == 1
+
+        # Clean up
+        ac.release()
+        await task
+        ac.release()
+
+    async def test_admission_rate_calculation(self) -> None:
+        """Admission and rejection rates should be calculated correctly."""
+        ac = AdmissionController(max_concurrent=2, queue_size=16)
+
+        # 4 admits
+        for _ in range(4):
+            assert await ac.acquire(priority=0, timeout=1.0)
+            ac.release()
+
+        stats = ac.stats
+        assert stats["total_admitted"] == 4
+        assert stats["total_rejected"] == 0
+        assert stats["admission_rate"] == 1.0
+        assert stats["rejection_rate"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Concurrent stress test
+# ---------------------------------------------------------------------------
+
+
+class TestAdmissionStress:
+    """Stress tests for concurrent admission control."""
+
+    async def test_100_concurrent_acquires(self) -> None:
+        """100 simultaneous acquire calls should not corrupt state."""
+        ac = AdmissionController(max_concurrent=10, queue_size=200)
+        results: list[bool] = []
+        lock = asyncio.Lock()
+
+        async def worker(worker_id: int) -> None:
+            admitted = await ac.acquire(priority=worker_id % 4, timeout=2.0)
+            async with lock:
+                results.append(admitted)
+            if admitted:
+                # Simulate some work
+                await asyncio.sleep(0.01)
+                ac.release()
+
+        tasks = [asyncio.create_task(worker(i)) for i in range(100)]
+        await asyncio.gather(*tasks)
+
+        assert len(results) == 100
+        # All should have been admitted (enough timeout, all release quickly)
+        admitted_count = sum(1 for r in results if r)
+        assert admitted_count == 100
+
+        assert ac.in_flight == 0
+        assert ac.queue_depth == 0
+
+    async def test_stress_with_limited_capacity(self) -> None:
+        """Stress test where capacity is very limited but queue is large."""
+        ac = AdmissionController(max_concurrent=2, queue_size=100)
+        admitted_count = 0
+        lock = asyncio.Lock()
+
+        async def worker() -> None:
+            nonlocal admitted_count
+            result = await ac.acquire(priority=0, timeout=5.0)
+            if result:
+                async with lock:
+                    admitted_count += 1
+                await asyncio.sleep(0.005)
+                ac.release()
+
+        tasks = [asyncio.create_task(worker()) for _ in range(50)]
+        await asyncio.gather(*tasks)
+
+        assert admitted_count == 50
+        assert ac.in_flight == 0
+
+    async def test_fast_path_overhead(self) -> None:
+        """Verify that the fast path (no queuing) adds minimal overhead.
+
+        The requirement is <1ms overhead per request when not queuing.
+        """
+        ac = AdmissionController(max_concurrent=1000, queue_size=16)
+
+        # Warm up
+        for _ in range(10):
+            await ac.acquire(priority=0, timeout=1.0)
+            ac.release()
+
+        # Measure fast-path overhead
+        iterations = 1000
+        start = time.monotonic()
+        for _ in range(iterations):
+            await ac.acquire(priority=0, timeout=1.0)
+            ac.release()
+        elapsed_ms = (time.monotonic() - start) * 1000
+
+        overhead_per_request_ms = elapsed_ms / iterations
+        # Should be well under 1ms per acquire+release cycle
+        assert overhead_per_request_ms < 1.0, (
+            f"Fast-path overhead {overhead_per_request_ms:.3f}ms exceeds 1ms budget"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestAdmissionValidation:
+    """Tests for constructor validation."""
+
+    def test_invalid_max_concurrent(self) -> None:
+        with pytest.raises(ValueError, match="max_concurrent"):
+            AdmissionController(max_concurrent=0)
+
+    def test_invalid_queue_size(self) -> None:
+        with pytest.raises(ValueError, match="queue_size"):
+            AdmissionController(queue_size=-1)
+
+    async def test_zero_queue_size_is_valid(self) -> None:
+        """A queue size of 0 means no queuing -- reject immediately at capacity."""
+        ac = AdmissionController(max_concurrent=1, queue_size=0)
+        assert await ac.acquire(priority=0, timeout=1.0)
+        # At capacity with queue_size=0, should reject immediately
+        admitted = await ac.acquire(priority=0, timeout=0.05)
+        assert admitted is False
+        ac.release()
+
+
+# ---------------------------------------------------------------------------
+# AdmissionTimeoutError
+# ---------------------------------------------------------------------------
+
+
+class TestAdmissionTimeoutError:
+    """Tests for the AdmissionTimeoutError exception."""
+
+    def test_error_attributes(self) -> None:
+        err = AdmissionTimeoutError(queue_depth=5, in_flight=128)
+        assert err.queue_depth == 5
+        assert err.in_flight == 128
+        assert "128" in str(err)
+        assert "5" in str(err)


### PR DESCRIPTION
## Summary
- AdmissionController caps concurrent requests at configurable threshold (default: 128)
- Priority queue: short requests first, FIFO within same priority
- 503 with queue depth on timeout
- Prometheus metrics: queue_depth, in_flight, admission_wait_seconds
- CLI: `--max-concurrent 128`

## Motivation
Profiling data shows the scheduling cliff: c=128->c=256 yields +0.4% throughput but +1434% TTFT.

## Changes
- `src/infergrid/router/admission.py` (309 LOC) — core controller
- `tests/unit/test_admission.py` (457 LOC) — 16 test cases
- `benchmarks/scripts/benchmark_admission.py` (364 LOC) — comparison benchmark
- Modified: router.py, config.py, cli.py, __init__.py

## Test plan
- [ ] `pytest tests/unit/test_admission.py -v`
- [ ] Verify existing tests still pass
- [ ] Run benchmark_admission.py against live engine