### PR TITLE
fix: R4 engine circuit breaker + late-prepare stream response

### DIFF
--- a/benchmarks/scripts/repro_gate0_stall.sh
+++ b/benchmarks/scripts/repro_gate0_stall.sh
@@ -46,11 +46,13 @@ python3 benchmarks/scripts/mock_engine.py --port 8003 \
 sleep 2
 
 echo "--- starting infergrid serve (dev mode: skip engine launch, attach to mocks) ---"
+# Use gate05_mock.yaml so engines are pinned to ports 8002/8003 matching mocks.
+# Without --config the router auto-allocates from 8001 and the mapping breaks.
 INFERGRID_ENGINE_LOG_DIR="$LOGDIR" \
 INFERGRID_DEV_SKIP_ENGINE_LAUNCH=1 \
+PYTHONPATH="$REPO_ROOT/src:${PYTHONPATH:-}" \
 python3 -m infergrid.cli serve \
-    --port 8000 \
-    "meta-llama/Llama-3.1-8B-Instruct" "Qwen/Qwen2.5-7B-Instruct" \
+    --config benchmarks/configs/gate05_mock.yaml \
     --log-level INFO \
     > "$LOGDIR/infergrid.log" 2>&1 &
 IG_PID=$!

--- a/src/infergrid/engines/base.py
+++ b/src/infergrid/engines/base.py
@@ -14,11 +14,21 @@ import logging
 import os
 import re
 import tempfile
+import time
 from typing import Any, AsyncIterator
 
 import aiohttp
 
 logger = logging.getLogger(__name__)
+
+
+class EngineCircuitOpenError(Exception):
+    """Raised when an engine's circuit breaker is open (too many recent timeouts).
+
+    Router handlers should catch this and return HTTP 503 without re-attempting
+    the engine call. Shedding fast is the point: it turns a 30-second
+    per-request timeout storm into millisecond-scale errors.
+    """
 
 # Directory for per-engine subprocess logs. Overridden via INFERGRID_ENGINE_LOG_DIR env.
 _ENGINE_LOG_DIR = os.environ.get("INFERGRID_ENGINE_LOG_DIR") or tempfile.gettempdir()
@@ -68,6 +78,12 @@ class EngineAdapter(abc.ABC):
         # pooling — a meaningful slice of Gate 0's 3h stall was spent dialing
         # new sockets to an engine that had already stopped responding.
         self._session: aiohttp.ClientSession | None = None
+        # Circuit breaker state (R4). After `_CIRCUIT_THRESHOLD` consecutive
+        # TimeoutErrors, the circuit opens for `_CIRCUIT_COOLDOWN_S` seconds.
+        # forward_request raises EngineCircuitOpenError while open, without
+        # touching the network.
+        self._consecutive_timeouts = 0
+        self._circuit_open_until: float = 0.0
 
     @property
     def base_url(self) -> str:
@@ -233,6 +249,9 @@ class EngineAdapter(abc.ABC):
     _ENGINE_TOTAL_TIMEOUT_S = 240
     _ENGINE_CONNECT_TIMEOUT_S = 10
     _ENGINE_IDLE_TIMEOUT_S = 30
