### PR TITLE
fix: D3 router request-IDs + PROGRESS test counts + CORRECTIONS.md

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -23,7 +23,7 @@ InferGrid is a middleware orchestration layer for LLM inference that sits on top
 | Infrastructure (profiling, scripts, benchmarks) | 6,774 lines |
 | Documentation (docs/) | 871 lines |
 | Profiling data points | 416,019 rows across 879 files |
-| Unit tests | 121 passing |
+| Unit tests | 129 collected, 121 pass, 8 xfail (pre-existing in `test_benchmark_client`) |
 | GPU configurations profiled | 3 (vLLM A100, SGLang A100, vLLM H100) |
 | PRs merged | 12 |
 
@@ -150,7 +150,7 @@ InferGrid is a middleware orchestration layer for LLM inference that sits on top
 - Streaming session leak in vLLM/SGLang adapters
 - Port allocation without availability check
 
-**Test results:** 121 unit tests, all passing (9 seconds on M1 Mac).
+**Test results:** 129 unit tests collected, 121 pass + 8 pre-existing integration xfail in `test_benchmark_client.py` (CSV/dataframe export, connection error handling — orthogonal to the core router/cache/tenant code paths). Runs in ~12s on M1 Mac.
 
 ### Phase 6: Documentation + Polish (Apr 16, 2026)
 

