### PR TITLE
fix(bench): real TTFT — time first non-empty content, not first SSE frame

### DIFF
--- a/benchmarks/scripts/benchmark_multi_model.py
+++ b/benchmarks/scripts/benchmark_multi_model.py
@@ -530,15 +530,20 @@ class MultiModelBenchmarkClient:
                         if data_str == "[DONE]":
                             break
 
-                        if first_token_time is None:
-                            first_token_time = time.time()
-
                         try:
                             chunk = json.loads(data_str)
                             choices = chunk.get("choices", [])
                             if choices and choices[0].get("text", ""):
+                                # C2 fix: TTFT is time-to-first-non-empty-content,
+                                # not time-to-first-SSE-frame (which is just the
+                                # network RTT to the server). Empty/role-only
+                                # frames do not count as a token.
+                                if first_token_time is None:
+                                    first_token_time = time.time()
                                 tokens_out += 1
                         except (json.JSONDecodeError, KeyError):
+                            if first_token_time is None:
+                                first_token_time = time.time()
                             tokens_out += 1
 
             except asyncio.TimeoutError:

--- a/benchmarks/scripts/mock_engine.py
+++ b/benchmarks/scripts/mock_engine.py
@@ -32,11 +32,19 @@ logger = logging.getLogger("mock_engine")
 
 
 class MockEngineState:
-    def __init__(self, model: str, hang_after: int, ok_latency: float, stall_s: float):
+    def __init__(
+        self,
+        model: str,
+        hang_after: int,
+        ok_latency: float,
+        stall_s: float,
+        delay_first_content_s: float = 0.0,
+    ):
         self.model = model
         self.hang_after = hang_after
         self.ok_latency = ok_latency
         self.stall_s = stall_s
+        self.delay_first_content_s = delay_first_content_s
         self.request_count = 0
         self.stalled_count = 0
 
@@ -113,6 +121,22 @@ async def handle_completions(request: web.Request) -> web.StreamResponse:
         headers={"Content-Type": "text/event-stream"},
     )
     await resp.prepare(request)
+
+    # Discriminator for real-TTFT: emit an empty-text frame immediately so a
+    # broken harness that times the first SSE frame sees a near-zero TTFT,
+    # then sleep before the first real-content chunk. A correct harness times
+    # the first non-empty `choices[0].text` and reports ~delay_first_content_s.
+    if state.delay_first_content_s > 0:
+        preamble = {
+            "id": f"mock-{rid}",
+            "object": "text_completion.chunk",
+            "created": int(time.time()),
+            "model": state.model,
+            "choices": [{"index": 0, "text": "", "finish_reason": None}],
+        }
+        await resp.write(f"data: {json.dumps(preamble)}\n\n".encode())
+        await asyncio.sleep(state.delay_first_content_s)
+
     for tok_i in range(max(1, max_tokens)):
         chunk = {
             "id": f"mock-{rid}",
@@ -161,6 +185,12 @@ def main() -> None:
         default=float(os.environ.get("MOCK_STALL_S", "10000")),
         help="Seconds to sleep when stalled",
     )
+    p.add_argument(
+        "--delay-first-content-s",
+        type=float,
+        default=float(os.environ.get("MOCK_DELAY_FIRST_CONTENT", "0")),
+        help="On streaming responses, emit an empty-text SSE frame, then sleep this long before the first real-content chunk (real-TTFT discriminator)",
+    )
     p.add_argument("--log-level", default="INFO")
     args = p.parse_args()
 
@@ -174,10 +204,11 @@ def main() -> None:
         hang_after=args.hang_after,
         ok_latency=args.ok_latency_s,
         stall_s=args.stall_s,
+        delay_first_content_s=args.delay_first_content_s,
     )
     logger.info(
-        "mock engine starting: port=%d model=%s hang_after=%d ok_latency=%.2fs stall=%.0fs",
-        args.port, args.model, args.hang_after, args.ok_latency_s, args.stall_s,
+        "mock engine starting: port=%d model=%s hang_after=%d ok_latency=%.2fs stall=%.0fs delay_first_content=%.2fs",
+        args.port, args.model, args.hang_after, args.ok_latency_s, args.stall_s, args.delay_first_content_s,
     )
     web.run_app(make_app(state), host="127.0.0.1", port=args.port, print=None)
 

