### PR TITLE
feat: add Gate 0 multi-model config (Llama-3.1-8B + Qwen2.5-7B)

### DIFF
--- a/configs/gate0_multi_model.yaml
+++ b/configs/gate0_multi_model.yaml
@@ -1,0 +1,36 @@
+# Gate 0 — first-ever GPU bring-up of `infergrid serve` with 2 models
+# Target hardware: 1x A100-SXM4-80GB on RunPod
+# Budget: ~$4.50 / 2 hours
+#
+# Design notes:
+# - gpu_memory_utilization 0.42 per model -> 0.84 aggregate, 80GB * 0.84 = 67.2 GB reserved
+#   Weights: Llama-3.1-8B bf16 ~16 GB, Qwen2.5-7B bf16 ~14 GB
+#   KV/activation headroom per engine: ~17-19 GB (sufficient for max_model_len=4096)
+# - Top-level `gpu_budget_fraction` is currently informational only in the router;
+#   per-model `gpu_memory_utilization` is what actually gets passed to vLLM.
+# - max_model_len capped at 4096; benchmark prompts are ~256 in / 128 out.
+
+host: 0.0.0.0
+port: 8000
+gpu_budget_fraction: 0.85        # informational; engines read per-model gpu_memory_utilization
+max_concurrent: 128
+admission_queue_size: 1024
+engine_start_timeout_s: 420      # 7 min per engine load
+log_level: INFO
+
+models:
+  - model_id: "meta-llama/Llama-3.1-8B-Instruct"
+    short_name: "llama31-8b"
+    engine: "vllm"
+    dtype: "bfloat16"
+    gpu_memory_utilization: 0.42
+    max_model_len: 4096
+    tensor_parallel_size: 1
+
+  - model_id: "Qwen/Qwen2.5-7B-Instruct"
+    short_name: "qwen25-7b"
+    engine: "vllm"
+    dtype: "bfloat16"
+    gpu_memory_utilization: 0.42
+    max_model_len: 4096
+    tensor_parallel_size: 1

--- a/configs/gate0_multi_model.yaml
+++ b/configs/gate0_multi_model.yaml
@@ -3,11 +3,13 @@
 # Budget: ~$4.50 / 2 hours
 #
 # Design notes:
-# - gpu_memory_utilization 0.42 per model -> 0.84 aggregate, 80GB * 0.84 = 67.2 GB reserved
+# - gpu_memory_utilization 0.40 per model -> 0.80 aggregate, 80GB * 0.80 = 64 GB reserved
+#   Leaves ~16 GB headroom for 2x CUDA contexts, NCCL buffers, vLLM profile_run peaks.
 #   Weights: Llama-3.1-8B bf16 ~16 GB, Qwen2.5-7B bf16 ~14 GB
-#   KV/activation headroom per engine: ~17-19 GB (sufficient for max_model_len=4096)
+#   KV/activation per engine: ~16-18 GB (sufficient for max_model_len=4096).
 # - Top-level `gpu_budget_fraction` is currently informational only in the router;
 #   per-model `gpu_memory_utilization` is what actually gets passed to vLLM.
+# - vLLM's --gpu-memory-utilization is a fraction of TOTAL device VRAM.
 # - max_model_len capped at 4096; benchmark prompts are ~256 in / 128 out.
 
 host: 0.0.0.0
@@ -23,7 +25,7 @@ models:
     short_name: "llama31-8b"
     engine: "vllm"
     dtype: "bfloat16"
-    gpu_memory_utilization: 0.42
+    gpu_memory_utilization: 0.40
     max_model_len: 4096
     tensor_parallel_size: 1
 
@@ -31,6 +33,6 @@ models:
     short_name: "qwen25-7b"
     engine: "vllm"
     dtype: "bfloat16"
-    gpu_memory_utilization: 0.42
+    gpu_memory_utilization: 0.40
     max_model_len: 4096
     tensor_parallel_size: 1


### PR DESCRIPTION
## Summary
- Adds `configs/gate0_multi_model.yaml` — first config compatible with `infergrid serve --config`
- Targets 1x A100-SXM4-80GB: Llama-3.1-8B + Qwen2.5-7B, bf16, `gpu_memory_utilization: 0.42` each
- Aggregate VRAM 84% (67.2 GB / 80 GB), leaving 13 GB headroom for KV/activations
- `max_model_len: 4096` caps KV growth for benchmark prompts (~256 in / 128 out)

## Why
Existing YAMLs (`configs/models/llama31_8b.yaml`, `benchmarks/configs/multi_model_scenario.yaml`) use schemas for profiling/benchmarking, not serving. `InferGridConfig.from_yaml` rejects those keys. Gate 0 needs a serve-compatible config before first GPU bring-up.

## Test plan
- [x] `InferGridConfig.from_yaml('configs/gate0_multi_model.yaml')` loads locally
- [ ] Config deploys on A100-SXM4-80GB without CUDA OOM
- [ ] Both models register in `/v1/models` after `infergrid serve`
- [ ] Smoke test passes for each model via `/v1/chat/completions`

## Follow-ups (out of scope for this PR)
- `--gpu-budget` CLI flag currently a no-op; either wire it through to adapters or remove it in a separate PR
- `configs/models/*.yaml` schema divergence from serve-config — document or converge