### PR TITLE
fix(bench): TTFT v2 — whitespace, delta.content, JSON fallback

### DIFF
--- a/benchmarks/scripts/benchmark_multi_model.py
+++ b/benchmarks/scripts/benchmark_multi_model.py
@@ -533,18 +533,32 @@ class MultiModelBenchmarkClient:
                         try:
                             chunk = json.loads(data_str)
                             choices = chunk.get("choices", [])
-                            if choices and choices[0].get("text", ""):
-                                # C2 fix: TTFT is time-to-first-non-empty-content,
-                                # not time-to-first-SSE-frame (which is just the
-                                # network RTT to the server). Empty/role-only
-                                # frames do not count as a token.
+                            if not choices:
+                                continue
+                            # Support /v1/completions (`text` field) AND
+                            # /v1/chat/completions (`delta.content` field). On
+                            # chat-template engines `text` is always missing,
+                            # so without the delta fallback TTFT silently
+                            # collapses to total_latency_ms.
+                            content = (
+                                choices[0].get("text")
+                                or choices[0].get("delta", {}).get("content")
+                                or ""
+                            )
+                            # C2 fix: TTFT is time-to-first-non-empty-content.
+                            # `.strip()` rejects whitespace-only or role-only
+                            # frames that vLLM/SGLang emit before real tokens —
+                            # bool("\n") is True, which would re-introduce the
+                            # very bug PR #28 set out to kill.
+                            if content.strip():
                                 if first_token_time is None:
                                     first_token_time = time.time()
                                 tokens_out += 1
                         except (json.JSONDecodeError, KeyError):
-                            if first_token_time is None:
-                                first_token_time = time.time()
-                            tokens_out += 1
+                            # Malformed SSE chunk — do NOT count as a token
+                            # and do NOT stamp TTFT (a parse error is not
+                            # generation progress).
+                            continue
 
             except asyncio.TimeoutError:
                 logger.warning("req=%d MODEL=%s TIMEOUT after %.0fs",

--- a/benchmarks/scripts/mock_engine.py
+++ b/benchmarks/scripts/mock_engine.py
@@ -39,12 +39,16 @@ class MockEngineState:
         ok_latency: float,
         stall_s: float,
         delay_first_content_s: float = 0.0,
+        first_chunk_whitespace: int = 0,
+        chat_completions_shape: bool = False,
     ):
         self.model = model
         self.hang_after = hang_after
         self.ok_latency = ok_latency
         self.stall_s = stall_s
         self.delay_first_content_s = delay_first_content_s
+        self.first_chunk_whitespace = first_chunk_whitespace
+        self.chat_completions_shape = chat_completions_shape
         self.request_count = 0
         self.stalled_count = 0
 
@@ -122,31 +126,47 @@ async def handle_completions(request: web.Request) -> web.StreamResponse:
     )
     await resp.prepare(request)
 
-    # Discriminator for real-TTFT: emit an empty-text frame immediately so a
-    # broken harness that times the first SSE frame sees a near-zero TTFT,
-    # then sleep before the first real-content chunk. A correct harness times
-    # the first non-empty `choices[0].text` and reports ~delay_first_content_s.
-    if state.delay_first_content_s > 0:
-        preamble = {
+    def _make_chunk(text_value: str | None, finish: str | None = None) -> dict[str, Any]:
+        # Chat-completions shape uses `delta.content`; classic completions
+        # uses `text`. Real engines pick based on endpoint; we let the test
+        # override so the harness can be exercised against both shapes.
+        if state.chat_completions_shape:
+            choice: dict[str, Any] = {
+                "index": 0,
+                "delta": {"content": text_value} if text_value is not None else {"role": "assistant"},
+                "finish_reason": finish,
+            }
+            obj = "chat.completion.chunk"
+        else:
+            choice = {"index": 0, "text": text_value if text_value is not None else "", "finish_reason": finish}
+            obj = "text_completion.chunk"
+        return {
             "id": f"mock-{rid}",
-            "object": "text_completion.chunk",
+            "object": obj,
             "created": int(time.time()),
             "model": state.model,
-            "choices": [{"index": 0, "text": "", "finish_reason": None}],
+            "choices": [choice],
         }
-        await resp.write(f"data: {json.dumps(preamble)}\n\n".encode())
+
+    # Discriminator for real-TTFT v2:
+    #   --first-chunk-whitespace N: emit N whitespace-only frames before
+    #     content. A broken `bool(text)` check counts whitespace as a token
+    #     and stamps TTFT early; the v2 fix uses `text.strip()` and is honest.
+    #   --delay-first-content-s D: emit one empty/role-only frame, sleep D,
+    #     then real content. A broken harness that times the first SSE frame
+    #     reports D≈0; the v2 fix reports ~D.
+    if state.first_chunk_whitespace > 0:
+        for _ in range(state.first_chunk_whitespace):
+            await resp.write(f"data: {json.dumps(_make_chunk(' '))}\n\n".encode())
+        if state.delay_first_content_s > 0:
+            await asyncio.sleep(state.delay_first_content_s)
+    elif state.delay_first_content_s > 0:
+        # Empty-text (or role-only delta) preamble.
+        await resp.write(f"data: {json.dumps(_make_chunk(None))}\n\n".encode())
         await asyncio.sleep(state.delay_first_content_s)
 
     for tok_i in range(max(1, max_tokens)):
-        chunk = {
-            "id": f"mock-{rid}",
-            "object": "text_completion.chunk",
-            "created": int(time.time()),
-            "model": state.model,
-            "choices": [{"index": 0, "text": f"t{tok_i} ", "finish_reason": None}],
-        }
-        await resp.write(f"data: {json.dumps(chunk)}\n\n".encode())
-        # Small inter-token delay to look like generation
+        await resp.write(f"data: {json.dumps(_make_chunk(f't{tok_i} '))}\n\n".encode())
         await asyncio.sleep(max(0.001, state.ok_latency / max(1, max_tokens)))
     await resp.write(b"data: [DONE]\n\n")
     await resp.write_eof()
@@ -191,6 +211,18 @@ def main() -> None:
         default=float(os.environ.get("MOCK_DELAY_FIRST_CONTENT", "0")),
         help="On streaming responses, emit an empty-text SSE frame, then sleep this long before the first real-content chunk (real-TTFT discriminator)",
     )
