### PR TITLE
fix(router): hold admission slot for full streaming lifetime

### DIFF
--- a/benchmarks/scripts/smoke_bench.sh
+++ b/benchmarks/scripts/smoke_bench.sh
@@ -33,6 +33,7 @@ rm -f "$LOGDIR"/*.log "$LOGDIR"/tmp_config.yaml 2>/dev/null
 
 cleanup() {
     echo "--- cleanup ---"
+    [ -n "${POLLER_PID:-}" ] && kill "$POLLER_PID" 2>/dev/null || true
     pkill -f "mock_engine.py --port 8002" 2>/dev/null || true
     pkill -f "mock_engine.py --port 8003" 2>/dev/null || true
     pkill -f "infergrid.cli serve.*tmp_config" 2>/dev/null || true
@@ -97,6 +98,27 @@ done
 
 # ---- 4. Sweep c=1,8,32 ----
 echo "--- sweep c=1,8,32 num=$NUM_REQUESTS ---"
+
+# Background poller: every 50 ms, sample admission gauges. Drops a CSV row
+# per sample so peak in_flight + peak queue_depth survive the bench wall clock.
+# Gauges go back to 0 between phases, so a final snapshot would lie about
+# whether admission actually engaged. The poller is the only honest signal.
+ADM_CSV="$LOGDIR/admission_trace.csv"
+echo "ts,in_flight,queue_depth,admitted_total,rejected_total" > "$ADM_CSV"
+(
+  while true; do
+    M=$(curl -sf http://localhost:8000/metrics 2>/dev/null) || M=""
+    IF=$(printf '%s\n' "$M" | awk '/^infergrid_admission_in_flight /{print $2; exit}')
+    QD=$(printf '%s\n' "$M" | awk '/^infergrid_admission_queue_depth /{print $2; exit}')
+    AT=$(printf '%s\n' "$M" | awk '/^infergrid_admission_admitted_total /{print $2; exit}')
+    RT=$(printf '%s\n' "$M" | awk '/^infergrid_admission_rejected_total\{/{sum+=$2} END{print sum+0}')
+    printf "%s,%s,%s,%s,%s\n" "$(date +%s.%N)" "${IF:-0}" "${QD:-0}" "${AT:-0}" "${RT:-0}" >> "$ADM_CSV"
+    sleep 0.05
+  done
+) > "$LOGDIR/poller.log" 2>&1 &
+POLLER_PID=$!
+echo "  poller pid=$POLLER_PID sampling /metrics every 50 ms"
+
 START=$(date +%s)
 python3 benchmarks/scripts/benchmark_multi_model.py \
     --url http://localhost:8000 \
@@ -109,8 +131,17 @@ BENCH_RC=$?
 END=$(date +%s)
 ELAPSED=$((END - START))
 
+# Stop the poller
+kill "$POLLER_PID" 2>/dev/null || true
+
 # Final metrics snapshot for admission verification
 curl -sf http://localhost:8000/metrics > "$LOGDIR/metrics_final.txt" 2>/dev/null || true
+
+# Compute peak admission in_flight + queue_depth from poller trace.
+# Float-aware so a fractional gauge doesn't break the int parse.
+PEAK_IF=$(awk -F, 'NR>1 && $2+0>peak{peak=$2+0} END{printf "%.0f", peak+0}' "$ADM_CSV" 2>/dev/null || echo 0)
+PEAK_QD=$(awk -F, 'NR>1 && $3+0>peak{peak=$3+0} END{printf "%.0f", peak+0}' "$ADM_CSV" 2>/dev/null || echo 0)
+SAMPLES=$(($(wc -l < "$ADM_CSV") - 1))
 
 # ---- 5. Asserts ----
 echo "═══════════════════════════════════════════════════════"
@@ -134,19 +165,27 @@ fi
 echo "    throughput lines (all non-zero): $TPUT_NONZERO/$TPUT_LINES"
 echo "    throughput > 0:   $([ $THROUGHPUT_OK -eq 1 ] && echo PASS || echo CHECK)"
 
-# Admission engaged at c=32 (in_flight gauge should have hit max_concurrent)
+# Admission engaged at c=32 (in_flight gauge should have hit MAX_CONCURRENT
+# during the c=32 phase). With MAX_CONCURRENT=16 and c=32 over a streaming
+# bench, healthy admission shows peak in_flight close to 16 and queue_depth
+# briefly > 0 between request waves.
+ADM_FLOOR=$((MAX_CONCURRENT * 3 / 4))   # 75% of cap counts as engaged
 ADM_OK=0
-if grep -qE "infergrid_admission_in_flight" "$LOGDIR/metrics_final.txt" 2>/dev/null; then
+if [ "$PEAK_IF" -ge "$ADM_FLOOR" ]; then
     ADM_OK=1
 fi
-echo "    admission metrics present: $([ $ADM_OK -eq 1 ] && echo PASS || echo CHECK)"
+echo "    admission samples: $SAMPLES"
+echo "    admission peak in_flight:    $PEAK_IF (need >= $ADM_FLOOR / cap=$MAX_CONCURRENT)"
+echo "    admission peak queue_depth:  $PEAK_QD"
+echo "    admission engaged: $([ $ADM_OK -eq 1 ] && echo PASS || echo FAIL)"
 
 echo ""
 echo "  Logs: $LOGDIR/"
+echo "  Trace: $ADM_CSV"
 echo ""
 
 # Overall exit
-if [ $BENCH_RC -eq 0 ] && [ $ELAPSED -le 120 ] && [ $THROUGHPUT_OK -eq 1 ]; then
+if [ $BENCH_RC -eq 0 ] && [ $ELAPSED -le 120 ] && [ $THROUGHPUT_OK -eq 1 ] && [ $ADM_OK -eq 1 ]; then
     echo "OVERALL: PASS"
     exit 0
 else

--- a/src/infergrid/router/router.py
+++ b/src/infergrid/router/router.py
@@ -399,6 +399,10 @@ class WorkloadRouter:
                 in_flight=self.admission_controller.in_flight,
             )
 
+        # If we leave this scope without handing the slot to the streaming
+        # wrapper below, release it ourselves. The wrapper sets `released=True`
+        # so we only release once.
+        released = False
         try:
             # Ensure model is loaded
             state = await self.ensure_model_loaded(model_id)
@@ -431,6 +435,27 @@ class WorkloadRouter:
                 tenant_id, tokens_in=tokens_in, tokens_out=tokens_out,
                 gpu_seconds=elapsed,
             )
+
+            # For streaming, `result` is an async generator that has NOT yet
+            # been consumed. If we release admission here in `finally`, the
+            # slot frees microseconds after acquire() — the engine is still
+            # generating tokens but admission already counts the slot as free.
+            # That is exactly the streaming-bypass bug confirmed by the
+            # smoke_bench poller (peak in_flight=0 with cap=16).
+            #
+            # Fix: hand the slot to a wrapper generator whose own `finally`
+            # releases when the iterator exhausts, raises, or is GC'd by the
+            # caller. Caveat: a client that abandons mid-stream keeps the slot
+            # held until the wrapper is collected. Acceptable trade-off for the
+            # honest engagement we need at Gate 1; revisit with a hard
+            # per-request keepalive timeout once we have real-traffic data.
+            if stream and hasattr(result, "__aiter__"):
+                wrapped = self._stream_with_admission(
+                    result, tenant_id=tenant_id,
+                )
+                released = True  # ownership transferred to wrapper
+                return wrapped
+
             return result
 
         except BudgetExceededError:
@@ -442,6 +467,25 @@ class WorkloadRouter:
                 status="error", latency_s=elapsed,
             )
             raise
+        finally:
+            if not released:
+                self.admission_controller.release()
+                await self.tenant_manager.release_for_tenant(tenant_id)
+
+    async def _stream_with_admission(
+        self,
+        inner: Any,
+        tenant_id: str,
+    ) -> Any:
+        """Stream inner iterator while holding the admission slot.
+
+        Releases the admission slot and tenant slot in `finally` so cancellation,
+        client disconnect (aiohttp closes the response), and normal completion
+        all converge on a single release path.
+        """
+        try:
+            async for chunk in inner:
+                yield chunk
         finally:
             self.admission_controller.release()
             await self.tenant_manager.release_for_tenant(tenant_id)

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -6,6 +6,7 @@ and request length classification.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock
 
@@ -232,3 +233,115 @@ class TestEvictionOrdering:
         assert evicted is not None
         assert evicted in ["model-0", "model-1", "model-2"]
         assert evicted not in router._models
+
+
+# ---------------------------------------------------------------------------
+# Streaming admission control
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingAdmission:
+    """Regression: admission slot must be held for the full streaming lifetime.
+
+    Pre-fix bug: route_request awaits forward_request (which returns the
+    async-generator object immediately for stream=True), then its outer finally
+    fires admission_controller.release() — so the slot is freed in microseconds
+    while the engine is still generating tokens. The smoke_bench poller showed
+    peak in_flight = 0 with cap = 16 over 149 samples. That makes admission
+    cap a no-op for streaming traffic.
+
+    Fix: route_request hands the slot to a wrapper async generator whose own
+    finally releases. These tests pin that contract.
+    """
+
+    def _make_router_with_slow_stream(
+        self, *, max_concurrent: int, chunk_count: int = 5, chunk_delay_s: float = 0.05,
+    ) -> WorkloadRouter:
+        cfg = InferGridConfig(
+            port=9999,
+            max_concurrent=max_concurrent,
+            models=[ModelConfig(model_id="m", engine="vllm")],
+        )
+        router = WorkloadRouter(config=cfg)
+
+        async def fake_stream():
+            for i in range(chunk_count):
+                await asyncio.sleep(chunk_delay_s)
+                yield f"data: chunk{i}\n\n".encode()
+
+        adapter = MagicMock()
+        adapter.is_healthy = True
+        # forward_request is `await`ed; AsyncMock with side_effect returning the
+        # async-gen object mirrors the real adapter contract.
+        adapter.forward_request = AsyncMock(side_effect=lambda *a, **kw: fake_stream())
+        state = ModelState(config=ModelConfig(model_id="m"), adapter=adapter)
+        router._models["m"] = state
+        return router
+
+    async def test_in_flight_is_held_during_stream(self) -> None:
+        router = self._make_router_with_slow_stream(max_concurrent=4)
+
+        # Start one stream and begin iterating
+        result = await router.route_request(
+            model_id="m", path="/v1/completions",
+            payload={"stream": True, "max_tokens": 32}, stream=True,
+        )
+        agen = result.__aiter__()
+        first = await agen.__anext__()
+        assert first.startswith(b"data: ")
+
+        # Mid-stream: slot must still be held
+        assert router.admission_controller.in_flight == 1, (
+            "admission slot was released before stream finished — streaming "
+            "bypass regression"
+        )
+
+        # Drain
+        async for _ in agen:
+            pass
+
+        # Done: slot released
+        assert router.admission_controller.in_flight == 0
+
+    async def test_streaming_respects_concurrency_cap(self) -> None:
+        # cap=2, 3 concurrent streams → one must queue
+        router = self._make_router_with_slow_stream(max_concurrent=2, chunk_count=3, chunk_delay_s=0.04)
+
+        async def consume():
+            r = await router.route_request(
+                model_id="m", path="/v1/completions",
+                payload={"stream": True, "max_tokens": 32}, stream=True,
+            )
+            async for _ in r:
+                pass
+
+        tasks = [asyncio.create_task(consume()) for _ in range(3)]
+        # Let the first wave grab slots
+        await asyncio.sleep(0.02)
+
+        adm = router.admission_controller
+        assert adm.in_flight == 2, f"expected in_flight=2, got {adm.in_flight}"
+        assert adm.queue_depth == 1, f"expected queue_depth=1, got {adm.queue_depth}"
+
+        await asyncio.gather(*tasks)
+        assert adm.in_flight == 0
+        assert adm.queue_depth == 0
+
+    async def test_slot_released_when_consumer_aborts_midstream(self) -> None:
+        router = self._make_router_with_slow_stream(
+            max_concurrent=2, chunk_count=20, chunk_delay_s=0.05,
+        )
+
+        result = await router.route_request(
+            model_id="m", path="/v1/completions",
+            payload={"stream": True, "max_tokens": 256}, stream=True,
+        )
+        agen = result.__aiter__()
+        await agen.__anext__()
+        assert router.admission_controller.in_flight == 1
+
+        # Consumer abandons. aclose() runs the wrapper's finally, releasing
+        # the slot. (A truly-leaked iterator would only release on GC; aclose
+        # is the well-behaved path and is what aiohttp does on disconnect.)
+        await agen.aclose()
+        assert router.admission_controller.in_flight == 0


### PR DESCRIPTION
## Summary
Streaming requests bypassed admission control entirely. `route_request` awaited `forward_request`, which returned the async-generator immediately for `stream=True`, then released the slot in `finally` — microseconds after acquire. Empirical smoke (149 samples) showed peak `in_flight=0` with `cap=16`. Gate 1's hypothesis is unmeasurable without this fix.

## Why it matters now
Gate 1 plans to compare Arm A (`cap=128`) vs Arm B (`cap=1024`) at c=256. Pre-fix, both arms admit all 256 reqs simultaneously to the engine — measuring engine-level contention, not admission. The H100 spend would buy us no signal.

## Changes
- `src/infergrid/router/router.py` — `route_request` returns an async-generator wrapper for `stream=True` whose own `finally` releases admission + tenant slots. Outer `finally` skips release when ownership transferred (tracked by `released` flag).
- `benchmarks/scripts/smoke_bench.sh` — background poller samples `/metrics` every 50 ms during the bench, tracks peak `in_flight` and peak `queue_depth`. Pass criterion: peak `in_flight >= 75%` of `MAX_CONCURRENT`.
- `tests/unit/test_router.py` — `TestStreamingAdmission` (3 tests): in_flight held during stream; cap respected; slot released on abort. All 3 fail pre-fix, pass post-fix.

## Empirical confirmation
| Run | Peak in_flight | Peak queue_depth | Result |
|---|---:|---:|---|
| Pre-fix | 0 | 0 | FAIL |
| Post-fix | 16 | 16 | PASS |

149 / 155 poller samples respectively, MAX_CONCURRENT=16, c=32 streaming workload over 2 mock engines.

## Caveat
A client that abandons mid-stream without calling `aclose()` (or having aiohttp call it on disconnect) keeps the slot held until the wrapper is GC'd. Acceptable trade-off for the honest engagement we need at Gate 1; bound it with a per-request keepalive timeout once we have real-traffic data.

## Test plan
- [x] `python3 -m pytest tests/unit/` — 124 passed.
- [x] `bash benchmarks/scripts/smoke_bench.sh` — OVERALL: PASS, peak in_flight=16, peak queue_depth=16.
- [x] Stash router fix; `pytest tests/unit/test_router.py::TestStreamingAdmission` — 3 fail (in_flight==0). Discriminator works.
- [ ] Gate 1: verify Arm A TTFT p99 stays flat from c=128 → c=256 while Arm B explodes (the actual hypothesis is now testable).