### PR TITLE
refactor: deduplicate adapters, fix code review items

### DIFF
--- a/src/infergrid/cli.py
+++ b/src/infergrid/cli.py
@@ -238,8 +238,10 @@ def _cmd_status(args: argparse.Namespace) -> None:
     url = f"http://localhost:{args.port}/infergrid/status"
     try:
         data = asyncio.run(_fetch_json(url))
-    except Exception as exc:
-        print(f"Error connecting to InferGrid at port {args.port}: {exc}")
+    except Exception:
+        logger.error(
+            "Error connecting to InferGrid at port %d", args.port, exc_info=True,
+        )
         sys.exit(1)
 
     print(json.dumps(data, indent=2))
@@ -250,8 +252,10 @@ def _cmd_models(args: argparse.Namespace) -> None:
     url = f"http://localhost:{args.port}/v1/models"
     try:
         data = asyncio.run(_fetch_json(url))
-    except Exception as exc:
-        print(f"Error connecting to InferGrid at port {args.port}: {exc}")
+    except Exception:
+        logger.error(
+            "Error connecting to InferGrid at port %d", args.port, exc_info=True,
+        )
         sys.exit(1)
 
     models = data.get("data", [])

--- a/src/infergrid/engines/base.py
+++ b/src/infergrid/engines/base.py
@@ -1,29 +1,42 @@
-"""Abstract base class for LLM engine adapters.
+"""Base class for LLM engine adapters.
 
-Both vLLM and SGLang adapters implement this interface, providing
-a uniform way for the router to start/stop engines and forward
-OpenAI-compatible requests.
+Both vLLM and SGLang adapters inherit from EngineAdapter, which provides
+the shared logic for starting/stopping the subprocess, health-checking,
+and forwarding OpenAI-compatible requests.  Subclasses only need to
+implement ``_build_cmd()`` and set ``engine_name``.
 """
 
 from __future__ import annotations
 
 import abc
-from typing import Any
+import asyncio
+import logging
+from typing import Any, AsyncIterator
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
 
 
 class EngineAdapter(abc.ABC):
-    """Base interface for engine adapters.
+    """Base class for engine adapters.
 
     Each adapter manages a single engine subprocess and proxies
     OpenAI-compatible HTTP requests to it.
+
+    Subclasses must set ``engine_name`` and implement ``_build_cmd()``.
 
     Args:
         model_id: HuggingFace model identifier.
         port: Port number for the engine's HTTP server.
         gpu_memory_utilization: Fraction of GPU memory the engine may use.
         tensor_parallel_size: Number of GPUs for tensor parallelism.
+        dtype: Weight data type (e.g. "bfloat16", "float16", "auto").
+        max_model_len: Maximum sequence length.
         extra_args: Additional CLI arguments for the engine process.
     """
+
+    engine_name: str  # e.g. "vLLM" or "SGLang" -- set by subclasses
 
     def __init__(
         self,
@@ -31,21 +44,37 @@ class EngineAdapter(abc.ABC):
         port: int,
         gpu_memory_utilization: float = 0.85,
         tensor_parallel_size: int = 1,
+        dtype: str = "auto",
+        max_model_len: int = 8192,
         extra_args: list[str] | None = None,
     ) -> None:
         self.model_id = model_id
         self.port = port
         self.gpu_memory_utilization = gpu_memory_utilization
         self.tensor_parallel_size = tensor_parallel_size
+        self.dtype = dtype
+        self.max_model_len = max_model_len
         self.extra_args = extra_args or []
         self._healthy = False
+        self._process: asyncio.subprocess.Process | None = None
 
     @property
     def base_url(self) -> str:
         """HTTP base URL for this engine instance."""
         return f"http://localhost:{self.port}"
 
+    # ── Abstract: subclasses must implement ────────────────────────
+
     @abc.abstractmethod
+    def _build_cmd(self) -> list[str]:
+        """Build the engine server launch command.
+
+        Returns:
+            Command as a list of strings.
+        """
+
+    # ── Lifecycle ──────────────────────────────────────────────────
+
     async def start(self, timeout_s: int = 300) -> None:
         """Start the engine subprocess and wait until it is ready.
 
@@ -56,37 +85,143 @@ class EngineAdapter(abc.ABC):
             TimeoutError: If the engine does not become healthy in time.
             RuntimeError: If the engine process exits unexpectedly.
         """
+        cmd = self._build_cmd()
+        logger.info("Starting %s server: %s", self.engine_name, " ".join(cmd))
 
