### PR TITLE
fix: Gate 0.5 bench harness resilience + local reproducer

### DIFF
--- a/benchmarks/configs/gate05_mock.yaml
+++ b/benchmarks/configs/gate05_mock.yaml
@@ -1,0 +1,20 @@
+# Gate 0.5 local reproducer config — points at mock engines on fixed ports.
+# Used by benchmarks/scripts/repro_gate0_stall.sh.
+
+host: 0.0.0.0
+port: 8000
+max_concurrent: 128
+log_level: INFO
+
+models:
+  - model_id: "meta-llama/Llama-3.1-8B-Instruct"
+    engine: "vllm"
+    port: 8002              # mock_engine.py listens here
+    gpu_memory_utilization: 0.35
+    max_model_len: 4096
+
+  - model_id: "Qwen/Qwen2.5-7B-Instruct"
+    engine: "vllm"
+    port: 8003              # mock_engine.py listens here
+    gpu_memory_utilization: 0.35
+    max_model_len: 4096

--- a/benchmarks/scripts/benchmark_multi_model.py
+++ b/benchmarks/scripts/benchmark_multi_model.py
@@ -463,6 +463,12 @@ class MultiModelBenchmarkClient:
             first_token_time: float | None = None
             tokens_out = 0
 
+            # D1: per-request log so a stall is visible on the terminal within
+            # seconds, not only in the post-run CSV. Previously a 3-hour stall
+            # on c=1 produced zero output between "Starting benchmark" and the
+            # 300s timeout storm.
+            logger.info("req=%d MODEL=%s START", request_id, model)
+
             try:
                 timeout = aiohttp.ClientTimeout(total=self.timeout_s)
                 async with session.post(
@@ -502,6 +508,8 @@ class MultiModelBenchmarkClient:
                             tokens_out += 1
 
             except asyncio.TimeoutError:
+                logger.warning("req=%d MODEL=%s TIMEOUT after %.0fs",
+                               request_id, model, time.time() - start_time)
                 return MultiModelRequestMetrics(
                     model=model,
                     request_id=request_id,
@@ -514,6 +522,7 @@ class MultiModelBenchmarkClient:
                     error="timeout",
                 )
             except Exception as exc:
+                logger.warning("req=%d MODEL=%s ERROR %s", request_id, model, exc)
                 return MultiModelRequestMetrics(
                     model=model,
                     request_id=request_id,
@@ -539,6 +548,11 @@ class MultiModelBenchmarkClient:
                 tpot_ms = generation_time_ms / (tokens_out - 1)
             else:
                 tpot_ms = 0.0
+
+            logger.info(
+                "req=%d MODEL=%s DONE tokens_out=%d latency_ms=%.0f ttft_ms=%.0f",
+                request_id, model, tokens_out, total_latency_ms, ttft_ms,
+            )
 
             return MultiModelRequestMetrics(
                 model=model,

--- a/benchmarks/scripts/mock_engine.py
+++ b/benchmarks/scripts/mock_engine.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Mock vLLM-compatible engine for local Gate 0.5 bench harness reproduction.
+
+Mimics just enough of vLLM's OpenAI-compatible surface to drive `infergrid serve`
+and the multi-model benchmark harness without a GPU. After a configurable number
+of successful requests, subsequent POST /v1/completions handlers enter a long
+sleep, mimicking the Gate 0 symptom where vLLM stopped returning response
+headers. GET /v1/models stays healthy so the router's health checks pass.
+
+Usage:
+    python3 mock_engine.py --port 8002 --model meta-llama/Llama-3.1-8B-Instruct \
+        --hang-after 40 --ok-latency-s 0.5
+
+Env overrides:
+    MOCK_HANG_AFTER  — request count before entering stall mode
+    MOCK_OK_LATENCY  — seconds to sleep on successful requests
+    MOCK_STALL_S     — seconds to sleep when stalled (default: 10_000)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import time
+from aiohttp import web
+
+
+logger = logging.getLogger("mock_engine")
+
+
+class MockEngineState:
+    def __init__(self, model: str, hang_after: int, ok_latency: float, stall_s: float):
+        self.model = model
+        self.hang_after = hang_after
+        self.ok_latency = ok_latency
+        self.stall_s = stall_s
+        self.request_count = 0
+        self.stalled_count = 0
+
+
+async def handle_models(request: web.Request) -> web.Response:
+    state: MockEngineState = request.app["state"]
+    return web.json_response({
+        "object": "list",
+        "data": [
+            {
+                "id": state.model,
+                "object": "model",
+                "created": int(time.time()),
+                "owned_by": "mock",
+            }
+        ],
+    })
+
+
+async def handle_health(request: web.Request) -> web.Response:
+    return web.json_response({"status": "ok"})
+
+
+async def handle_completions(request: web.Request) -> web.StreamResponse:
+    state: MockEngineState = request.app["state"]
+    state.request_count += 1
+    rid = state.request_count
+
+    body = await request.json()
+    prompt = body.get("prompt", "")
+    max_tokens = int(body.get("max_tokens", 32))
+    stream = bool(body.get("stream", False))
+
+    # Enter stall mode after `hang_after` successful requests
+    if state.hang_after > 0 and rid > state.hang_after:
+        state.stalled_count += 1
+        logger.info("req=%d STALL for %.0fs (hang_after=%d)", rid, state.stall_s, state.hang_after)
+        try:
+            await asyncio.sleep(state.stall_s)
+        except asyncio.CancelledError:
+            logger.info("req=%d cancelled after %.1fs", rid, state.stall_s)
+            raise
+        # If we ever wake up, return something harmless
+        return web.Response(status=504, text="mock stall exit")
+
+    logger.info("req=%d OK (prompt_len=%d, max_tokens=%d, stream=%s, ok_latency=%.2fs)",
+                rid, len(prompt), max_tokens, stream, state.ok_latency)
+
+    # Simulate engine work
+    await asyncio.sleep(state.ok_latency)
+
+    if not stream:
+        return web.json_response({
+            "id": f"mock-{rid}",
+            "object": "text_completion",
+            "created": int(time.time()),
+            "model": state.model,
+            "choices": [{
+                "index": 0,
+                "text": f"mock response to req {rid}",
+                "finish_reason": "stop",
+            }],
+            "usage": {
+                "prompt_tokens": len(prompt.split()),
+                "completion_tokens": 5,
+                "total_tokens": len(prompt.split()) + 5,
+            },
+        })
+
+    # SSE stream response
+    resp = web.StreamResponse(
+        status=200,
+        reason="OK",
+        headers={"Content-Type": "text/event-stream"},
+    )
+    await resp.prepare(request)
+    for tok_i in range(max(1, max_tokens)):
+        chunk = {
+            "id": f"mock-{rid}",
+            "object": "text_completion.chunk",
+            "created": int(time.time()),
+            "model": state.model,
+            "choices": [{"index": 0, "text": f"t{tok_i} ", "finish_reason": None}],
+        }
+        await resp.write(f"data: {json.dumps(chunk)}\n\n".encode())
+        # Small inter-token delay to look like generation
+        await asyncio.sleep(max(0.001, state.ok_latency / max(1, max_tokens)))
+    await resp.write(b"data: [DONE]\n\n")
+    await resp.write_eof()
+    return resp
+
+
+def make_app(state: MockEngineState) -> web.Application:
+    app = web.Application()
+    app["state"] = state
+    app.router.add_get("/v1/models", handle_models)
+    app.router.add_get("/health", handle_health)
+    app.router.add_post("/v1/completions", handle_completions)
+    app.router.add_post("/v1/chat/completions", handle_completions)  # share handler
+    return app
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Mock vLLM engine for Gate 0.5 repro")
+    p.add_argument("--port", type=int, required=True)
+    p.add_argument("--model", default="mock-model")
+    p.add_argument(
+        "--hang-after",
+        type=int,
+        default=int(os.environ.get("MOCK_HANG_AFTER", "0")),
+        help="Enter stall mode after N successful requests (0=never)",
+    )
+    p.add_argument(
+        "--ok-latency-s",
+        type=float,
+        default=float(os.environ.get("MOCK_OK_LATENCY", "0.2")),
+        help="Seconds to sleep on successful requests",
+    )
+    p.add_argument(
+        "--stall-s",
+        type=float,
+        default=float(os.environ.get("MOCK_STALL_S", "10000")),
+        help="Seconds to sleep when stalled",
+    )
+    p.add_argument("--log-level", default="INFO")
+    args = p.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+    )
+
+    state = MockEngineState(
+        model=args.model,
+        hang_after=args.hang_after,
+        ok_latency=args.ok_latency_s,
+        stall_s=args.stall_s,
+    )
+    logger.info(
+        "mock engine starting: port=%d model=%s hang_after=%d ok_latency=%.2fs stall=%.0fs",
+        args.port, args.model, args.hang_after, args.ok_latency_s, args.stall_s,
+    )
+    web.run_app(make_app(state), host="127.0.0.1", port=args.port, print=None)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/scripts/repro_gate0_stall.sh
+++ b/benchmarks/scripts/repro_gate0_stall.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Gate 0.5 reproducer — recreates the 2026-04-18 bench harness stall locally.
+#
+# Runs 2 mock engines (ports 8002, 8003) + infergrid serve (port 8000)
+# + the multi-model benchmark at concurrency=1 alternating. With
+# --hang-after 20 the engines start stalling on request 21, mimicking
+# the real incident.
+#
+# Pass/fail:
+#   BEFORE resilience fixes: script hangs ~300s per stalled request.
+#   AFTER resilience fixes:  fast failure, script completes in <120s.
+#
+# Usage:
+#   ./benchmarks/scripts/repro_gate0_stall.sh [HANG_AFTER=20]
+
+set -euo pipefail
+
+HANG_AFTER=${1:-20}
+NUM_REQUESTS=${NUM_REQUESTS:-50}
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+LOGDIR=${LOGDIR:-/tmp/gate05_repro}
+mkdir -p "$LOGDIR"
+rm -f "$LOGDIR"/*.log
+
+cleanup() {
+    echo "--- cleanup ---"
+    jobs -p | xargs -r kill 2>/dev/null || true
+    pkill -f "mock_engine.py --port 8002" 2>/dev/null || true
+    pkill -f "mock_engine.py --port 8003" 2>/dev/null || true
+    pkill -f "infergrid serve --port 8000" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "--- starting mock engines (hang_after=$HANG_AFTER) ---"
+python3 benchmarks/scripts/mock_engine.py --port 8002 \
+    --model "meta-llama/Llama-3.1-8B-Instruct" \
+    --hang-after "$HANG_AFTER" --ok-latency-s 0.2 \
+    > "$LOGDIR/mock_8002.log" 2>&1 &
+python3 benchmarks/scripts/mock_engine.py --port 8003 \
+    --model "Qwen/Qwen2.5-7B-Instruct" \
+    --hang-after "$HANG_AFTER" --ok-latency-s 0.2 \
+    > "$LOGDIR/mock_8003.log" 2>&1 &
+
+sleep 2
+
+echo "--- starting infergrid serve (dev mode: skip engine launch, attach to mocks) ---"
+INFERGRID_ENGINE_LOG_DIR="$LOGDIR" \
+INFERGRID_DEV_SKIP_ENGINE_LAUNCH=1 \
+python3 -m infergrid.cli serve \
+    --port 8000 \
+    "meta-llama/Llama-3.1-8B-Instruct" "Qwen/Qwen2.5-7B-Instruct" \
+    --log-level INFO \
+    > "$LOGDIR/infergrid.log" 2>&1 &
+IG_PID=$!
+
+# Wait for /v1/models
+for i in $(seq 1 30); do
+    N=$(curl -sf http://localhost:8000/v1/models 2>/dev/null \
+        | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('data',[])))" 2>/dev/null \
+        || echo 0)
+    if [ "$N" = "2" ]; then
+        echo "  ready after ${i}s"
+        break
+    fi
+    sleep 1
+done
+
+echo "--- running benchmark (c=1 alternating, num=$NUM_REQUESTS) ---"
+START=$(date +%s)
+python3 benchmarks/scripts/benchmark_multi_model.py \
+    --url http://localhost:8000 \
+    --models meta-llama/Llama-3.1-8B-Instruct Qwen/Qwen2.5-7B-Instruct \
+    --concurrency 1 --workload alternating --num-requests "$NUM_REQUESTS" \
+    --output-dir "$LOGDIR/bench" \
+    --seed 42 \
+    ${BENCH_EXTRA:-} \
+    > "$LOGDIR/bench.log" 2>&1 || true
+END=$(date +%s)
+ELAPSED=$((END - START))
+
+echo ""
+echo "═══════════════════════════════════════════════════════════"
+echo " REPRO RESULT: elapsed=${ELAPSED}s (hang_after=$HANG_AFTER, num=$NUM_REQUESTS)"
+echo "═══════════════════════════════════════════════════════════"
+echo "  BEFORE fixes: expected >= 300s (one stall × 300s timeout)"
+echo "  AFTER fixes:  expected <= 120s (stall short-circuited)"
+echo ""
+echo "Logs: $LOGDIR/"
+tail -3 "$LOGDIR/bench.log" || true

--- a/src/infergrid/engines/base.py
+++ b/src/infergrid/engines/base.py
@@ -63,6 +63,11 @@ class EngineAdapter(abc.ABC):
         self.extra_args = extra_args or []
         self._healthy = False
         self._process: asyncio.subprocess.Process | None = None
+        # Single aiohttp session reused across forward_request calls. Opening a
+        # new session+connector per request leaks FDs and defeats connection
+        # pooling — a meaningful slice of Gate 0's 3h stall was spent dialing
+        # new sockets to an engine that had already stopped responding.
+        self._session: aiohttp.ClientSession | None = None
 
     @property
     def base_url(self) -> str:
@@ -91,6 +96,29 @@ class EngineAdapter(abc.ABC):
             TimeoutError: If the engine does not become healthy in time.
             RuntimeError: If the engine process exits unexpectedly.
         """
+        # Dev/test mode: reuse an already-running engine on self.port (e.g. the
+        # mock engine from benchmarks/scripts/mock_engine.py). Skips subprocess
+        # launch so the router can be exercised without a GPU.
+        if os.environ.get("INFERGRID_DEV_SKIP_ENGINE_LAUNCH"):
+            logger.info(
+                "%s dev mode: skipping subprocess launch, attaching to localhost:%d",
+                self.engine_name, self.port,
+            )
+            # Wait briefly for the already-running engine to be healthy
+            deadline = asyncio.get_event_loop().time() + timeout_s
+            while asyncio.get_event_loop().time() < deadline:
+                if await self.health_check():
+                    self._healthy = True
+                    logger.info(
+                        "%s (mock) reachable on port %d for model %s",
+                        self.engine_name, self.port, self.model_id,
+                    )
+                    return
+                await asyncio.sleep(1.0)
+            raise TimeoutError(
+                f"{self.engine_name} dev-mode: no mock engine on port {self.port}"
+            )
+
         cmd = self._build_cmd()
         logger.info("Starting %s server: %s", self.engine_name, " ".join(cmd))
 
@@ -153,7 +181,11 @@ class EngineAdapter(abc.ABC):
         )
 
     async def stop(self) -> None:
-        """Stop the engine subprocess gracefully."""
+        """Stop the engine subprocess gracefully and close the shared session."""
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
         if self._process is None:
             return
 
@@ -191,6 +223,32 @@ class EngineAdapter(abc.ABC):
             self._healthy = False
             return False
 
+    # Asymmetric timeouts for router-to-engine calls (Gate 0.5 fix).
+    # total: upper bound on any single engine call. Set below the harness /
+    #   router-to-client total so router surfaces failure before the client
+    #   gives up.
+    # sock_connect: TCP connect budget.
+    # sock_read: idle budget — max time between bytes. This is the one that
+    #   turns a silent vLLM hang from a 300s stall into a ~30s fast failure.
+    _ENGINE_TOTAL_TIMEOUT_S = 240
+    _ENGINE_CONNECT_TIMEOUT_S = 10
+    _ENGINE_IDLE_TIMEOUT_S = 30
+
+    def _get_session(self) -> aiohttp.ClientSession:
+        """Return the shared session, creating it on first use.
+
+        One session per adapter means connection pooling works and the FD
+        footprint stays bounded at high request counts.
+        """
+        if self._session is None or self._session.closed:
+            timeout = aiohttp.ClientTimeout(
+                total=self._ENGINE_TOTAL_TIMEOUT_S,
+                sock_connect=self._ENGINE_CONNECT_TIMEOUT_S,
+                sock_read=self._ENGINE_IDLE_TIMEOUT_S,
+            )
+            self._session = aiohttp.ClientSession(timeout=timeout)
+        return self._session
+
     async def forward_request(
         self,
         path: str,
@@ -208,26 +266,23 @@ class EngineAdapter(abc.ABC):
             JSON response dict, or async byte iterator for streaming.
 
         Raises:
-            aiohttp.ClientError: On connection or HTTP errors.
+            asyncio.TimeoutError: on total/connect/idle timeout.
+            aiohttp.ClientError: on connection or HTTP errors.
         """
         url = f"{self.base_url}{path}"
         if stream:
             payload["stream"] = True
 
-        timeout = aiohttp.ClientTimeout(total=300)
-        session = aiohttp.ClientSession(timeout=timeout)
+        session = self._get_session()
 
-        try:
-            if stream:
-                return self._stream_response(session, url, payload)
-            else:
-                async with session.post(url, json=payload) as resp:
-                    result = await resp.json()
-                    await session.close()
-                    return result
-        except Exception:
-            await session.close()
-            raise
+        if stream:
+            # Return the async generator directly; it uses the shared session
+            # and does NOT close it on completion (session lifetime == adapter
+            # lifetime).
+            return self._stream_response(session, url, payload)
+
+        async with session.post(url, json=payload) as resp:
+            return await resp.json()
 
     async def _stream_response(
         self,
@@ -235,22 +290,10 @@ class EngineAdapter(abc.ABC):
         url: str,
         payload: dict[str, Any],
     ) -> AsyncIterator[bytes]:
-        """Stream SSE chunks from the engine.
-
-        Args:
-            session: aiohttp session (caller manages lifetime).
-            url: Full request URL.
-            payload: JSON body.
-
-        Yields:
-            Raw SSE bytes from the engine.
-        """
-        try:
-            async with session.post(url, json=payload) as resp:
-                async for chunk in resp.content.iter_any():
-                    yield chunk
-        finally:
-            await session.close()
+        """Stream SSE chunks from the engine over the shared session."""
+        async with session.post(url, json=payload) as resp:
+            async for chunk in resp.content.iter_any():
+                yield chunk
 
     @property
     def is_healthy(self) -> bool:


### PR DESCRIPTION
## Summary
Addresses the Gate 0 benchmark harness stall (#19 outcome: router's aiohttp client timed out waiting 300s for vLLM response headers, repeated 76 times over 3h on c=1 alternating workload).

**This PR does not fix the underlying vLLM engine hang.** It converts "3-hour silent stall" into "~30-second visible failure" so the next incident is diagnosable in minutes, not hours.

## What's fixed

| Change | Why | File |
|---|---|---|
| R1 session reuse | One `aiohttp.ClientSession` per adapter (was: new session per request — FD leak + no pooling) | `src/infergrid/engines/base.py` |
| R2 asymmetric timeouts | Router-to-engine total=240s < client-to-router 300s, so router surfaces failure first | `src/infergrid/engines/base.py` |
| R3 idle timeout | `sock_read=30s` catches silent engine hangs within 30s instead of 300s | `src/infergrid/engines/base.py` |
| D1 per-request log | Harness emits START/DONE/TIMEOUT per request (Gate 0 produced zero output between "Starting..." and the 300s storm) | `benchmarks/scripts/benchmark_multi_model.py` |

## Local reproducer (no GPU)

New files:
- `benchmarks/scripts/mock_engine.py` — vLLM-OpenAI-compatible mock. `--hang-after N` enters permanent stall on request N+1, mimicking the Gate 0 engine.
- `benchmarks/scripts/repro_gate0_stall.sh` — driver that wires up 2 mocks + `infergrid serve` + the harness. Completes in <2 min on pass state; hangs for 300s on BEFORE-fix state.
- `benchmarks/configs/gate05_mock.yaml` — attaches router to mocks on fixed ports 8002/8003.

Dev-mode hook: `INFERGRID_DEV_SKIP_ENGINE_LAUNCH=1` makes `EngineAdapter.start()` skip subprocess spawning; no effect when unset.

## Deferred to PR #22
- R4 per-engine circuit breaker (shed after N consecutive timeouts)
- R5 harness phase-abort on failure cascade
- D2 tar `/tmp/infergrid_engine_*.log` in pod bootstrap
- D3 router request-ID trace logs

## Test plan
- [x] 121 unit tests still pass (8 pre-existing integration xfail, unchanged baseline)
- [x] Python syntax checks on all new files
- [ ] Reviewer runs `bash benchmarks/scripts/repro_gate0_stall.sh 40` — should complete in <2 min
- [ ] With `MOCK_HANG_AFTER=0 bash ... 0`: all 50 requests succeed

## Related
- Gate 0 results: PR #19 (merged), `results/gate0_20260418/GATE0_OUTCOME.md`
- Investigation memory: `investigation_gate05.md`
- Gate 1 (H100 admission TTFT) blocks on this PR + rerunning the harness locally with a real vLLM