+    p.add_argument(
+        "--first-chunk-whitespace",
+        type=int,
+        default=int(os.environ.get("MOCK_FIRST_CHUNK_WHITESPACE", "0")),
+        help="Emit N whitespace-only SSE frames before any real content (TTFT v2 discriminator: ensures `text.strip()` is checked, not bool(text))",
+    )
+    p.add_argument(
+        "--chat-completions-shape",
+        action="store_true",
+        default=os.environ.get("MOCK_CHAT_SHAPE", "0") not in ("", "0"),
+        help="Emit chat.completion.chunk shape (delta.content) instead of text_completion.chunk (text). Tests harness chat-template path.",
+    )
     p.add_argument("--log-level", default="INFO")
     args = p.parse_args()
 
@@ -205,10 +237,12 @@ def main() -> None:
         ok_latency=args.ok_latency_s,
         stall_s=args.stall_s,
         delay_first_content_s=args.delay_first_content_s,
+        first_chunk_whitespace=args.first_chunk_whitespace,
+        chat_completions_shape=args.chat_completions_shape,
     )
     logger.info(
-        "mock engine starting: port=%d model=%s hang_after=%d ok_latency=%.2fs stall=%.0fs delay_first_content=%.2fs",
-        args.port, args.model, args.hang_after, args.ok_latency_s, args.stall_s, args.delay_first_content_s,
+        "mock engine starting: port=%d model=%s hang_after=%d ok_latency=%.2fs stall=%.0fs delay_first_content=%.2fs first_chunk_ws=%d chat_shape=%s",
+        args.port, args.model, args.hang_after, args.ok_latency_s, args.stall_s, args.delay_first_content_s, args.first_chunk_whitespace, args.chat_completions_shape,
     )
     web.run_app(make_app(state), host="127.0.0.1", port=args.port, print=None)
 

--- a/benchmarks/scripts/smoke_bench.sh
+++ b/benchmarks/scripts/smoke_bench.sh
@@ -99,10 +99,12 @@ done
 # ---- 4. Sweep c=1,8,32 ----
 echo "--- sweep c=1,8,32 num=$NUM_REQUESTS ---"
 
-# Background poller: every 50 ms, sample admission gauges. Drops a CSV row
+# Background poller: every 10 ms, sample admission gauges. Drops a CSV row
 # per sample so peak in_flight + peak queue_depth survive the bench wall clock.
 # Gauges go back to 0 between phases, so a final snapshot would lie about
 # whether admission actually engaged. The poller is the only honest signal.
+# 10 ms cadence chosen so we don't alias with mock chunk delay (~6-50 ms);
+# Nyquist on a 50 ms signal needs <25 ms sampling to be honest.
 ADM_CSV="$LOGDIR/admission_trace.csv"
 echo "ts,in_flight,queue_depth,admitted_total,rejected_total" > "$ADM_CSV"
 (
@@ -113,11 +115,11 @@ echo "ts,in_flight,queue_depth,admitted_total,rejected_total" > "$ADM_CSV"
     AT=$(printf '%s\n' "$M" | awk '/^infergrid_admission_admitted_total /{print $2; exit}')
     RT=$(printf '%s\n' "$M" | awk '/^infergrid_admission_rejected_total\{/{sum+=$2} END{print sum+0}')
     printf "%s,%s,%s,%s,%s\n" "$(date +%s.%N)" "${IF:-0}" "${QD:-0}" "${AT:-0}" "${RT:-0}" >> "$ADM_CSV"
-    sleep 0.05
+    sleep 0.01
   done
 ) > "$LOGDIR/poller.log" 2>&1 &
 POLLER_PID=$!
-echo "  poller pid=$POLLER_PID sampling /metrics every 50 ms"
+echo "  poller pid=$POLLER_PID sampling /metrics every 10 ms"
 
 START=$(date +%s)
 python3 benchmarks/scripts/benchmark_multi_model.py \

--- a/benchmarks/scripts/test_real_ttft.py
+++ b/benchmarks/scripts/test_real_ttft.py
@@ -1,21 +1,19 @@
 #!/usr/bin/env python3
-"""Discriminator test for the real-TTFT fix in benchmark_multi_model.py.
+"""Discriminator tests for the real-TTFT fix in benchmark_multi_model.py.
 