-    @abc.abstractmethod
+        self._process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        # Poll for health
+        deadline = asyncio.get_event_loop().time() + timeout_s
+        while asyncio.get_event_loop().time() < deadline:
+            if self._process.returncode is not None:
+                stderr = ""
+                if self._process.stderr:
+                    stderr_bytes = await self._process.stderr.read()
+                    stderr = stderr_bytes.decode(errors="replace")[-2000:]
+                raise RuntimeError(
+                    f"{self.engine_name} process exited with code "
+                    f"{self._process.returncode}: {stderr}"
+                )
+
+            if await self.health_check():
+                self._healthy = True
+                logger.info(
+                    "%s server ready on port %d for model %s",
+                    self.engine_name, self.port, self.model_id,
+                )
+                return
+
+            await asyncio.sleep(2.0)
+
+        # Timed out -- kill the process
+        await self.stop()
+        raise TimeoutError(
+            f"{self.engine_name} server did not become healthy within {timeout_s}s"
+        )
+
     async def stop(self) -> None:
         """Stop the engine subprocess gracefully."""
+        if self._process is None:
+            return
 
-    @abc.abstractmethod
+        logger.info("Stopping %s server on port %d", self.engine_name, self.port)
+        try:
+            self._process.terminate()
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=10.0)
+            except asyncio.TimeoutError:
+                logger.warning("%s process did not exit, killing", self.engine_name)
+                self._process.kill()
+                await self._process.wait()
+        except ProcessLookupError:
+            pass  # already dead
+
+        self._process = None
+        self._healthy = False
+
     async def health_check(self) -> bool:
-        """Check whether the engine is alive and serving.
+        """Probe the /v1/models endpoint.
 
         Returns:
-            True if the engine responds to a health probe.
+            True if the server responds with HTTP 200.
         """
+        url = f"{self.base_url}/v1/models"
+        try:
+            timeout = aiohttp.ClientTimeout(total=5)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(url) as resp:
+                    healthy = resp.status == 200
+                    self._healthy = healthy
+                    return healthy
+        except Exception as exc:
+            logger.debug("Health check failed for %s: %s", self.model_id, exc)
+            self._healthy = False
+            return False
 
-    @abc.abstractmethod
     async def forward_request(
         self,
         path: str,
         payload: dict[str, Any],
         stream: bool = False,
-    ) -> Any:
+    ) -> dict[str, Any] | AsyncIterator[bytes]:
         """Forward an OpenAI-compatible request to the engine.
 
         Args:
             path: API path (e.g. "/v1/chat/completions").
             payload: JSON request body.
-            stream: Whether to stream the response.
+            stream: If True, return an async iterator of SSE chunks.
 
         Returns:
-            The JSON response dict, or an async generator of SSE chunks
-            when streaming.
+            JSON response dict, or async byte iterator for streaming.
+
+        Raises:
+            aiohttp.ClientError: On connection or HTTP errors.
         """
+        url = f"{self.base_url}{path}"
+        if stream:
+            payload["stream"] = True
+
+        timeout = aiohttp.ClientTimeout(total=300)
+        session = aiohttp.ClientSession(timeout=timeout)
+
+        try:
+            if stream:
+                return self._stream_response(session, url, payload)
+            else:
+                async with session.post(url, json=payload) as resp:
+                    result = await resp.json()
+                    await session.close()
+                    return result
+        except Exception:
+            await session.close()
+            raise
+
+    async def _stream_response(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        payload: dict[str, Any],
+    ) -> AsyncIterator[bytes]:
+        """Stream SSE chunks from the engine.
+
+        Args:
+            session: aiohttp session (caller manages lifetime).
+            url: Full request URL.
+            payload: JSON body.
+
+        Yields:
+            Raw SSE bytes from the engine.
+        """
+        try:
+            async with session.post(url, json=payload) as resp:
+                async for chunk in resp.content.iter_any():
+                    yield chunk
+        finally:
+            await session.close()
 
     @property
     def is_healthy(self) -> bool:

--- a/src/infergrid/engines/sglang_adapter/adapter.py
+++ b/src/infergrid/engines/sglang_adapter/adapter.py
@@ -12,15 +12,7 @@ Usage:
 
 from __future__ import annotations
 
-import asyncio
-import logging
-from typing import Any, AsyncIterator
-
-import aiohttp
-
 from infergrid.engines.base import EngineAdapter
-
-logger = logging.getLogger(__name__)
 
 
 class SGLangAdapter(EngineAdapter):
@@ -28,6 +20,9 @@ class SGLangAdapter(EngineAdapter):
 
     Launches ``python -m sglang.launch_server`` and health-checks
     via ``/v1/models``.
+
+    All lifecycle logic (start, stop, health_check, forward_request)
+    is inherited from :class:`EngineAdapter`.
 
     Args:
         model_id: HuggingFace model identifier.
@@ -39,26 +34,7 @@ class SGLangAdapter(EngineAdapter):
         extra_args: Additional CLI arguments passed to sglang.
     """
 
