### PR TITLE
fix(router): aclose inner generator in streaming wrapper finally

### DIFF
--- a/src/infergrid/router/router.py
+++ b/src/infergrid/router/router.py
@@ -481,12 +481,21 @@ class WorkloadRouter:
 
         Releases the admission slot and tenant slot in `finally` so cancellation,
         client disconnect (aiohttp closes the response), and normal completion
-        all converge on a single release path.
+        all converge on a single release path. Also `aclose()`s the inner
+        engine generator so its underlying aiohttp `session.post()` context
+        unwinds eagerly — without this, an aborted client leaves the engine
+        connection open and the engine keeps generating tokens until the
+        inner generator is GC'd.
         """
         try:
             async for chunk in inner:
                 yield chunk
         finally:
+            if hasattr(inner, "aclose"):
+                try:
+                    await inner.aclose()
+                except Exception:
+                    pass
             self.admission_controller.release()
             await self.tenant_manager.release_for_tenant(tenant_id)
 


### PR DESCRIPTION
## Summary
PR #29 followup. The streaming wrapper's `finally` released admission + tenant slots but did not `aclose()` the inner engine generator. Without that, the engine-side `async with session.post(...)` stays suspended until GC, so the engine keeps generating tokens for a client that already disconnected.

## Fix
One block in `_stream_with_admission` finally — `if hasattr(inner, 'aclose'): try: await inner.aclose() except: pass`. Best-effort because the inner gen may already have errored.

## Side benefit
Silences the "coroutine method 'aclose' ... was never awaited" warning that was showing up in `test_slot_released_when_consumer_aborts_midstream`.

## Test plan
- [x] `pytest tests/unit/test_router.py::TestStreamingAdmission` — 3 passed, 0 warnings.