+    # Circuit breaker parameters (R4).
+    _CIRCUIT_THRESHOLD = 3          # consecutive timeouts before opening
+    _CIRCUIT_COOLDOWN_S = 60.0      # seconds the circuit stays open
 
     def _get_session(self) -> aiohttp.ClientSession:
         """Return the shared session, creating it on first use.
@@ -248,6 +267,39 @@ class EngineAdapter(abc.ABC):
             )
             self._session = aiohttp.ClientSession(timeout=timeout)
         return self._session
+
+    def _check_circuit(self) -> None:
+        """Raise EngineCircuitOpenError if the circuit is currently open."""
+        if self._circuit_open_until and time.monotonic() < self._circuit_open_until:
+            raise EngineCircuitOpenError(
+                f"{self.engine_name} circuit open for {self.model_id}: "
+                f"{self._consecutive_timeouts} consecutive timeouts, "
+                f"cooldown {self._circuit_open_until - time.monotonic():.1f}s remaining"
+            )
+        # Cooldown elapsed — give it one chance to recover. The next success
+        # resets _consecutive_timeouts; another failure re-opens the circuit.
+
+    def _note_timeout(self) -> None:
+        """Record a router-to-engine TimeoutError; open circuit if threshold hit."""
+        self._consecutive_timeouts += 1
+        if self._consecutive_timeouts >= self._CIRCUIT_THRESHOLD:
+            self._circuit_open_until = time.monotonic() + self._CIRCUIT_COOLDOWN_S
+            self._healthy = False
+            logger.warning(
+                "%s circuit OPEN for %s: %d consecutive timeouts, cooldown %.0fs",
+                self.engine_name, self.model_id,
+                self._consecutive_timeouts, self._CIRCUIT_COOLDOWN_S,
+            )
+
+    def _note_success(self) -> None:
+        """Record a successful request; close circuit if it was cooling down."""
+        if self._consecutive_timeouts > 0 or self._circuit_open_until:
+            logger.info(
+                "%s circuit RESET for %s (was %d consecutive timeouts)",
+                self.engine_name, self.model_id, self._consecutive_timeouts,
+            )
+        self._consecutive_timeouts = 0
+        self._circuit_open_until = 0.0
 
     async def forward_request(
         self,
@@ -269,6 +321,8 @@ class EngineAdapter(abc.ABC):
             asyncio.TimeoutError: on total/connect/idle timeout.
             aiohttp.ClientError: on connection or HTTP errors.
         """
+        self._check_circuit()
+
         url = f"{self.base_url}{path}"
         if stream:
             payload["stream"] = True
@@ -278,11 +332,17 @@ class EngineAdapter(abc.ABC):
         if stream:
             # Return the async generator directly; it uses the shared session
             # and does NOT close it on completion (session lifetime == adapter
-            # lifetime).
+            # lifetime). The generator notes success/timeout internally.
             return self._stream_response(session, url, payload)
 
-        async with session.post(url, json=payload) as resp:
-            return await resp.json()
+        try:
+            async with session.post(url, json=payload) as resp:
+                result = await resp.json()
+        except (asyncio.TimeoutError, aiohttp.ServerTimeoutError):
+            self._note_timeout()
+            raise
+        self._note_success()
+        return result
 
     async def _stream_response(
         self,
@@ -291,9 +351,15 @@ class EngineAdapter(abc.ABC):
         payload: dict[str, Any],
     ) -> AsyncIterator[bytes]:
         """Stream SSE chunks from the engine over the shared session."""
-        async with session.post(url, json=payload) as resp:
-            async for chunk in resp.content.iter_any():
-                yield chunk
+        try:
+            async with session.post(url, json=payload) as resp:
+                async for chunk in resp.content.iter_any():
+                    yield chunk
+        except (asyncio.TimeoutError, aiohttp.ServerTimeoutError):
+            self._note_timeout()
+            raise
+        else:
+            self._note_success()
 
     @property
     def is_healthy(self) -> bool:

--- a/src/infergrid/router/router.py
+++ b/src/infergrid/router/router.py
@@ -18,12 +18,13 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
+import aiohttp
 from aiohttp import web
 
 from infergrid.cache.manager import CacheManager
 from infergrid.common.config import InferGridConfig, ModelConfig
 from infergrid.common.metrics import MetricsCollector
-from infergrid.engines.base import EngineAdapter
+from infergrid.engines.base import EngineAdapter, EngineCircuitOpenError
 from infergrid.engines.sglang_adapter.adapter import SGLangAdapter
 from infergrid.engines.vllm_adapter.adapter import VLLMAdapter
 from infergrid.router.admission import AdmissionController, AdmissionTimeoutError
@@ -551,13 +552,43 @@ class WorkloadRouter:
             )
 
             if stream and hasattr(result, "__aiter__"):