-    def __init__(
-        self,
-        model_id: str,
-        port: int,
-        gpu_memory_utilization: float = 0.85,
-        tensor_parallel_size: int = 1,
-        dtype: str = "auto",
-        max_model_len: int = 8192,
-        extra_args: list[str] | None = None,
-    ) -> None:
-        super().__init__(
-            model_id=model_id,
-            port=port,
-            gpu_memory_utilization=gpu_memory_utilization,
-            tensor_parallel_size=tensor_parallel_size,
-            extra_args=extra_args,
-        )
-        self.dtype = dtype
-        self.max_model_len = max_model_len
-        self._process: asyncio.subprocess.Process | None = None
+    engine_name = "SGLang"
 
     def _build_cmd(self) -> list[str]:
         """Build the SGLang server launch command.
@@ -78,143 +54,3 @@ class SGLangAdapter(EngineAdapter):
             cmd.extend(["--dtype", self.dtype])
         cmd.extend(self.extra_args)
         return cmd
-
-    async def start(self, timeout_s: int = 300) -> None:
-        """Start the SGLang server subprocess.
-
-        Args:
-            timeout_s: Maximum seconds to wait for the server to be ready.
-
-        Raises:
-            TimeoutError: Server did not become healthy in time.
-            RuntimeError: Server process exited before becoming healthy.
-        """
-        cmd = self._build_cmd()
-        logger.info("Starting SGLang server: %s", " ".join(cmd))
-
-        self._process = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-
-        deadline = asyncio.get_running_loop().time() + timeout_s
-        while asyncio.get_running_loop().time() < deadline:
-            if self._process.returncode is not None:
-                stderr = ""
-                if self._process.stderr:
-                    stderr_bytes = await self._process.stderr.read()
-                    stderr = stderr_bytes.decode(errors="replace")[-2000:]
-                raise RuntimeError(
-                    f"SGLang process exited with code {self._process.returncode}: "
-                    f"{stderr}"
-                )
-
-            if await self.health_check():
-                self._healthy = True
-                logger.info(
-                    "SGLang server ready on port %d for model %s",
-                    self.port, self.model_id,
-                )
-                return
-
-            await asyncio.sleep(2.0)
-
-        await self.stop()
-        raise TimeoutError(
-            f"SGLang server did not become healthy within {timeout_s}s"
-        )
-
-    async def stop(self) -> None:
-        """Stop the SGLang server subprocess."""
-        if self._process is None:
-            return
-
-        logger.info("Stopping SGLang server on port %d", self.port)
-        try:
-            self._process.terminate()
-            try:
-                await asyncio.wait_for(self._process.wait(), timeout=10.0)
-            except asyncio.TimeoutError:
-                logger.warning("SGLang process did not exit, killing")
-                self._process.kill()
-                await self._process.wait()
-        except ProcessLookupError:
-            pass
-
-        self._process = None
-        self._healthy = False
-
-    async def health_check(self) -> bool:
-        """Probe the /v1/models endpoint.
-
-        Returns:
-            True if the server responds with HTTP 200.
-        """
-        url = f"{self.base_url}/v1/models"
-        try:
-            timeout = aiohttp.ClientTimeout(total=5)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(url) as resp:
-                    healthy = resp.status == 200
-                    self._healthy = healthy
-                    return healthy
-        except Exception:
-            self._healthy = False
-            return False
-
-    async def forward_request(
-        self,
-        path: str,
-        payload: dict[str, Any],
-        stream: bool = False,
-    ) -> dict[str, Any] | AsyncIterator[bytes]:
-        """Forward an OpenAI-compatible request to the SGLang server.
-
-        Args:
-            path: API path (e.g. "/v1/chat/completions").
-            payload: JSON request body.
-            stream: If True, return an async iterator of SSE chunks.
-
-        Returns:
-            JSON response dict, or async byte iterator for streaming.
-
-        Raises:
-            aiohttp.ClientError: On connection or HTTP errors.
-        """
-        url = f"{self.base_url}{path}"
-        if stream:
-            payload["stream"] = True
-
-        timeout = aiohttp.ClientTimeout(total=300)
-
-        if stream:
-            return self._stream_response(url, payload, timeout)
-        else:
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.post(url, json=payload) as resp:
-                    return await resp.json()
-
-    async def _stream_response(
-        self,
-        url: str,
-        payload: dict[str, Any],
-        timeout: aiohttp.ClientTimeout,
-    ) -> AsyncIterator[bytes]:
-        """Stream SSE chunks from the engine.
-
-        Creates and owns its own ClientSession to guarantee cleanup
-        even if the caller abandons iteration.
-
-        Args:
-            url: Full request URL.
-            payload: JSON body.
-            timeout: Client timeout configuration.
-
-        Yields:
-            Raw SSE bytes from the engine.
-        """
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.post(url, json=payload) as resp:
-                async for chunk in resp.content.iter_any():
-                    yield chunk

--- a/src/infergrid/engines/vllm_adapter/adapter.py
+++ b/src/infergrid/engines/vllm_adapter/adapter.py
@@ -12,15 +12,7 @@ Usage:
 
 from __future__ import annotations
 
-import asyncio
-import logging
-from typing import Any, AsyncIterator
-
-import aiohttp
-
 from infergrid.engines.base import EngineAdapter
-
-logger = logging.getLogger(__name__)
 
 
 class VLLMAdapter(EngineAdapter):
@@ -28,6 +20,9 @@ class VLLMAdapter(EngineAdapter):
 
     Launches ``python -m vllm.entrypoints.openai.api_server`` and
     health-checks via ``/v1/models``.
+
+    All lifecycle logic (start, stop, health_check, forward_request)
+    is inherited from :class:`EngineAdapter`.
 
     Args:
         model_id: HuggingFace model identifier.
@@ -39,26 +34,7 @@ class VLLMAdapter(EngineAdapter):
         extra_args: Additional CLI arguments passed to vllm.
     """
 
