### PR TITLE
fix: Gate 0 compat hardening — deps pinned, CLI --config, engine log capture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"
 dependencies = [
-    "numpy~=1.24",
+    "numpy>=1.24,<2.3",
     "pandas~=2.0",
     "pyyaml>=6.0",
     "prometheus-client~=0.19",
@@ -32,9 +32,9 @@ profiling = [
     "datasets~=2.14",
     "jupyter~=1.0",
     "ipykernel~=6.25",
-    "transformers>=4.45",
+    "transformers>=4.51.1,<5.0",
 ]
-vllm = ["vllm~=0.6.0"]
+vllm = ["vllm==0.8.5", "numba>=0.60,<0.62", "numpy>=1.24,<2.3"]
 sglang = ["sglang~=0.3.0"]
 
 [project.scripts]

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,7 +1,6 @@
 # requirements-gpu.txt
 # Pinned dependencies for InferGrid GPU profiling runs
 # Tested on: NVIDIA A100-SXM4-80GB, CUDA 12.4, Python 3.11
-# Date: 2026-03-22
 
 # === Inference engine ===
 vllm==0.8.5
@@ -10,17 +9,20 @@ vllm==0.8.5
 # torch, torchvision, torchaudio are pulled by vllm as transitive deps
 # Pinning them separately causes conflicts
 
+# === vLLM 0.8.5 compat pins (Gate 0 regression fences) ===
+# transformers>=5.0 removes PreTrainedTokenizerBase.all_special_tokens_extended,
+#   which vllm 0.8.5's tokenizer_group relies on. Pin to the 4.51+ series.
+# numpy>=2.3 breaks numba (numba needs numpy<=2.2 at the time of vllm 0.8.5),
+#   and vllm 0.8.5's spec_decode.ngram_proposer imports numba on import.
+transformers>=4.51.1,<5.0
+numpy>=1.24,<2.3
+
 # === Profiling dependencies ===
 aiohttp>=3.9,<4.0
-numpy>=1.24,<2.2
 pandas>=2.2,<3.0
 matplotlib>=3.8,<4.0
 pyyaml>=6.0,<7.0
 nvidia-ml-py>=12.0
-
-# === Tokenizer (for accurate token counting in profiling scripts) ===
-# transformers version MUST match what vllm pulls — do not override
-# The venv install order handles this: install vllm FIRST, then profiling deps
 
 # === Dataset ===
 datasets>=2.14

--- a/src/infergrid/cli.py
+++ b/src/infergrid/cli.py
@@ -45,8 +45,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     serve_parser.add_argument(
         "models",
-        nargs="+",
-        help="HuggingFace model IDs to serve",
+        nargs="*",
+        help="HuggingFace model IDs to serve (optional when --config provides models)",
     )
     serve_parser.add_argument(
         "--gpu-budget",
@@ -200,6 +200,11 @@ def _cmd_serve(args: argparse.Namespace) -> None:
     if args.config:
         config = InferGridConfig.from_yaml(args.config)
     else:
+        if not args.models:
+            raise SystemExit(
+                "infergrid serve: at least one positional MODEL is required "
+                "when --config is not provided"
+            )
         gpu_budget = _parse_gpu_budget(args.gpu_budget)
         config = InferGridConfig.from_cli_args(
             model_ids=args.models,

--- a/src/infergrid/engines/base.py
+++ b/src/infergrid/engines/base.py
@@ -107,10 +107,15 @@ class EngineAdapter(abc.ABC):
         engine_log = open(self._engine_log_path, "w", buffering=1)
         logger.info("%s engine log: %s", self.engine_name, self._engine_log_path)
 
+        # Force unbuffered Python in the child so crash-time stderr actually hits
+        # disk before the process dies (block buffering otherwise swallows the
+        # last few KB — exactly where the root cause tends to be).
+        child_env = {**os.environ, "PYTHONUNBUFFERED": "1"}
         self._process = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=engine_log,
             stderr=engine_log,
+            env=child_env,
         )
         engine_log.close()  # subprocess has its own dup'd fd; our handle is safe to drop
 

--- a/src/infergrid/engines/base.py
+++ b/src/infergrid/engines/base.py
@@ -11,11 +11,17 @@ from __future__ import annotations
 import abc
 import asyncio
 import logging
+import os
+import re
+import tempfile
 from typing import Any, AsyncIterator
 
 import aiohttp
 
 logger = logging.getLogger(__name__)
+
+# Directory for per-engine subprocess logs. Overridden via INFERGRID_ENGINE_LOG_DIR env.
+_ENGINE_LOG_DIR = os.environ.get("INFERGRID_ENGINE_LOG_DIR") or tempfile.gettempdir()
 
 
 class EngineAdapter(abc.ABC):
@@ -88,23 +94,41 @@ class EngineAdapter(abc.ABC):
         cmd = self._build_cmd()
         logger.info("Starting %s server: %s", self.engine_name, " ".join(cmd))
 
+        # Persist full stdout+stderr to a per-engine log file. vLLM's v1 engine
+        # spawns its own worker subprocess whose stderr is lost if we read via
+        # PIPE + trailing slice -- we must tee the full stream to disk so the
+        # root cause survives for postmortem (e.g. "Numba needs NumPy <= 2.2").
+        safe_id = re.sub(r"[^A-Za-z0-9._-]", "_", self.model_id)
+        self._engine_log_path = os.path.join(
+            _ENGINE_LOG_DIR,
+            f"infergrid_engine_{self.engine_name.lower()}_{safe_id}_p{self.port}.log",
+        )
+        # Truncate on each start to keep failures scoped to the current attempt.
+        engine_log = open(self._engine_log_path, "w", buffering=1)
+        logger.info("%s engine log: %s", self.engine_name, self._engine_log_path)
+
         self._process = await asyncio.create_subprocess_exec(
             *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            stdout=engine_log,
+            stderr=engine_log,
         )
+        engine_log.close()  # subprocess has its own dup'd fd; our handle is safe to drop
 
         # Poll for health
         deadline = asyncio.get_event_loop().time() + timeout_s
         while asyncio.get_event_loop().time() < deadline:
             if self._process.returncode is not None:
-                stderr = ""
-                if self._process.stderr:
-                    stderr_bytes = await self._process.stderr.read()
-                    stderr = stderr_bytes.decode(errors="replace")[-2000:]
+                tail = ""
+                try:
+                    with open(self._engine_log_path, "r", errors="replace") as f:
+                        tail = f.read()[-10_000:]
+                except OSError:
+                    pass
                 raise RuntimeError(
                     f"{self.engine_name} process exited with code "
-                    f"{self._process.returncode}: {stderr}"
+                    f"{self._process.returncode}. "
+                    f"Full log: {self._engine_log_path}. "
+                    f"Last 10KB:\n{tail}"
                 )
 
             if await self.health_check():


### PR DESCRIPTION
## Summary
Three fixes surfaced during the first live GPU bring-up of `infergrid serve` on A100-SXM4-80GB (Gate 0). Before these pins every attempt failed-fast in Phase 4/5 with opaque stack traces.

1. **`requirements-gpu.txt`** — pin `transformers>=4.51.1,<5.0` and `numpy>=1.24,<2.3`. vLLM 0.8.5 silently pulled `transformers==5.5.4` (removed `PreTrainedTokenizerBase.all_special_tokens_extended`) and `numpy==2.4.4` (breaks numba, which vLLM imports on module load).
2. **`cli.py`** — `nargs="+"` → `nargs="*"` on positional `models`. `infergrid serve --config foo.yaml` used to crash at argparse even though the YAML supplied models. When `--config` is absent we still require ≥1 model with a clear `SystemExit`.
3. **`engines/base.py`** — subprocess stdout+stderr now tee to a per-engine log file (default `/tmp`, override with `INFERGRID_ENGINE_LOG_DIR`). The previous 2 KB tail-slice lost the actual root cause for vLLM's v1 engine worker (parent only prints "See root cause above"). `RuntimeError` now cites the persisted log path.

## Test plan
- [x] 121 unit tests pass locally (`python3 -m pytest -q`)
- [x] `infergrid serve --config gate0_multi_model.yaml` parses without positional models
- [ ] Gate 0 pod re-runs with these pins (currently in-flight on a1SXM4 pod; success blocks on this PR + the config PR merging)
- [ ] After re-run: confirm engine log file path appears in any RuntimeError

## Related
- Builds on PR #15 (Gate 0 multi-model config)
- Unblocks the PR #17 that will land Gate 0 results

## Follow-ups (out of scope)
- Document `VLLM_USE_V1=0` for vLLM 0.8.5 co-load stability (set as env during bring-up; worth codifying as a default for this vLLM pin)