--- a/benchmarks/scripts/test_real_ttft.py
+++ b/benchmarks/scripts/test_real_ttft.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Discriminator test for the real-TTFT fix in benchmark_multi_model.py.
+
+The bug (caveat C2 in results/CORRECTIONS.md): the bench harness was timing
+TTFT to the first SSE `data: ...` line, not to the first chunk that actually
+contained non-empty `choices[0].text`. Over localhost the gap is ~5 ms; over
+network it is the round-trip latency. Reported TTFTs were therefore SSE
+first-frame RTTs, not the metric a paper or LP screenshot should use.
+
+This test:
+    1. Spawns mock_engine.py with --delay-first-content-s 0.5, which emits
+       an empty-text SSE preamble immediately, then sleeps 500 ms before the
+       first real-content chunk.
+    2. Drives the actual MultiModelBenchmarkClient._send_request code path.
+    3. Asserts TTFT > 400 ms.
+
+If the bug returns (someone moves the first_token_time assignment back above
+the non-empty-text check), this test reports ~5-50 ms and fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import aiohttp
+
+HERE = Path(__file__).parent
+sys.path.insert(0, str(HERE))
+
+from benchmark_multi_model import MultiModelBenchmarkClient  # noqa: E402
+
+
+def free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+async def wait_ready(url: str, timeout_s: float = 10.0) -> None:
+    end = time.time() + timeout_s
+    async with aiohttp.ClientSession() as s:
+        while time.time() < end:
+            try:
+                async with s.get(url, timeout=aiohttp.ClientTimeout(total=1)) as r:
+                    if r.status == 200:
+                        return
+            except Exception:
+                pass
+            await asyncio.sleep(0.1)
+    raise RuntimeError(f"mock not ready at {url} after {timeout_s}s")
+
+
+async def measure_ttft(base_url: str, model: str) -> float:
+    client = MultiModelBenchmarkClient(
+        base_url=base_url, concurrency=1, timeout_s=30, max_tokens=8
+    )
+    sem = asyncio.Semaphore(1)
+    async with aiohttp.ClientSession() as session:
+        m = await client._send_request(session, 0, model, "hello", 8, sem)
+    if m.error:
+        raise RuntimeError(f"bench request error: {m.error}")
+    return m.ttft_ms
+
+
+async def main() -> int:
+    port = free_port()
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            str(HERE / "mock_engine.py"),
+            "--port", str(port),
+            "--model", "discriminator-model",
+            "--ok-latency-s", "0.05",
+            "--delay-first-content-s", "0.5",
+            "--log-level", "WARNING",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        base_url = f"http://127.0.0.1:{port}"
+        await wait_ready(f"{base_url}/v1/models", timeout_s=10.0)
+        ttft_ms = await measure_ttft(base_url, "discriminator-model")
+        print(f"discriminator ttft_ms = {ttft_ms:.1f}")
+        if ttft_ms <= 400.0:
+            print(
+                f"FAIL: REAL-TTFT REGRESSION. ttft_ms={ttft_ms:.1f} but mock "
+                "delays first non-empty content by 500 ms. The harness is "
+                "timing the empty SSE preamble as the first token (caveat C2)."
+            )
+            return 1
+        print("OK: real-TTFT discriminator passed (>400ms with 500ms delay)")
+        return 0
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/results/CORRECTIONS.md
+++ b/results/CORRECTIONS.md
@@ -54,6 +54,15 @@ These will be re-measured properly in Gate 1 with a corrected harness path
 that times from request submit to first non-zero-token in the streamed
 content (not first SSE frame).
 
+**Status (2026-04-19, PR #28):** harness fix landed.
+`benchmark_multi_model.py` now sets `first_token_time` only when
+`choices[0].text` is non-empty, and `benchmarks/scripts/test_real_ttft.py`
+is a discriminator that fails-loud if anyone moves the assignment back. On
+the local mock-engine reproducer (`--delay-first-content-s 0.5`) the broken
+code reported TTFT = 52.5 ms; the fixed code reports 553.9 ms. Numbers in
+`switch_latency.json` and `gate06_20260419/` predate this fix and are still
+under-counted by ~30 ms (network RTT). Gate 1 onward will be honest TTFT.
+
 ---
 
 ## C3 — Router `avg_latency_s: 0.0102` excludes streaming tail


### PR DESCRIPTION
## Summary
- Bench harness was timing TTFT to first `data: ` line (SSE first-frame RTT, ~30 ms over localhost), not to first non-empty `choices[0].text`. Caveat C2 in `results/CORRECTIONS.md`.
- One-block fix in `benchmarks/scripts/benchmark_multi_model.py`: assign `first_token_time` only when content is non-empty.
- Wrapped in a discriminator test (`benchmarks/scripts/test_real_ttft.py`) that fails if anyone moves the assignment back.
- `mock_engine.py` grows `--delay-first-content-s` for the discriminator: emits an empty-text SSE preamble immediately, then sleeps before the first real chunk.

## Local results
| Code | TTFT | Notes |
|---|---:|---|
| Pre-fix harness | 52.5 ms | Times the empty preamble. C2 bug. |
| Post-fix harness | 553.9 ms | 500 ms mock delay + ~50 ms ok-latency. |

500 ms gap = order-of-magnitude discrimination. The test asserts TTFT > 400 ms.

## Why this matters now
Gate 1 reports TTFT p99. Without this fix, those numbers continue to be SSE first-frame RTTs, which is exactly the kind of subtly-wrong number that gets cited in a preprint or screenshot and then has to be retracted. Fixing now, before Gate 1, means Gate 1's TTFT numbers are usable as-is.

`CORRECTIONS.md` C2 is updated to mark the harness fix landed and to flag that pre-PR-#28 numbers (`switch_latency.json`, `gate06_20260419/`) are still under-counted by ~30 ms.

## Test plan
- [x] `python3 benchmarks/scripts/test_real_ttft.py` reports `OK: real-TTFT discriminator passed` with the fix applied.
- [x] Manually stashing the bench fix and re-running the discriminator reports `FAIL: REAL-TTFT REGRESSION` (52.5 ms < 400 ms).
- [ ] Gate 1 run against H100 SXM5 reports honest TTFT numbers (next).