### PR TITLE
fix(router): record streaming budget at stream end, not at handoff

### DIFF
--- a/src/infergrid/router/router.py
+++ b/src/infergrid/router/router.py
@@ -51,6 +51,19 @@ BUCKET_PRIORITY: dict[str, int] = {
 }
 
 
+def _approx_tokens_in(payload: dict[str, Any]) -> int:
+    """Whitespace-split approximation of input token count.
+
+    Off by a constant factor vs a real tokenizer (BPE expands ~1.3x on
+    English) but cheap, no model dependency, and sufficient for tenant
+    budget accounting. The bench harness reports ground-truth counts.
+    """
+    text = payload.get("prompt") or " ".join(
+        str(m.get("content", "")) for m in payload.get("messages", [])
+    )
+    return len(text.split())
+
+
 def classify_request_length(max_tokens: int, input_tokens: int = 0) -> str:
     """Classify a request into a length bucket.
 
@@ -410,12 +423,32 @@ class WorkloadRouter:
             # Forward the request
             result = await state.adapter.forward_request(path, payload, stream=stream)
 
-            # Update tracking
-            elapsed = time.monotonic() - start_time
             state.request_count += 1
-            state.total_latency_s += elapsed
             state.last_request_time = time.monotonic()
 
+            # For streaming: result is an async generator that has NOT been
+            # consumed yet. We must defer ALL accounting (latency, tokens,
+            # tenant budget, metrics) into the wrapper's finally — recording
+            # them here would log placeholder values (latency = handoff time,
+            # tokens_out = 0) and never correct them post-stream. Both the
+            # admission slot and the budget reflect the true stream lifetime.
+            if stream and hasattr(result, "__aiter__"):
+                tokens_in = _approx_tokens_in(payload)
+                wrapped = self._stream_with_admission(
+                    result,
+                    model_id=model_id,
+                    tenant_id=tenant_id,
+                    state=state,
+                    tokens_in=tokens_in,
+                    start_time=start_time,
+                )
+                released = True  # ownership transferred to wrapper
+                return wrapped
+
+            # Non-streaming: usage is in the response dict, accounting is
+            # accurate at this point.
+            elapsed = time.monotonic() - start_time
+            state.total_latency_s += elapsed
             tokens_out = 0
             tokens_in = 0
             if isinstance(result, dict):
@@ -435,27 +468,6 @@ class WorkloadRouter:
                 tenant_id, tokens_in=tokens_in, tokens_out=tokens_out,
                 gpu_seconds=elapsed,
             )
-
-            # For streaming, `result` is an async generator that has NOT yet
-            # been consumed. If we release admission here in `finally`, the
-            # slot frees microseconds after acquire() — the engine is still
-            # generating tokens but admission already counts the slot as free.
-            # That is exactly the streaming-bypass bug confirmed by the
-            # smoke_bench poller (peak in_flight=0 with cap=16).
-            #
-            # Fix: hand the slot to a wrapper generator whose own `finally`
-            # releases when the iterator exhausts, raises, or is GC'd by the
-            # caller. Caveat: a client that abandons mid-stream keeps the slot
-            # held until the wrapper is collected. Acceptable trade-off for the
-            # honest engagement we need at Gate 1; revisit with a hard
-            # per-request keepalive timeout once we have real-traffic data.
-            if stream and hasattr(result, "__aiter__"):
-                wrapped = self._stream_with_admission(
-                    result, tenant_id=tenant_id,
-                )
-                released = True  # ownership transferred to wrapper
-                return wrapped
-
             return result
 
         except BudgetExceededError:
@@ -475,27 +487,63 @@ class WorkloadRouter:
     async def _stream_with_admission(
         self,
         inner: Any,
+        *,
+        model_id: str,
         tenant_id: str,
+        state: ModelState,
+        tokens_in: int,
+        start_time: float,
     ) -> Any:
-        """Stream inner iterator while holding the admission slot.
+        """Stream inner iterator while holding admission + accounting slots.
 
-        Releases the admission slot and tenant slot in `finally` so cancellation,
-        client disconnect (aiohttp closes the response), and normal completion
-        all converge on a single release path. Also `aclose()`s the inner
-        engine generator so its underlying aiohttp `session.post()` context
-        unwinds eagerly — without this, an aborted client leaves the engine
-        connection open and the engine keeps generating tokens until the
-        inner generator is GC'd.
+        Releases the admission slot, tenant slot, and records request +
+        budget metrics in `finally` so cancellation, client disconnect
+        (aiohttp closes the response), and normal completion all converge
+        on a single accounting path. Also `aclose()`s the inner engine
+        generator so its aiohttp `session.post()` unwinds eagerly — without
+        this, an aborted client leaves the engine connection open and the
+        engine keeps generating tokens until the inner generator is GC'd.
+
+        chunk_count is a coarse proxy for tokens_out: each SSE chunk is
+        usually one token (in /v1/completions) or a delta frame (in
+        /v1/chat/completions). The bench harness reports ground-truth
+        token counts; the router uses chunk_count for tenant budget +
+        Prometheus only. Wrong by a small constant factor on chat APIs;
+        not wrong by orders of magnitude as the pre-PR-#32 zero was.
         """