-    def __init__(
-        self,
-        model_id: str,
-        port: int,
-        gpu_memory_utilization: float = 0.85,
-        tensor_parallel_size: int = 1,
-        dtype: str = "auto",
-        max_model_len: int = 8192,
-        extra_args: list[str] | None = None,
-    ) -> None:
-        super().__init__(
-            model_id=model_id,
-            port=port,
-            gpu_memory_utilization=gpu_memory_utilization,
-            tensor_parallel_size=tensor_parallel_size,
-            extra_args=extra_args,
-        )
-        self.dtype = dtype
-        self.max_model_len = max_model_len
-        self._process: asyncio.subprocess.Process | None = None
+    engine_name = "vLLM"
 
     def _build_cmd(self) -> list[str]:
         """Build the vLLM server launch command.
@@ -77,145 +53,3 @@ class VLLMAdapter(EngineAdapter):
         ]
         cmd.extend(self.extra_args)
         return cmd
-
-    async def start(self, timeout_s: int = 300) -> None:
-        """Start the vLLM server subprocess.
-
-        Args:
-            timeout_s: Maximum seconds to wait for the server to be ready.
-
-        Raises:
-            TimeoutError: Server did not become healthy in time.
-            RuntimeError: Server process exited before becoming healthy.
-        """
-        cmd = self._build_cmd()
-        logger.info("Starting vLLM server: %s", " ".join(cmd))
-
-        self._process = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-
-        # Poll for health
-        deadline = asyncio.get_running_loop().time() + timeout_s
-        while asyncio.get_running_loop().time() < deadline:
-            if self._process.returncode is not None:
-                stderr = ""
-                if self._process.stderr:
-                    stderr_bytes = await self._process.stderr.read()
-                    stderr = stderr_bytes.decode(errors="replace")[-2000:]
-                raise RuntimeError(
-                    f"vLLM process exited with code {self._process.returncode}: "
-                    f"{stderr}"
-                )
-
-            if await self.health_check():
-                self._healthy = True
-                logger.info(
-                    "vLLM server ready on port %d for model %s",
-                    self.port, self.model_id,
-                )
-                return
-
-            await asyncio.sleep(2.0)
-
-        # Timed out -- kill the process
-        await self.stop()
-        raise TimeoutError(
-            f"vLLM server did not become healthy within {timeout_s}s"
-        )
-
-    async def stop(self) -> None:
-        """Stop the vLLM server subprocess."""
-        if self._process is None:
-            return
-
-        logger.info("Stopping vLLM server on port %d", self.port)
-        try:
-            self._process.terminate()
-            try:
-                await asyncio.wait_for(self._process.wait(), timeout=10.0)
-            except asyncio.TimeoutError:
-                logger.warning("vLLM process did not exit, killing")
-                self._process.kill()
-                await self._process.wait()
-        except ProcessLookupError:
-            pass  # already dead
-
-        self._process = None
-        self._healthy = False
-
-    async def health_check(self) -> bool:
-        """Probe the /v1/models endpoint.
-
-        Returns:
-            True if the server responds with HTTP 200.
-        """
-        url = f"{self.base_url}/v1/models"
-        try:
-            timeout = aiohttp.ClientTimeout(total=5)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.get(url) as resp:
-                    healthy = resp.status == 200
-                    self._healthy = healthy
-                    return healthy
-        except Exception:
-            self._healthy = False
-            return False
-
-    async def forward_request(
-        self,
-        path: str,
-        payload: dict[str, Any],
-        stream: bool = False,
-    ) -> dict[str, Any] | AsyncIterator[bytes]:
-        """Forward an OpenAI-compatible request to the vLLM server.
-
-        Args:
-            path: API path (e.g. "/v1/chat/completions").
-            payload: JSON request body.
-            stream: If True, return an async iterator of SSE chunks.
-
-        Returns:
-            JSON response dict, or async byte iterator for streaming.
-
-        Raises:
-            aiohttp.ClientError: On connection or HTTP errors.
-        """
-        url = f"{self.base_url}{path}"
-        if stream:
-            payload["stream"] = True
-
-        timeout = aiohttp.ClientTimeout(total=300)
-
-        if stream:
-            return self._stream_response(url, payload, timeout)
-        else:
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.post(url, json=payload) as resp:
-                    return await resp.json()
-
-    async def _stream_response(
-        self,
-        url: str,
-        payload: dict[str, Any],
-        timeout: aiohttp.ClientTimeout,
-    ) -> AsyncIterator[bytes]:
-        """Stream SSE chunks from the engine.
-
-        Creates and owns its own ClientSession to guarantee cleanup
-        even if the caller abandons iteration.
-
-        Args:
-            url: Full request URL.
-            payload: JSON body.
-            timeout: Client timeout configuration.
-
-        Yields:
-            Raw SSE bytes from the engine.
-        """
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.post(url, json=payload) as resp:
-                async for chunk in resp.content.iter_any():
-                    yield chunk

--- a/src/infergrid/tenant/manager.py
+++ b/src/infergrid/tenant/manager.py
@@ -49,20 +49,20 @@ class TenantRecord:
         self.budget = budget
         self.usage = TenantUsage()
         self._semaphore = asyncio.Semaphore(budget.max_concurrent_requests)
+        self._available = budget.max_concurrent_requests
         self._lock = asyncio.Lock()
 
     async def try_acquire(self) -> bool:
         """Try to acquire a request slot without blocking.
 
         Checks both the concurrency semaphore and the sliding-window