-                response = web.StreamResponse(
-                    status=200,
-                    headers={"Content-Type": "text/event-stream"},
-                )
-                await response.prepare(request)
-                async for chunk in result:
-                    await response.write(chunk)
+                # Delay response.prepare() until the FIRST chunk arrives so an
+                # engine failure before any byte is sent can still return a
+                # clean 500 (instead of an uncommittable mid-stream error).
+                # Gate 0.5 repro showed the SSE client hangs for its full
+                # client-side timeout when the server commits 200 then closes
+                # with no body.
+                response: web.StreamResponse | None = None
+                try:
+                    async for chunk in result:
+                        if response is None:
+                            response = web.StreamResponse(
+                                status=200,
+                                headers={"Content-Type": "text/event-stream"},
+                            )
+                            await response.prepare(request)
+                        await response.write(chunk)
+                except (asyncio.TimeoutError, aiohttp.ServerTimeoutError) as exc:
+                    if response is None:
+                        # Engine failed before first byte — clean 504.
+                        return web.json_response(
+                            {"error": "engine timeout", "detail": str(exc)},
+                            status=504,
+                        )
+                    # Already committed 200 headers; close the stream.
+                    logger.warning(
+                        "engine timeout mid-stream for %s: %s", model_id, exc,
+                    )
+                    await response.write_eof()
+                    return response
+
+                if response is None:
+                    # Iterator yielded nothing — treat as empty successful response.
+                    response = web.StreamResponse(
+                        status=200,
+                        headers={"Content-Type": "text/event-stream"},
+                    )
+                    await response.prepare(request)
                 await response.write_eof()
                 return response
 
@@ -571,6 +602,12 @@ class WorkloadRouter:
                     "queue_depth": exc.queue_depth,
                     "in_flight": exc.in_flight,
                 },
+                status=503,
+            )
+        except EngineCircuitOpenError as exc:
+            # Engine has hit the consecutive-timeout threshold; shed fast.
+            return web.json_response(
+                {"error": "engine unavailable", "detail": str(exc)},
                 status=503,
             )
         except BudgetExceededError as exc:


### PR DESCRIPTION
## Summary
Closes the Gate 0.5 loop. PR #21 added router-side sock_read=30s (R3); it worked — router detected engine stalls at 30s. **But the harness still blocked for its full 300s** because the router had already committed `200 OK` headers before the engine failed, leaving a half-open SSE body.

This PR:
1. **Delays `response.prepare()` until the first chunk arrives.** If the engine fails before any byte, return a clean 504 JSON error instead of a half-open stream.
2. **Adds R4 engine circuit breaker.** After 3 consecutive `asyncio.TimeoutError`s on an engine, the circuit opens for 60s; subsequent `forward_request` calls raise `EngineCircuitOpenError` without hitting the network; router returns 503. Successful calls reset the counter.

## Local reproducer evidence

With `benchmarks/scripts/repro_gate0_stall.sh 2` (num=5, hang_after=2):

| | Before | After this PR |
|---|---:|---:|
| Wall clock | 301s | **33s** |
| Harness verdict | TIMEOUT after 301s | fast 5xx + next request progresses |

Baseline run (`hang_after=9999`, num=20): all 20 requests succeed in 11s. No regression.

## Files

- `src/infergrid/engines/base.py` — `EngineCircuitOpenError`, counter, threshold, cooldown; wraps `forward_request` and `_stream_response` in try/except
- `src/infergrid/router/router.py` — delayed prepare; catch `EngineCircuitOpenError` → 503; catch mid-stream timeout → EOF + graceful exit
- `benchmarks/scripts/repro_gate0_stall.sh` — use `--config gate05_mock.yaml` so router engine ports align with mocks

## Test plan
- [x] 121 unit tests pass (8 pre-existing integration xfail, baseline unchanged)
- [x] Local reproducer: stall scenario drops 301s → 33s
- [x] Local reproducer: baseline (no stall) still succeeds
- [ ] Reviewer runs `bash benchmarks/scripts/repro_gate0_stall.sh 2` — expect <45s wall clock
- [ ] Reviewer runs `bash benchmarks/scripts/repro_gate0_stall.sh 9999` — expect <20s wall clock

## Deferred to PR #23
- R5 harness phase-abort on failure cascade (cosmetic; R4 already shorts on server side)
- D2 tar `/tmp/infergrid_engine_*.log` in pod bootstrap
- D3 router request-ID trace logs

## Unblocks
- Gate 1 (H100 admission-control TTFT) can now rerun the bench harness without the 3h stall risk.