--- a/results/CORRECTIONS.md
+++ b/results/CORRECTIONS.md
@@ -1,0 +1,86 @@
+# Results — Corrections & Caveats
+
+This file records discrepancies and misleading metrics in the committed results
+artifacts so the preprint and any external citations don't propagate stale or
+wrong numbers. Each entry: where the issue is, what's wrong, what's correct,
+and what action (if any) is required.
+
+---
+
+## C1 — Driver version mismatch in PR #14 commit message vs metadata
+
+**Where:** `git log` for `PR #14` (data: Phase 1 profiling raw results) commit message vs.
+the `driver` fields in three `run_metadata.json` files.
+
+**Discrepancy:** the PR #14 commit message reads
+"vLLM A100-SXM4-80GB (driver 580.126.16)" and "SGLang A100-SXM4-80GB (driver 580.126.16)".
+Reality from on-disk metadata:
+
+| Run dir | metadata driver |
+|---|---|
+| `results_vllm_a100-sxm_20260416_182457/run_metadata.json` | **570.195.03** |
+| `results_sglang_a100-sxm_20260416_183302/run_metadata.json` | 580.126.16 |
+| `results_vllm_h100-sxm_20260416_182420/run_metadata.json` | 580.126.09 |
+
+**Correct citation for the preprint:**
+- vLLM A100-SXM: NVIDIA driver **570.195.03**
+- SGLang A100-SXM: NVIDIA driver **580.126.16**
+- vLLM H100-SXM: NVIDIA driver **580.126.09**
+
+The PR #14 commit message error does not affect the data itself. No re-run needed.
+
+---
+
+## C2 — `switch_latency.json` "TTFT" is not real TTFT
+
+**Where:** `results/gate0_20260418/benchmarks/switch_latency.json` (Gate 0 partial bench output).
+
+**Reported numbers:** `cold_swap_ttft_mean_ms: 31.3`, `warm_ttft_mean_ms: 30.2 / 31.2`.
+
+**Why these are misleading:** the harness measures "first token" by timestamping
+the first SSE line that begins with `data: ` (see `benchmark_multi_model.py`
+around line 485-494). For a localhost connection, the **first SSE frame
+arrives within the TCP round-trip window (~30 ms)** — long before actual model
+generation finishes. So the recorded "TTFT" is essentially network RTT plus
+the latency of the first SSE chunk header, **not** the time from request to
+first generated token from the model.
+
+**Don't cite these numbers.** Real TTFT for an 7-8B model on A100-SXM is
+expected to be:
+- cold (first request to a freshly-loaded model): 30-80 ms
+- warm: 5-15 ms
+
+These will be re-measured properly in Gate 1 with a corrected harness path
+that times from request submit to first non-zero-token in the streamed
+content (not first SSE frame).
+
+---
+
+## C3 — Router `avg_latency_s: 0.0102` excludes streaming tail
+
+**Where:** `results/gate0_20260418/status_after.json` — the
+`loaded_models["..."].avg_latency_s` field.
+
+**What it actually measures:** time spent inside `route_request` from
+admission to the moment `forward_request` returns the async iterator —
+not the full request lifetime. For streaming responses, this excludes the
+generation time entirely.
+
+**Correct interpretation:** "router-internal handler overhead per request"
+(useful for proving the router is not a bottleneck). It is **not** the
+end-to-end latency a client sees.
+
+---
+
+## C4 — Gate 0 bench ran on a branch predating PR #16's engine log capture
+
+**Where:** Gate 0 was executed against branch `feat/gate0-config` before
+PR #16 merged. The pod's vLLM subprocess wrote stderr only to in-memory PIPE
+with a 2 KB tail slice, so when vLLM hung at request ~46 we lost the actual
+root cause.
+
+**Action:** PR #16 (now merged) writes per-engine stdout+stderr to disk under
+`INFERGRID_ENGINE_LOG_DIR` (default `/tmp`). All future Gate runs MUST clone
+main (post-PR #16) so the engine logs are preserved.
+
+---

--- a/src/infergrid/router/router.py
+++ b/src/infergrid/router/router.py
@@ -542,6 +542,16 @@ class WorkloadRouter:
         path = request.path
         stream = payload.get("stream", False)
 
+        # D3: per-request trace ID. Stable across the lifetime of one request,
+        # printed at entry, exit, and all error branches so a stuck request can
+        # be tracked end-to-end in the log without grepping by timestamp. The
+        # client can also pass X-Request-ID to correlate with their own log.
+        req_id = request.headers.get("X-Request-ID") or (
+            f"r{int(time.time() * 1000) % 1_000_000_000:09d}"
+        )
+        logger.info("req_id=%s ENTER model=%s tenant=%s stream=%s path=%s",
+                    req_id, model_id, tenant_id, stream, path)
+
         try:
             result = await self.route_request(
                 model_id=model_id,
@@ -571,13 +581,16 @@ class WorkloadRouter:
                 except (asyncio.TimeoutError, aiohttp.ServerTimeoutError) as exc:
                     if response is None:
                         # Engine failed before first byte — clean 504.
+                        logger.warning("req_id=%s EXIT 504 engine_timeout_pre_byte detail=%s",
+                                       req_id, exc)
                         return web.json_response(
                             {"error": "engine timeout", "detail": str(exc)},
                             status=504,
                         )
                     # Already committed 200 headers; close the stream.
                     logger.warning(
-                        "engine timeout mid-stream for %s: %s", model_id, exc,
+                        "req_id=%s EXIT 200_partial engine_timeout_mid_stream detail=%s",
+                        req_id, exc,
                     )
                     await response.write_eof()
                     return response
@@ -590,11 +603,15 @@ class WorkloadRouter:
                     )
                     await response.prepare(request)
                 await response.write_eof()
+                logger.info("req_id=%s EXIT 200 stream_complete", req_id)
                 return response
 
+            logger.info("req_id=%s EXIT 200 json_complete", req_id)
             return web.json_response(result)
 
         except AdmissionTimeoutError as exc:
+            logger.warning("req_id=%s EXIT 503 admission_timeout queue=%d in_flight=%d",
+                           req_id, exc.queue_depth, exc.in_flight)
             return web.json_response(
                 {
                     "error": "server overloaded",
@@ -606,20 +623,23 @@ class WorkloadRouter:
             )
         except EngineCircuitOpenError as exc:
             # Engine has hit the consecutive-timeout threshold; shed fast.
+            logger.warning("req_id=%s EXIT 503 circuit_open detail=%s", req_id, exc)
             return web.json_response(
                 {"error": "engine unavailable", "detail": str(exc)},
                 status=503,
             )
         except BudgetExceededError as exc:
+            logger.warning("req_id=%s EXIT 429 budget_exceeded detail=%s", req_id, exc)
             return web.json_response(
                 {"error": str(exc)}, status=429
             )
         except ValueError as exc:
+            logger.warning("req_id=%s EXIT 404 value_error detail=%s", req_id, exc)
             return web.json_response(
                 {"error": str(exc)}, status=404
             )
         except Exception as exc:
-            logger.exception("Request failed: %s", exc)
+            logger.exception("req_id=%s EXIT 500 unhandled: %s", req_id, exc)
             return web.json_response(
                 {"error": f"internal error: {exc}"}, status=500
             )


### PR DESCRIPTION
## Summary
Three small follow-ups bundled before Gate 1.

1. **D3 router request-ID logs** (`src/infergrid/router/router.py`) — every request gets a `req_id` (millisecond counter or `X-Request-ID` header). Logged at ENTER and at every EXIT path: 200/json_complete, 200/stream_complete, 200_partial/engine_timeout_mid_stream, 504/engine_timeout_pre_byte, 503/admission_timeout, 503/circuit_open, 429/budget, 404/value, 500/unhandled. Lets a stuck Gate 1 request be tracked end-to-end.

2. **PROGRESS.md test counts corrected** — "121 passing" → "129 collected, 121 pass, 8 pre-existing integration xfail in test_benchmark_client". Reflected in metric table and Phase 5 narrative.

3. **`results/CORRECTIONS.md` (new)** — public record of 3 misleading numbers + 1 process gap that the preprint must NOT cite as-is:
   - C1: PR #14 commit message had wrong driver version for vLLM A100-SXM (real: 570.195.03, message said 580.126.16)
   - C2: `switch_latency.json` 30 ms "TTFT" is SSE first-frame RTT, NOT real TTFT
   - C3: router `status_after.json avg_latency_s` excludes streaming tail
   - C4: Gate 0 ran on a branch predating PR #16 engine log capture; future Gates must clone main

## Test plan
- [x] 121 unit tests pass (no regression)
- [x] Syntax checks
- [ ] Reviewer eyeballs `req_id=...` lines in `infergrid.log` after a smoke run

## Unblocks
- Gate 1 (H100 admission TTFT): debugging stuck requests now requires only a `grep req_id=X` instead of timestamp correlation.