-        rate limit.  The check and acquire are done under the same lock
-        to avoid a TOCTOU race on the semaphore counter.
+        rate limit.
 
         Returns:
             True if the request is allowed, False if it should be rejected.
         """
+        # Check rate limit first (cheap)
         async with self._lock:
-            # Check rate limit (cheap)
             now = time.monotonic()
             window_start = now - 60.0
             # Prune old timestamps
@@ -73,13 +73,13 @@ class TenantRecord:
             if len(self.usage._request_timestamps) >= self.budget.rate_limit_rpm:
                 return False
 
-            # Check concurrency limit -- read + acquire under same lock
-            if self._semaphore._value <= 0:  # type: ignore[attr-defined]
-                return False
-            # Safe: we hold _lock so no other task can race between
-            # the check and the acquire.
-            await self._semaphore.acquire()
+        # Try concurrency limit (non-blocking)
+        if self._available <= 0:
+            return False
 
+        self._available -= 1
+        await self._semaphore.acquire()
+        async with self._lock:
             self.usage._request_timestamps.append(time.monotonic())
             self.usage.active_requests += 1
         return True
@@ -87,6 +87,7 @@ class TenantRecord:
     async def release(self) -> None:
         """Release a request slot after completion."""
         self._semaphore.release()
+        self._available += 1
         async with self._lock:
             self.usage.active_requests = max(0, self.usage.active_requests - 1)
 


### PR DESCRIPTION
## Summary
Addresses all HIGH and MEDIUM items from code review.

- **Adapter dedup**: 453 lines → 113 lines (-199 net). All shared logic in base class.
- **Silent exceptions**: health_check() now logs failures via logger.debug
- **Semaphore fix**: TenantManager uses tracked counter instead of _value private access
- **CLI logging**: print() → logger.error() with exc_info

## Test plan
- [x] `pytest tests/unit/ -v` — all tests pass