-The bug (caveat C2 in results/CORRECTIONS.md): the bench harness was timing
-TTFT to the first SSE `data: ...` line, not to the first chunk that actually
-contained non-empty `choices[0].text`. Over localhost the gap is ~5 ms; over
-network it is the round-trip latency. Reported TTFTs were therefore SSE
-first-frame RTTs, not the metric a paper or LP screenshot should use.
+Caveat C2 from `results/CORRECTIONS.md`. The bench used to time TTFT to the
+first SSE `data: ...` line, regardless of whether that frame contained any
+real content. v1 of the fix (PR #28) moved the timestamp inside the
+`if choices[0].text != ""` branch. v2 (PR #31) tightened it further:
 
-This test:
-    1. Spawns mock_engine.py with --delay-first-content-s 0.5, which emits
-       an empty-text SSE preamble immediately, then sleeps 500 ms before the
-       first real-content chunk.
-    2. Drives the actual MultiModelBenchmarkClient._send_request code path.
-    3. Asserts TTFT > 400 ms.
+- whitespace-only frames must NOT count as the first token (`bool("\n")` is
+  truthy in Python, so v1 still under-counted)
+- chat-completions chunks (`delta.content`) must be honored (v1 only looked
+  at `text`, so chat-template engines silently reported TTFT == 0)
+- malformed SSE chunks (`json.JSONDecodeError`) must NOT count as a token
 
-If the bug returns (someone moves the first_token_time assignment back above
-the non-empty-text check), this test reports ~5-50 ms and fails.
+Each test spawns a mock engine variant and drives the actual
+`MultiModelBenchmarkClient._send_request` code path.
 """
 
 from __future__ import annotations
@@ -33,6 +31,8 @@ HERE = Path(__file__).parent
 sys.path.insert(0, str(HERE))
 
 from benchmark_multi_model import MultiModelBenchmarkClient  # noqa: E402
+
+DELAY_S = 0.5
 
 
 def free_port() -> int:
@@ -57,53 +57,110 @@ async def wait_ready(url: str, timeout_s: float = 10.0) -> None:
     raise RuntimeError(f"mock not ready at {url} after {timeout_s}s")
 
 
-async def measure_ttft(base_url: str, model: str) -> float:
-    client = MultiModelBenchmarkClient(
-        base_url=base_url, concurrency=1, timeout_s=30, max_tokens=8
-    )
-    sem = asyncio.Semaphore(1)
-    async with aiohttp.ClientSession() as session:
-        m = await client._send_request(session, 0, model, "hello", 8, sem)
-    if m.error:
-        raise RuntimeError(f"bench request error: {m.error}")
-    return m.ttft_ms
-
-
-async def main() -> int:
-    port = free_port()
-    proc = subprocess.Popen(
+def spawn_mock(*, port: int, model: str, ok_latency_s: float, extra_args: list[str]) -> subprocess.Popen:
+    return subprocess.Popen(
         [
             sys.executable,
             str(HERE / "mock_engine.py"),
             "--port", str(port),
-            "--model", "discriminator-model",
-            "--ok-latency-s", "0.05",
-            "--delay-first-content-s", "0.5",
+            "--model", model,
+            "--ok-latency-s", str(ok_latency_s),
             "--log-level", "WARNING",
+            *extra_args,
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
+
+
+async def run_case(
+    name: str, mock_args: list[str], ok_latency_s: float, max_tokens: int,
+) -> tuple[float, int]:
+    """Returns (ttft_ms, tokens_out) from a single bench request to a mock."""
+    port = free_port()
+    proc = spawn_mock(
+        port=port, model=name, ok_latency_s=ok_latency_s, extra_args=mock_args,
+    )
     try:
         base_url = f"http://127.0.0.1:{port}"
         await wait_ready(f"{base_url}/v1/models", timeout_s=10.0)
-        ttft_ms = await measure_ttft(base_url, "discriminator-model")
-        print(f"discriminator ttft_ms = {ttft_ms:.1f}")
-        if ttft_ms <= 400.0:
-            print(
-                f"FAIL: REAL-TTFT REGRESSION. ttft_ms={ttft_ms:.1f} but mock "
-                "delays first non-empty content by 500 ms. The harness is "
-                "timing the empty SSE preamble as the first token (caveat C2)."
-            )
-            return 1
-        print("OK: real-TTFT discriminator passed (>400ms with 500ms delay)")
-        return 0
+        client = MultiModelBenchmarkClient(
+            base_url=base_url, concurrency=1, timeout_s=30, max_tokens=max_tokens,
+        )
+        sem = asyncio.Semaphore(1)
+        async with aiohttp.ClientSession() as session:
+            m = await client._send_request(session, 0, name, "hello", max_tokens, sem)
+        if m.error:
+            raise RuntimeError(f"bench request error: {m.error}")
+        return (m.ttft_ms, m.tokens_out)
     finally:
         proc.terminate()
         try:
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             proc.kill()
+
+
+# Per-case checks. Each case picks the metric the bug actually corrupts:
+#
+#   empty-preamble: SSE-first-frame bug stamps TTFT on the empty frame, so
+#     pre-PR-#28 reports ttft≈5ms. Fix reports ttft > 400ms.
+#
+#   whitespace-preamble: same SSE-first-frame timing PLUS bool(" ") truthy
+#     in PR #28's check, so PR #28 still reports ttft≈5ms here. PR #31's
+#     `.strip()` fixes it; reports ttft > 400ms.
+#
+#   chat-shape: vLLM/SGLang chat completions emit `delta.content`, not
+#     `text`. Pre-PR-#31 the `choices[0].get("text", "")` never matches,
+#     so tokens_out stays 0 AND first_token_time stays None (TTFT collapses
+#     to total_latency_ms). Discriminator: tokens_out must equal max_tokens.
+#     We don't gate on TTFT here because aiohttp StreamResponse coalesces
+#     small writes under longer per-chunk sleeps — the tokens_out signal
+#     is unaffected by that buffering.
+async def main() -> int:
+    results: list[tuple[str, str, bool]] = []
+
+    # Case 1 + 2: TTFT discriminators (delay-then-content).
+    timing_cases = [
+        ("empty-preamble", ["--delay-first-content-s", str(DELAY_S)]),
+        ("whitespace-preamble", [
+            "--first-chunk-whitespace", "1",
+            "--delay-first-content-s", str(DELAY_S),
+        ]),
+    ]
+    for name, args in timing_cases:
+        try:
+            ttft, _ = await run_case(name, args, ok_latency_s=0.05, max_tokens=8)
+            passed = ttft > 400.0
+            results.append((name, f"ttft_ms={ttft:.1f} (need > 400)", passed))
+        except Exception as exc:
+            results.append((name, f"ERROR: {exc}", False))
+
+    # Case 3: chat-shape token-count discriminator.
+    try:
+        _, tokens_out = await run_case(
+            "chat-shape",
+            ["--chat-completions-shape"],
+            ok_latency_s=0.05, max_tokens=8,
+        )
+        passed = tokens_out == 8
+        results.append(("chat-shape", f"tokens_out={tokens_out} (need == 8)", passed))
+    except Exception as exc:
+        results.append(("chat-shape", f"ERROR: {exc}", False))
+
+    print("\n=== real-TTFT discriminator results ===")
+    any_failed = False
+    for name, detail, passed in results:
+        status = "PASS" if passed else "FAIL"
+        print(f"  {status}  {name:<22}  {detail}")
+        if not passed:
+            any_failed = True
+
+    if any_failed:
+        print("\nFAIL: at least one TTFT discriminator regressed.")
+        return 1
+    print("\nOK: all real-TTFT discriminators passed.")
+    return 0
 
 
 if __name__ == "__main__":

--- a/results/CORRECTIONS.md
+++ b/results/CORRECTIONS.md
@@ -54,14 +54,30 @@ These will be re-measured properly in Gate 1 with a corrected harness path
 that times from request submit to first non-zero-token in the streamed
 content (not first SSE frame).
 
-**Status (2026-04-19, PR #28):** harness fix landed.
-`benchmark_multi_model.py` now sets `first_token_time` only when
-`choices[0].text` is non-empty, and `benchmarks/scripts/test_real_ttft.py`
-is a discriminator that fails-loud if anyone moves the assignment back. On
-the local mock-engine reproducer (`--delay-first-content-s 0.5`) the broken
-code reported TTFT = 52.5 ms; the fixed code reports 553.9 ms. Numbers in
-`switch_latency.json` and `gate06_20260419/` predate this fix and are still
-under-counted by ~30 ms (network RTT). Gate 1 onward will be honest TTFT.
+**Status (2026-04-19, PR #28 + #31):** harness fix landed in two passes.
+
+**v1 (PR #28):** `benchmark_multi_model.py` now sets `first_token_time` only
+when `choices[0].text` is non-empty.
+
+**v2 (PR #31):** PR #28 was incomplete and shipped two more silent failure
+modes that the v1 discriminator did not catch:
+- `bool(" ")` is truthy in Python, so a whitespace-only first chunk (which
+  vLLM/SGLang both emit during warm-up tokenization) was still counted as
+  the first token. Now uses `text.strip()`.
+- Chat-completions endpoints emit `delta.content`, not `text`. The v1 check
+  always saw `""`, so on chat-template engines TTFT silently collapsed to
+  `total_latency_ms` and `tokens_out` was always 0. Now falls back to
+  `choices[0].get("delta", {}).get("content")`.
+- `JSONDecodeError`/`KeyError` in chunk parse used to *increment* `tokens_out`
+  and stamp `first_token_time`. A parse error is not generation progress;
+  v2 `continues` instead.
+
+`benchmarks/scripts/test_real_ttft.py` now has three discriminator cases
+(empty preamble, whitespace preamble, chat-shape token-count). On broken
+code the new whitespace and chat-shape cases fail loud (52 ms vs need >400,
+tokens_out=0 vs need 8). Numbers in `switch_latency.json` and
+`gate06_20260419/` predate both fixes; under-counted by ~30 ms RTT. Gate 1
+onward will be honest TTFT.
 
 ---
 

--- a/scripts/gate1_dress_rehearsal.sh
+++ b/scripts/gate1_dress_rehearsal.sh
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+# gate1_dress_rehearsal.sh -- LOCAL, NO-GPU dry-run of the Gate 1 experiment.
+#
+# Goal: prove the Gate 1 plumbing (configs, bench harness, /metrics scrape,
+# admission counters, JSON output, discriminator math) works end-to-end BEFORE
+# spending $7-10 on an H100 SXM5 spot pod.
+#
+# What this DOES validate:
+#   - infergrid serve loads BOTH gate1 configs (admission ON / admission OFF)
+#   - benchmark_multi_model.py runs at c=128 and c=256 against a mock backend
+#   - /metrics admission_in_flight gauge engages on Arm A, stays open on Arm B
+#   - per-(arm, concurrency) ttft_p99_ms is parsed cleanly from summary JSON
+#   - the discriminator math runs and prints PASS/FAIL the way Gate 1 will
+#
+# What this does NOT validate:
+#   - real H100 scheduler/KV behavior. The mock backend below is TUNED to
+#     produce a knee at in_flight>128 so the discriminator passes. That makes
+#     this a SCAFFOLDING self-test of the experiment, not a hypothesis test.
+#   - real vLLM warmup, real GPU memory budget, real engine bring-up.
+#
+# Pass criteria (all must hold):
+#   - both configs serve OK in dev-skip mode
+#   - 4 bench runs (2 arms x c=128,256) complete with non-zero throughput
+#   - Arm A peak in_flight gauge clamps near max_concurrent=128
+#   - Arm B peak in_flight gauge exceeds 128 (admission OPEN)
+#   - discriminator: A_p99(c=256) <= 2*A_p99(c=128) AND B_p99(c=256) >= 4*A_p99(c=256)
+#
+# Usage:
+#   bash scripts/gate1_dress_rehearsal.sh
+# Env:
+#   NUM_REQUESTS=400          # per (arm, concurrency) combo
+#   LOGDIR=/tmp/gate1_dress
+#   MOCK_BASE_TTFT_S=0.05     # delay-first-content for in_flight <= knee
+#   MOCK_KNEE=128             # in_flight at which TTFT starts climbing
+#   MOCK_PER_EXCESS_S=0.012   # added per request above the knee
+#   SKIP_DISCRIMINATOR=0      # set 1 to plumbing-only run (no PASS/FAIL on math)
+
+set -u
+
+NUM_REQUESTS=${NUM_REQUESTS:-400}
+LOGDIR=${LOGDIR:-/tmp/gate1_dress}
+MOCK_BASE_TTFT_S=${MOCK_BASE_TTFT_S:-0.05}
+MOCK_KNEE=${MOCK_KNEE:-128}
+MOCK_PER_EXCESS_S=${MOCK_PER_EXCESS_S:-0.012}
+SKIP_DISCRIMINATOR=${SKIP_DISCRIMINATOR:-0}
+
+REPO_ROOT=$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || cd "$(dirname "$0")/.." && pwd)
+cd "$REPO_ROOT"
+
+ARM_A_CFG="$REPO_ROOT/configs/gate1_admission.yaml"
+ARM_B_CFG="$REPO_ROOT/configs/gate1_admission_off.yaml"
+[ -f "$ARM_A_CFG" ] || { echo "FATAL: missing $ARM_A_CFG"; exit 2; }
+[ -f "$ARM_B_CFG" ] || { echo "FATAL: missing $ARM_B_CFG"; exit 2; }
+
+# Read model_id from gate1_admission.yaml so the mock advertises the same id.
+MODEL_ID=$(python3 -c "
+import yaml,sys
+with open('$ARM_A_CFG') as f: c = yaml.safe_load(f)
+print(c['models'][0]['model_id'])
+")
+[ -n "$MODEL_ID" ] || { echo "FATAL: could not parse model_id"; exit 2; }
+
+mkdir -p "$LOGDIR"
+rm -rf "$LOGDIR"/results "$LOGDIR"/*.log "$LOGDIR"/*.csv "$LOGDIR"/*.json 2>/dev/null
+mkdir -p "$LOGDIR/results"
+
+MOCK_PORT=18002   # arbitrary local port for the load-aware mock
+SERVE_PORT=8000
+
+cleanup() {
+  echo "--- cleanup ---"
+  [ -n "${POLLER_PID:-}" ] && kill "$POLLER_PID" 2>/dev/null || true
+  [ -n "${SERVE_PID:-}"  ] && kill "$SERVE_PID"  2>/dev/null || true
+  [ -n "${MOCK_PID:-}"   ] && kill "$MOCK_PID"   2>/dev/null || true
+  pkill -f "infergrid.cli serve.*gate1_" 2>/dev/null || true
+  pkill -f "gate1_dress_mock.py"          2>/dev/null || true
+  sleep 1
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# 1. Emit a load-aware mock engine. Tracks in_flight; TTFT = base + max(0,
+#    in_flight - knee) * per_excess_s. This is the ONLY way the assertion
+#    "B_p99(c=256) >= 4*A_p99(c=256)" can be true with a mock backend, since
+#    on a real H100 the knee comes from KV pressure (not modelable in CPU).
+# ---------------------------------------------------------------------------
+MOCK_PY="$LOGDIR/gate1_dress_mock.py"
+cat > "$MOCK_PY" <<'PYEOF'
+"""Load-aware mock vLLM engine for Gate 1 dress rehearsal.
+
+OpenAI-compatible enough for infergrid's vLLMEngine adapter + the multi-model
+bench harness. Tracks concurrent in-flight requests and adds knee-shaped
+TTFT pressure so admission ON vs OFF produces a measurable difference.
+"""
+from __future__ import annotations
+import argparse, asyncio, json, os, time
+from aiohttp import web
+
+class State:
+    def __init__(self, model, base_s, knee, per_excess_s, tok_latency_s):
+        self.model = model
+        self.base_s = base_s
+        self.knee = knee
+        self.per_excess_s = per_excess_s
+        self.tok_latency_s = tok_latency_s
+        self.in_flight = 0
+        self.peak_in_flight = 0
+
+async def models(request):
+    s = request.app["s"]
+    return web.json_response({"object": "list", "data": [
+        {"id": s.model, "object": "model", "created": int(time.time()), "owned_by": "mock"}
+    ]})
+
+async def health(_):
+    return web.json_response({"status": "ok"})
+
+async def completions(request):
+    s: State = request.app["s"]
+    s.in_flight += 1
+    if s.in_flight > s.peak_in_flight: s.peak_in_flight = s.in_flight
+    try:
+        body = await request.json()
+        prompt = body.get("prompt", "")
+        max_tokens = int(body.get("max_tokens", 32))
+        stream = bool(body.get("stream", False))
+        ttft = s.base_s + max(0, s.in_flight - s.knee) * s.per_excess_s
+
+        if not stream:
+            await asyncio.sleep(ttft + max_tokens * s.tok_latency_s)
+            return web.json_response({
+                "id": "cmpl-mock", "object": "text_completion",
+                "created": int(time.time()), "model": s.model,
+                "choices": [{"index": 0, "text": "x " * max_tokens, "finish_reason": "length"}],
+                "usage": {"prompt_tokens": len(prompt.split()),
+                          "completion_tokens": max_tokens,
+                          "total_tokens": len(prompt.split()) + max_tokens},
+            })
+
+        # Streaming SSE: empty frame, then ttft sleep, then per-token frames.
+        resp = web.StreamResponse(status=200, headers={
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+        })
+        await resp.prepare(request)
+        # Empty-text frame (lets clients start their TTFT clock).
+        await resp.write(b'data: ' + json.dumps({
+            "id": "cmpl-mock", "object": "text_completion.chunk",
+            "created": int(time.time()), "model": s.model,
+            "choices": [{"index": 0, "text": "", "finish_reason": None}],
+        }).encode() + b'\n\n')
+        await asyncio.sleep(ttft)
+        for i in range(max_tokens):
+            await asyncio.sleep(s.tok_latency_s)
+            await resp.write(b'data: ' + json.dumps({
+                "id": "cmpl-mock", "object": "text_completion.chunk",
+                "created": int(time.time()), "model": s.model,
+                "choices": [{"index": 0, "text": "x ", "finish_reason": None}],
+            }).encode() + b'\n\n')
+        await resp.write(b'data: ' + json.dumps({
+            "id": "cmpl-mock", "object": "text_completion.chunk",
+            "created": int(time.time()), "model": s.model,
+            "choices": [{"index": 0, "text": "", "finish_reason": "length"}],
+        }).encode() + b'\n\n')
+        await resp.write(b'data: [DONE]\n\n')
+        await resp.write_eof()
+        return resp
+    finally:
+        s.in_flight -= 1
+
+async def chat(request):
+    body = await request.json()
+    body["prompt"] = " ".join(m.get("content", "") for m in body.get("messages", []))
+    request._read_bytes = json.dumps(body).encode()
+    return await completions(request)
+
+async def stats(request):
+    s = request.app["s"]
+    return web.json_response({"in_flight": s.in_flight, "peak_in_flight": s.peak_in_flight})
+
+def make_app(s):
+    app = web.Application(client_max_size=1024 * 1024 * 16)
+    app["s"] = s
+    app.router.add_get("/v1/models", models)
+    app.router.add_get("/health", health)
+    app.router.add_post("/v1/completions", completions)
+    app.router.add_post("/v1/chat/completions", chat)
+    app.router.add_get("/_mock/stats", stats)
+    return app
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--port", type=int, required=True)
+    p.add_argument("--model", required=True)
+    p.add_argument("--base-ttft-s", type=float, default=0.05)
+    p.add_argument("--knee", type=int, default=128)
+    p.add_argument("--per-excess-s", type=float, default=0.012)
+    p.add_argument("--tok-latency-s", type=float, default=0.010)
+    a = p.parse_args()
+    web.run_app(
+        make_app(State(a.model, a.base_ttft_s, a.knee, a.per_excess_s, a.tok_latency_s)),
+        host="127.0.0.1", port=a.port, print=None,
+    )
+PYEOF
+
+# ---------------------------------------------------------------------------
+# 2. Start the load-aware mock engine ONCE; it serves all 4 bench runs.
+#    infergrid runs in DEV_SKIP_ENGINE_LAUNCH mode; the model client adapter
+#    talks to whatever is on the per-model port. We override the per-model
+#    port via a tmp config (gate1 configs leave port=auto).
+# ---------------------------------------------------------------------------
+echo "--- Phase 1: load-aware mock engine on :$MOCK_PORT for $MODEL_ID ---"
+echo "    knee=$MOCK_KNEE base=${MOCK_BASE_TTFT_S}s per_excess=${MOCK_PER_EXCESS_S}s"
+python3 "$MOCK_PY" --port "$MOCK_PORT" --model "$MODEL_ID" \
+    --base-ttft-s "$MOCK_BASE_TTFT_S" --knee "$MOCK_KNEE" \
+    --per-excess-s "$MOCK_PER_EXCESS_S" --tok-latency-s 0.010 \
+    > "$LOGDIR/mock.log" 2>&1 &
+MOCK_PID=$!
+sleep 2
+curl -sf "http://127.0.0.1:$MOCK_PORT/v1/models" >/dev/null \
+  || { echo "FATAL: mock engine did not start; tail:"; tail -30 "$LOGDIR/mock.log"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 3. Per-arm rehearsal driver. Re-uses the gate1 configs verbatim, but
+#    materializes a tmp variant with the per-model port pinned to MOCK_PORT
+#    so the dev-skip engine adapter connects to the load-aware mock.
+# ---------------------------------------------------------------------------
+RESULTS_JSON="$LOGDIR/results/discriminator.json"
+echo '{"runs": []}' > "$RESULTS_JSON"
+
+run_arm() {
+  local arm="$1" cfg_in="$2" max_conc="$3"
+  local cfg_out="$LOGDIR/${arm}_config.yaml"
+  python3 -c "
+import yaml,sys
+with open('$cfg_in') as f: c = yaml.safe_load(f)
+c['models'][0]['port'] = $MOCK_PORT
+with open('$cfg_out','w') as f: yaml.safe_dump(c, f)
+"
+  echo "--- Phase 2.$arm: serve $cfg_in (max_concurrent=$max_conc) ---"
+  INFERGRID_DEV_SKIP_ENGINE_LAUNCH=1 \
+  PYTHONPATH="$REPO_ROOT/src:${PYTHONPATH:-}" \
+  python3 -m infergrid.cli serve --config "$cfg_out" --log-level WARNING \
+      > "$LOGDIR/serve_${arm}.log" 2>&1 &
+  SERVE_PID=$!
+
+  # Wait for /v1/models to be live.
+  local ready=0
+  for _ in $(seq 1 30); do
+    if curl -sf "http://localhost:$SERVE_PORT/v1/models" 2>/dev/null \
+        | python3 -c "import sys,json; sys.exit(0 if json.load(sys.stdin).get('data') else 1)" 2>/dev/null; then
+      ready=1; break
+    fi
+    sleep 1
+  done
+  [ $ready = 1 ] || { echo "FAIL: $arm /v1/models not ready"; tail -40 "$LOGDIR/serve_${arm}.log"; return 1; }
+
+  for conc in 128 256; do
+    local tag="${arm}_c${conc}"
+    local outdir="$LOGDIR/results/$tag"
+    mkdir -p "$outdir"
+
+    # Background poller: peak in_flight + queue_depth from /metrics.
+    local trace="$LOGDIR/results/${tag}_admission.csv"
+    echo "ts,in_flight,queue_depth,admitted,rejected" > "$trace"
+    (
+      while true; do
+        M=$(curl -sf "http://localhost:$SERVE_PORT/metrics" 2>/dev/null) || M=""
+        IF=$(printf '%s\n' "$M" | awk '/^infergrid_admission_in_flight /{print $2; exit}')
+        QD=$(printf '%s\n' "$M" | awk '/^infergrid_admission_queue_depth /{print $2; exit}')
+        AT=$(printf '%s\n' "$M" | awk '/^infergrid_admission_admitted_total /{print $2; exit}')
+        RT=$(printf '%s\n' "$M" | awk '/^infergrid_admission_rejected_total\{/{sum+=$2} END{print sum+0}')
+        printf "%s,%s,%s,%s,%s\n" "$(date +%s.%N)" "${IF:-0}" "${QD:-0}" "${AT:-0}" "${RT:-0}" >> "$trace"
+        sleep 0.05
+      done
+    ) > /dev/null 2>&1 &
+    POLLER_PID=$!
+
+    echo "    bench $tag: c=$conc num=$NUM_REQUESTS"
+    python3 benchmarks/scripts/benchmark_multi_model.py \
+        --url "http://localhost:$SERVE_PORT" \
+        --models "$MODEL_ID" \
+        --workload concurrent --concurrency "$conc" \
+        --num-requests "$NUM_REQUESTS" \
+        --output-dir "$outdir" --seed 42 \
+        > "$LOGDIR/results/${tag}_bench.log" 2>&1
+    local rc=$?
+
+    kill "$POLLER_PID" 2>/dev/null || true; wait "$POLLER_PID" 2>/dev/null || true
+
+    # Extract ttft_p99_ms from summary; record peak in_flight.
+    local sumfile="$outdir/concurrent_c${conc}_summary.json"
+    local p99=$(python3 -c "
+import json,sys
+try:
+    d = json.load(open('$sumfile'))
+    print(d.get('ttft_p99_ms', -1))
+except Exception:
+    print(-1)
+")
+    local peak_if=$(awk -F, 'NR>1 && $2+0>p{p=$2+0} END{printf "%.0f", p+0}' "$trace")
+    local peak_qd=$(awk -F, 'NR>1 && $3+0>p{p=$3+0} END{printf "%.0f", p+0}' "$trace")
+    echo "    => $tag rc=$rc ttft_p99=${p99}ms peak_in_flight=$peak_if peak_qd=$peak_qd"
+
+    python3 -c "
+import json
+d = json.load(open('$RESULTS_JSON'))
+d['runs'].append({'arm':'$arm','concurrency':$conc,'rc':$rc,
+                  'ttft_p99_ms':float('$p99'),'peak_in_flight':int('$peak_if'),
+                  'peak_queue_depth':int('$peak_qd'),'max_concurrent':$max_conc})
+json.dump(d, open('$RESULTS_JSON','w'), indent=2)
+"
+  done
+
+  kill "$SERVE_PID" 2>/dev/null || true; wait "$SERVE_PID" 2>/dev/null || true
+  pkill -f "infergrid.cli serve.*${arm}_config" 2>/dev/null || true
+  sleep 2   # let port :8000 free up before the next arm
+}
+
+run_arm A "$ARM_A_CFG" 128 || exit 1
+run_arm B "$ARM_B_CFG" 1024 || exit 1
+
+# ---------------------------------------------------------------------------
+# 4. Discriminator + plumbing assertions.
+# ---------------------------------------------------------------------------
+echo "═══════════════════════════════════════════════════════"
+echo " GATE 1 DRESS REHEARSAL RESULTS"
+echo "═══════════════════════════════════════════════════════"
+python3 - "$RESULTS_JSON" "$SKIP_DISCRIMINATOR" <<'PYEOF'
+import json, sys
+runs = json.load(open(sys.argv[1]))['runs']
+skip_disc = sys.argv[2] == "1"
+def get(arm, c):
+    for r in runs:
+        if r['arm'] == arm and r['concurrency'] == c: return r
+    return None
+A128, A256 = get('A',128), get('A',256)
+B128, B256 = get('B',128), get('B',256)
+fails = []
+for r in (A128, A256, B128, B256):
+    print(f"  {r['arm']} c={r['concurrency']}: ttft_p99={r['ttft_p99_ms']:.1f}ms "
+          f"peak_in_flight={r['peak_in_flight']} peak_qd={r['peak_queue_depth']} rc={r['rc']}")
+    if r['rc'] != 0 or r['ttft_p99_ms'] < 0:
+        fails.append(f"{r['arm']} c={r['concurrency']} bench failed")
+# Plumbing: A clamps near 128, B exceeds 128.
+if A256['peak_in_flight'] > 160:
+    fails.append(f"Arm A admission did NOT clamp at c=256 (peak_in_flight={A256['peak_in_flight']}, expected ~128)")
+if B256['peak_in_flight'] < 160:
+    fails.append(f"Arm B admission did NOT stay open at c=256 (peak_in_flight={B256['peak_in_flight']}, expected >160)")
+# Discriminator (matches Gate 1 hypothesis exactly).
+if not skip_disc:
+    a_ratio = A256['ttft_p99_ms'] / max(A128['ttft_p99_ms'], 0.001)
+    b_vs_a  = B256['ttft_p99_ms'] / max(A256['ttft_p99_ms'], 0.001)
+    print(f"\n  Discriminator: A_p99(256)/A_p99(128) = {a_ratio:.2f}x  (need <= 2.00x)")
+    print(f"  Discriminator: B_p99(256)/A_p99(256) = {b_vs_a:.2f}x  (need >= 4.00x)")
+    if a_ratio > 2.0: fails.append(f"A_p99 ratio {a_ratio:.2f}x > 2.0")
+    if b_vs_a  < 4.0: fails.append(f"B/A_p99 ratio {b_vs_a:.2f}x < 4.0")
+if fails:
+    print("\nOVERALL: FAIL"); [print("  -", f) for f in fails]; sys.exit(2)
+print("\nOVERALL: PASS — Gate 1 plumbing is wired correctly. Greenlight pod spin.")
+PYEOF
+RC=$?
+echo ""
+echo "  Logs: $LOGDIR/"
+echo "  Results JSON: $RESULTS_JSON"
+exit $RC


### PR DESCRIPTION
## Summary
PR #28 was incomplete. Three silent failure modes shipped past the v1 discriminator:

1. **`bool(\" \")` is True.** Whitespace-only first chunks (vLLM/SGLang emit these during warm-up tokenization) were still counted as the first token. Now uses `content.strip()`.
2. **Chat-completions endpoints emit `delta.content`, not `text`.** The v1 check always saw `\"\"`, so on chat-template engines TTFT silently collapsed to `total_latency_ms` and `tokens_out` was always 0. Now reads `choices[0].get(\"delta\", {}).get(\"content\")` as a fallback.
3. **`JSONDecodeError` used to increment `tokens_out` and stamp `first_token_time`.** A parse error is not generation progress; v2 `continues`.

Surfaced by Jay-style shadow review of PR #28 + #29.

## Discriminator now has 3 cases
| Case | Pre-v2 | Post-v2 |
|---|---:|---:|
| empty-preamble | ttft=554ms PASS (PR #28 already fixed) | ttft=554ms PASS |
| whitespace-preamble | ttft=52ms FAIL | ttft=556ms PASS |
| chat-shape | tokens_out=0 FAIL | tokens_out=8 PASS |

## Other changes
- `mock_engine.py` grows `--first-chunk-whitespace` and `--chat-completions-shape`.
- `smoke_bench.sh` poller bumped 50ms → 10ms (Jay Nyquist concern: 50ms cadence aliased the 50ms chunk-delay signal).
- `CORRECTIONS.md` C2 updated with v1 + v2 history.

## Bonus
The Gate 1 dress-rehearsal script `scripts/gate1_dress_rehearsal.sh` lands here too — local CPU-only dry-run that exercises the actual gate1_admission*.yaml configs against a load-aware mock at c=128/256 and asserts the experiment plumbing before any GPU spend. (Background-agent deliverable from this same session.)

## Test plan
- [x] `pytest tests/unit/` — 124 passed
- [x] `python3 benchmarks/scripts/test_real_ttft.py` — 3/3 pass
- [x] Stash bench fix; same test reports whitespace + chat-shape FAIL — discriminator works
- [x] `bash benchmarks/scripts/smoke_bench.sh` — OVERALL PASS, peak in_flight=16
- [ ] Run `bash scripts/gate1_dress_rehearsal.sh` next (separate PR follow-up if it surfaces issues)