### PR TITLE
feat: R5 phase-abort + checked-in gate pod bootstrap (D2)

### DIFF
--- a/benchmarks/scripts/benchmark_multi_model.py
+++ b/benchmarks/scripts/benchmark_multi_model.py
@@ -163,6 +163,7 @@ class MultiModelBenchmarkResults:
     switch_events: list[ModelSwitchEvent] = field(default_factory=list)
     gpu_metrics_df: Any = None
     config: dict[str, Any] = field(default_factory=dict)
+    aborted_after_n_errors: int | None = None  # R5: set if phase aborted early
 
     def summary(self) -> dict[str, Any]:
         """Compute aggregate statistics, broken down by model.
@@ -370,8 +371,17 @@ class MultiModelBenchmarkClient:
             sorted(set(schedule)),
         )
 
+        # R5: phase-abort on 5 consecutive request errors. Using as_completed +
+        # task cancellation so a stuck engine can't waste 30s × remaining_reqs.
+        # "Consecutive" is by completion order; at c=1 this matches request-id
+        # order. At c>1 it gives bounded blast radius from a stalling engine.
+        phase_name = getattr(self, "phase_name", "unknown")
+        consec_errors = 0
+        aborted_after: int | None = None
+        ABORT_THRESHOLD = 5
+
         async with aiohttp.ClientSession() as session:
-            tasks = []
+            tasks: list[asyncio.Task[MultiModelRequestMetrics]] = []
             for i, (model, req) in enumerate(zip(schedule, requests)):
                 prompt = req.get("prompt", "") if isinstance(req, dict) else str(req)
                 max_tokens = (
@@ -379,13 +389,36 @@ class MultiModelBenchmarkClient:
                     if isinstance(req, dict)
                     else self.max_tokens
                 )
-                tasks.append(
+                tasks.append(asyncio.create_task(
                     self._send_request(
                         session, i, model, prompt, max_tokens, semaphore
                     )
-                )
-            raw_metrics = await asyncio.gather(*tasks)
-            all_metrics = list(raw_metrics)
+                ))
+            raw_metrics: list[MultiModelRequestMetrics] = []
+            for fut in asyncio.as_completed(tasks):
+                m = await fut
+                raw_metrics.append(m)
+                if m.error is not None:
+                    consec_errors += 1
+                    if consec_errors >= ABORT_THRESHOLD:
+                        aborted_after = consec_errors
+                        logger.warning(
+                            "phase=%s c=%d ABORT %d consecutive errors",
+                            phase_name, self.concurrency, consec_errors,
+                        )
+                        for t in tasks:
+                            if not t.done():
+                                t.cancel()
+                        break
+                else:
+                    consec_errors = 0
+            # Drain any in-flight tasks (cancelled or otherwise) so we don't
+            # leak "Task was destroyed but it is pending" warnings.
+            drained = await asyncio.gather(*tasks, return_exceptions=True)
+            for d in drained:
+                if isinstance(d, MultiModelRequestMetrics) and d not in raw_metrics:
+                    raw_metrics.append(d)
+            all_metrics = raw_metrics
 
         if gpu_collector is not None:
             gpu_collector.stop()
@@ -424,6 +457,7 @@ class MultiModelBenchmarkClient:
             per_request=all_metrics,
             switch_events=switch_events,
             gpu_metrics_df=gpu_df,
+            aborted_after_n_errors=aborted_after,
         )
 
     async def _send_request(

--- a/scripts/gate_pod_bootstrap.sh
+++ b/scripts/gate_pod_bootstrap.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# Generic InferGrid Gate-run pod bootstrap (Gate 0.6, 1, 2, 3+).
+# Idempotent. Parameterized. Bundles results+engine_logs ON ANY EXIT (D2 fix).
+#
+# 5 Gate-0 lessons baked in here (see results/gate0_20260418/GATE0_OUTCOME.md):
+#   1. SSH port mapping --> handled upstream by scripts/provision_runpod.py.
+#   2. HF_TOKEN env --> sourced from /root/.gate_env (scp'd by master).
+#   3. transformers<5 --> asserted in dep verification (PR #16 pin).
+#   4. numpy<2.3      --> asserted in dep verification (PR #16 pin).
+#   5. vLLM v1 OOM at co-load --> VLLM_USE_V1=0 here; gpu_mem_util in config.
+#
+# Scope: this script ONLY runs ON the pod. It does not provision, tear down,
+# or rsync results out -- master handles those.
+#
+# Usage:
+#   nohup bash gate_pod_bootstrap.sh \
+#       --run-name gate1_20260420_1530 \
+#       --config configs/gate1_admission.yaml \
+#       --bench-script benchmarks/scripts/benchmark_multi_model.py \
+#       --bench-args "--url http://localhost:8000 --concurrency 1,8,32 --num-requests 50 --output-dir RDIR/benchmarks --seed 42" \
+#       > /workspace/bootstrap.console 2>&1 &
+#
+# --bench-script "" skips Phase 7 (serve-only runs).
+# RDIR placeholder in --bench-args is substituted with the run results dir.
+
+set -u
+exec > >(tee -a /workspace/bootstrap.log) 2>&1
+
+# ---- Args ----
+RUN_NAME=""; CONFIG=""; BENCH_SCRIPT=""; BENCH_ARGS=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --run-name)     RUN_NAME="$2"; shift 2 ;;
+    --config)       CONFIG="$2"; shift 2 ;;
+    --bench-script) BENCH_SCRIPT="$2"; shift 2 ;;
+    --bench-args)   BENCH_ARGS="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+[ -z "$RUN_NAME" ] && RUN_NAME="gate_$(date -u +%Y%m%d_%H%M%S)"
+[ -z "$CONFIG" ] && { echo "FATAL: --config required" >&2; exit 2; }
+
+RDIR=/workspace/results/$RUN_NAME
+ELOG=$RDIR/engine_logs
+TARBALL=/workspace/${RUN_NAME}_results.tar.gz
+STATUS=FAILED   # flipped to DONE only at very end
+
+mkdir -p "$ELOG"
+echo "=== Bootstrap start: $(date -u) RUN_NAME=$RUN_NAME ==="
+
+# ---- Single EXIT trap = D2 fix (covers fail, SIGTERM, kill, success) ----
+bundle_and_mark() {
+  local rc=$?
+  echo "--- trap: bundling (status=$STATUS rc=$rc) ---"
+  kill "$(cat $RDIR/server.pid 2>/dev/null)"     2>/dev/null || true
+  kill "$(cat $RDIR/gpu_trace.pid 2>/dev/null)" 2>/dev/null || true
+  sleep 2; pkill -9 -f "vllm.entrypoints" 2>/dev/null || true
+  cp /workspace/bootstrap.log "$RDIR/bootstrap.log" 2>/dev/null || true
+  tar -czf "$TARBALL" -C /workspace "results/$RUN_NAME" 2>/dev/null \
+    && echo "archive: $(du -h $TARBALL | cut -f1)" \
+    || echo "WARN: tar failed"
+  if [ "$STATUS" = "DONE" ]; then touch /workspace/${RUN_NAME}_DONE
+  else echo "rc=$rc" > /workspace/${RUN_NAME}_FAILED; fi
+  echo "=== Bootstrap end: $(date -u) status=$STATUS ==="
+}
+trap bundle_and_mark EXIT
+fail() { echo "FAIL: $1" >&2; exit 1; }   # trap still fires
+
+# ---- Env (HF_TOKEN etc.) ----
+[ -f /root/.gate_env ] && { set -a; . /root/.gate_env; set +a; echo "loaded /root/.gate_env"; }
+export VLLM_USE_V1=0
+export PYTHONUNBUFFERED=1
+export INFERGRID_ENGINE_LOG_DIR="$ELOG"   # PR #16 per-engine stderr capture
+[ -n "${HF_TOKEN:-}" ] || fail "HF_TOKEN not set"
+
+# ---- Phase 1: apt + clone main ----
+echo "--- Phase 1: apt + clone ---"
+apt-get update -qq && apt-get install -y -qq git rsync curl jq || fail "apt install"
+cd /workspace; rm -rf infergrid
+git clone --branch main --depth 1 https://github.com/coconut-labs/infergrid.git || fail "git clone"
+cd infergrid; echo "main HEAD: $(git rev-parse --short HEAD)  $(git log -1 --pretty=%s)"
+
+# ---- Phase 2: python deps ----
+echo "--- Phase 2: python deps ---"
+python3 -m pip install --quiet --upgrade pip || fail "pip upgrade"
+python3 -m pip install --quiet 'vllm==0.8.5' || fail "vllm install"
+python3 -m pip install --quiet -r requirements-gpu.txt || fail "requirements-gpu"
+python3 -m pip install --quiet -e . || fail "infergrid editable"
+python3 -m pip install --quiet 'huggingface_hub[cli]' || fail "hf cli"
+
+# ---- Dep verification (Gate-0 lessons 3+4) ----
+python3 -c "
+import transformers, numpy, vllm, torch
+print(f'vllm={vllm.__version__} transformers={transformers.__version__} numpy={numpy.__version__} torch={torch.__version__}')
+assert int(transformers.__version__.split('.')[0]) < 5, 'transformers must be < 5'
+assert tuple(int(x) for x in numpy.__version__.split('.')[:2]) < (2, 3), 'numpy must be < 2.3'
+print('PINS OK')" || fail "dep version check"
+
+# ---- Phase 3: HF login ----
+echo "--- Phase 3: HF login ---"
+huggingface-cli login --token "$HF_TOKEN" --add-to-git-credential 2>&1 | tail -3 || fail "hf login"
+
+# ---- Phase 4: serve ----
+echo "--- Phase 4: infergrid serve --config $CONFIG ---"
+nohup bash -c 'while true; do
+  nvidia-smi --query-gpu=timestamp,memory.used,memory.total,utilization.gpu,power.draw \
+    --format=csv,noheader >> '"$RDIR"'/gpu_trace.csv; sleep 1; done' \
+  > "$RDIR/gpu_trace.err" 2>&1 &
+echo $! > "$RDIR/gpu_trace.pid"
+nohup infergrid serve --config "$CONFIG" --port 8000 --log-level INFO \
+  > "$RDIR/server.log" 2>&1 &
+echo $! > "$RDIR/server.pid"
+SERVER_PID=$(cat "$RDIR/server.pid"); echo "serve pid=$SERVER_PID"
+
+# ---- Phase 5: wait for /v1/models stable ----
+echo "--- Phase 5: waiting for /v1/models (stable count) ---"
+LAST=-1; STABLE=0
+for i in $(seq 1 240); do
+  kill -0 "$SERVER_PID" 2>/dev/null || fail "serve died. tail: $(tail -120 $RDIR/server.log)"
+  grep -q "Failed to pre-load model" "$RDIR/server.log" 2>/dev/null \
+    && fail "engine pre-load failure: $(grep -B2 -A6 'Failed to pre-load' $RDIR/server.log | head -80)"
+  N=$(curl -sf http://localhost:8000/v1/models 2>/dev/null \
+      | python3 -c 'import sys,json; print(len(json.load(sys.stdin).get("data",[])))' 2>/dev/null || echo 0)
+  if [ "$N" -gt 0 ] && [ "$N" = "$LAST" ]; then STABLE=$((STABLE+1)); else STABLE=0; fi
+  if [ "$STABLE" -ge 1 ]; then echo "READY: $N models stable after $((i*5))s"; break; fi
+  LAST=$N; sleep 5
+done
+[ "$STABLE" -ge 1 ] || fail "models did not stabilize within 20 min (last N=$LAST)"
+
+# ---- Phase 6: smoke (derive model list from /v1/models) ----
+echo "--- Phase 6: smoke ---"
+MODELS=$(curl -sf http://localhost:8000/v1/models | python3 -c 'import sys,json; [print(m["id"]) for m in json.load(sys.stdin)["data"]]')
+for M in $MODELS; do
+  R=$(curl -s http://localhost:8000/v1/chat/completions -H "Content-Type: application/json" --max-time 60 \
+      -d "{\"model\":\"$M\",\"messages\":[{\"role\":\"user\",\"content\":\"Say one short sentence about GPUs.\"}],\"max_tokens\":32}")
+  echo "smoke[$M]=$R" >> "$RDIR/smoke.jsonl"
+  C=$(echo "$R" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('choices',[{}])[0].get('message',{}).get('content',''))" 2>/dev/null || echo "")
+  [ -n "$C" ] || fail "smoke empty for $M: $R"
+  echo "  $M OK: $C"
+done
+curl -s http://localhost:8000/infergrid/status > "$RDIR/status_before.json" 2>/dev/null || true
+
+# ---- Phase 7: bench (skipped if --bench-script empty) ----
+if [ -n "$BENCH_SCRIPT" ]; then
+  echo "--- Phase 7: bench ---"
+  ARGS="${BENCH_ARGS//RDIR/$RDIR}"
+  bash -c "python3 $BENCH_SCRIPT $ARGS 2>&1 | tee $RDIR/bench.log" \
+    || echo "WARN: bench non-zero; continuing to capture"
+else
+  echo "--- Phase 7: SKIPPED (no --bench-script) ---"
+fi
+
+# ---- Phase 8: capture ----
+echo "--- Phase 8: capture ---"
+curl -s http://localhost:8000/infergrid/status > "$RDIR/status_after.json"  2>/dev/null || true
+curl -s http://localhost:8000/metrics         > "$RDIR/prometheus_dump.txt" 2>/dev/null || true
+cp "$CONFIG" "$RDIR/" 2>/dev/null || true
+nvidia-smi > "$RDIR/nvidia_smi_final.txt" 2>&1
+pip freeze > "$RDIR/pip_freeze.txt" 2>/dev/null || true
+git rev-parse HEAD > "$RDIR/git_head.txt" 2>/dev/null || true
+
+STATUS=DONE   # trap will tar + write _DONE marker
+exit 0


### PR DESCRIPTION
## Summary
Two follow-ups from L5 god-planner: R5 harness phase-abort + a checked-in generic pod bootstrap with engine-log capture (D2). Together they close out the Gate 0.5 follow-up list.

## R5 — harness phase-abort
`benchmark_multi_model.py`: 5 consecutive errors in a phase → cancel in-flight tasks, log warning, return early with `aborted_after_n_errors` set. Outer loop continues to the next concurrency level.

**Validated locally** with `bash benchmarks/scripts/smoke_bench.sh 1` (mock engine stalls after req 1):
```
[WARNING] __main__: phase=unknown c=1 ABORT 5 consecutive errors
[WARNING] __main__: phase=unknown c=8 ABORT 5 consecutive errors
[WARNING] __main__: phase=unknown c=32 ABORT 5 consecutive errors
```

## D2 — checked-in `scripts/gate_pod_bootstrap.sh`
Generic, parameterized, idempotent. Single EXIT trap bundles results + per-engine logs (PR #16's `INFERGRID_ENGINE_LOG_DIR`) on any exit (success, fail, SIGTERM). Used for Gate 1+.

Args: `--run-name --config --bench-script --bench-args`. Bakes all 5 Gate-0 lessons inline so future operators don't re-learn them.

**Migration:** Gate 0.6 is mid-flight on the legacy `/tmp/gate06_pod_bootstrap.sh`. Do NOT hot-swap. Adopted from Gate 1 onward.

## Test plan
- [x] 121 unit tests still pass
- [x] R5 abort fires correctly in smoke_bench with stalls
- [x] R5 happy-path (no stalls) still completes normally
- [x] Bootstrap syntax check
- [ ] Reviewer reads bootstrap to confirm trap is correct and engine_log_dir is right