+        chunk_count = 0
+        status = "error"  # flipped to "ok" only on clean exhaustion
         try:
             async for chunk in inner:
+                chunk_count += 1
                 yield chunk
+            status = "ok"
         finally:
             if hasattr(inner, "aclose"):
                 try:
                     await inner.aclose()
                 except Exception:
                     pass
+            elapsed_real = time.monotonic() - start_time
+            state.total_latency_s += elapsed_real
+            try:
+                self.metrics.record_request(
+                    model=model_id,
+                    tenant=tenant_id,
+                    status=status,
+                    latency_s=elapsed_real,
+                    tokens_in=tokens_in,
+                    tokens_out=chunk_count,
+                )
+                await self.tenant_manager.record_completion(
+                    tenant_id, tokens_in=tokens_in, tokens_out=chunk_count,
+                    gpu_seconds=elapsed_real,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "stream metrics record failed model=%s tenant=%s: %s",
+                    model_id, tenant_id, exc,
+                )
             self.admission_controller.release()
             await self.tenant_manager.release_for_tenant(tenant_id)
 

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -345,3 +345,50 @@ class TestStreamingAdmission:
         # is the well-behaved path and is what aiohttp does on disconnect.)
         await agen.aclose()
         assert router.admission_controller.in_flight == 0
+
+    async def test_streaming_budget_accounting_uses_real_values(self) -> None:
+        """Regression: tenant.record_completion must reflect the actual stream,
+        not a placeholder logged at handoff time.
+
+        Pre-PR-#32 the route_request body called record_request /
+        record_completion with `latency_s = time-to-generator-object`
+        (microseconds) and `tokens_out = 0`, then released admission. Tenant
+        budget never saw the real stream cost. PR #32 moves the recording
+        into the wrapper's finally with chunk_count and real elapsed.
+        """
+        router = self._make_router_with_slow_stream(
+            max_concurrent=4, chunk_count=5, chunk_delay_s=0.04,
+        )
+
+        tm_calls: list[dict] = []
+
+        async def fake_record_completion(tenant_id, **kwargs):
+            tm_calls.append({"tenant_id": tenant_id, **kwargs})
+
+        router.tenant_manager.record_completion = fake_record_completion  # type: ignore[assignment]
+
+        result = await router.route_request(
+            model_id="m", path="/v1/completions",
+            payload={"prompt": "two words", "stream": True, "max_tokens": 5},
+            stream=True,
+        )
+        chunks: list = []
+        async for c in result:
+            chunks.append(c)
+        # Wrapper iteration is done — finally has run.
+
+        assert len(tm_calls) == 1, f"expected 1 record_completion call, got {len(tm_calls)}"
+        call = tm_calls[0]
+        # Real elapsed: 5 chunks × 40ms ≈ 200ms (≥ 150 ms allows for noise).
+        assert call["gpu_seconds"] >= 0.15, (
+            f"gpu_seconds={call['gpu_seconds']} — accounting recorded the "
+            "handoff time, not the real stream lifetime"
+        )
+        # tokens_out is the chunk count (coarse but non-zero — was 0 pre-fix).
+        assert call["tokens_out"] == 5, (
+            f"tokens_out={call['tokens_out']} — chunk count not recorded"
+        )
+        # tokens_in came from prompt split.
+        assert call["tokens_in"] == 2, (
+            f"tokens_in={call['tokens_in']} — _approx_tokens_in regression"
+        )


### PR DESCRIPTION
## Summary
PR #29 made admission honest. PR #32 makes the accounting honest. Pre-fix, `route_request` called `metrics.record_request` + `tenant_manager.record_completion` in its body — for streaming, that ran microseconds after acquire(), so `latency_s = time-to-generator-object` (microseconds) and `tokens_out = 0` (no usage dict yet). Tenant budget was under-counted by the ENTIRE stream duration.

Surfaced by Jay shadow review of PRs #28+#29.

## Fix
- **Streaming branch:** defer all accounting into `_stream_with_admission` finally. Records with real elapsed (start_time → stream-end) and `chunk_count` as a coarse tokens_out proxy. `status=\"error\"` default, flipped to `\"ok\"` only on clean exhaustion.
- **Non-streaming branch:** unchanged (usage dict has real numbers).
- **`_approx_tokens_in` helper:** whitespace-split on prompt or messages. Cheap and good enough for tenant budget; bench harness still reports ground-truth.

## Discriminator
`test_streaming_budget_accounting_uses_real_values` mocks `tenant_manager.record_completion`, drives a 5×40ms streaming request, asserts `gpu_seconds >= 150ms` and `tokens_out == 5`. On pre-PR-#32 router: `gpu_seconds = 0.07ms` (handoff). Post-fix: `gpu_seconds >= 150ms`.

## Followups left out of scope
- `chunk_count` overcounts on chat completions ([DONE], role-only frames). Acceptable for this MVP since the bench reports ground-truth tokens.
- A real tokenizer for `tokens_in` if we ever bill per token.

## Test plan
- [x] `pytest tests/unit/` — 125 passed (was 124, +1 budget test)
- [x] Stash router fix; budget test fails with `gpu_seconds=0.07ms`
- [x] Restore fix; budget test passes with `gpu_seconds >= 150ms`