### PR TITLE
fix(router): max-stream-duration fence + GC-path coverage

### DIFF
--- a/src/infergrid/router/router.py
+++ b/src/infergrid/router/router.py
@@ -13,10 +13,20 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+import os
 import socket
 import time
 from dataclasses import dataclass, field
 from typing import Any
+
+# Hard ceiling for any single streaming response. Guards against client-side
+# slow consumers that would otherwise hold an admission slot indefinitely
+# (engine-side stalls are already bounded by EngineAdapter sock_read /
+# total timeouts in engines/base.py). Default 600s = 10 minutes; override
+# via INFERGRID_STREAM_MAX_DURATION_S for tests or specific deployments.
+_STREAM_MAX_DURATION_S: float = float(
+    os.environ.get("INFERGRID_STREAM_MAX_DURATION_S", "600.0")
+)
 
 import aiohttp
 from aiohttp import web
@@ -514,10 +524,23 @@ class WorkloadRouter:
         chunk_count = 0
         status = "error"  # flipped to "ok" only on clean exhaustion
         try:
-            async for chunk in inner:
-                chunk_count += 1
-                yield chunk
+            # Hard fence: even with admission honest and engine timeouts in
+            # place, a slow client could hold a slot for the entire stream.
+            # Bound it. asyncio.timeout() raises asyncio.TimeoutError which
+            # the wrapper's finally still cleans up.
+            async with asyncio.timeout(_STREAM_MAX_DURATION_S):
+                async for chunk in inner:
+                    chunk_count += 1
+                    yield chunk
             status = "ok"
+        except asyncio.TimeoutError:
+            logger.warning(
+                "stream max-duration exceeded model=%s tenant=%s after %.1fs (chunks=%d)",
+                model_id, tenant_id, _STREAM_MAX_DURATION_S, chunk_count,
+            )
+            status = "timeout"
+            # Re-raise so the outer handle_request can return 504 to client.
+            raise
         finally:
             if hasattr(inner, "aclose"):
                 try:

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -7,11 +7,13 @@ and request length classification.
 from __future__ import annotations
 
 import asyncio
+import gc
 import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import infergrid.router.router as router_module
 from infergrid.common.config import InferGridConfig, ModelConfig
 from infergrid.router.router import (
     BudgetExceededError,
@@ -391,4 +393,64 @@ class TestStreamingAdmission:
         # tokens_in came from prompt split.
         assert call["tokens_in"] == 2, (
             f"tokens_in={call['tokens_in']} — _approx_tokens_in regression"
+        )
+
+    async def test_max_stream_duration_releases_slot(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Slow-client guard: a stream that exceeds the configured max
+        duration must abort and release the admission slot (PR #33)."""
+        monkeypatch.setattr(router_module, "_STREAM_MAX_DURATION_S", 0.15)
+
+        # 50 chunks × 50 ms = 2.5s — well past the 0.15s fence.
+        router = self._make_router_with_slow_stream(
+            max_concurrent=2, chunk_count=50, chunk_delay_s=0.05,
+        )
+
+        result = await router.route_request(
+            model_id="m", path="/v1/completions",
+            payload={"prompt": "p", "stream": True, "max_tokens": 50},
+            stream=True,
+        )
+        with pytest.raises(asyncio.TimeoutError):
+            async for _ in result:
+                pass
+
+        assert router.admission_controller.in_flight == 0, (
+            "admission slot leaked when max-stream-duration fence fired"
+        )
+
+    async def test_slot_released_after_gc_without_aclose(self) -> None:
+        """When a consumer drops the wrapper without calling aclose() (and
+        without aiohttp's disconnect path), the slot SHOULD eventually
+        release once Python GCs the async generator. CPython runs the
+        finalizer on the asyncio loop's idle pass, so we collect + yield.
+
+        This documents the GC-path behavior (and is the reason PR #33 also
+        adds a max-duration fence as a hard upper bound — GC timing is
+        cooperative and not guaranteed).
+        """
+        router = self._make_router_with_slow_stream(
+            max_concurrent=2, chunk_count=50, chunk_delay_s=0.05,
+        )
+
+        result = await router.route_request(
+            model_id="m", path="/v1/completions",
+            payload={"prompt": "p", "stream": True, "max_tokens": 50},
+            stream=True,
+        )
+        agen = result.__aiter__()
+        await agen.__anext__()
+        assert router.admission_controller.in_flight == 1
+
+        # Drop both refs WITHOUT aclose. The wrapper finalizer is queued
+        # by CPython on collection; asyncio's _asyncgen_finalizer_hook
+        # schedules its aclose on the loop, which runs on next idle.
+        del result, agen
+        for _ in range(3):
+            gc.collect()
+            await asyncio.sleep(0.05)
+
+        assert router.admission_controller.in_flight == 0, (
+            "GC-path did not release admission slot. The async-generator "
+            "finalizer hook may not be wired (sys.set_asyncgen_hooks). "
+            "Without it, abandoned streams leak slots until the loop dies."
         )


### PR DESCRIPTION
## Summary
Two safety nets PR #29 promised but didn't deliver, surfaced by Jay shadow review.

### 1. Max-stream-duration fence
Even with admission honest (PR #29) and engine-side sock_read timeouts, a slow client could hold a slot indefinitely. `_stream_with_admission` now wraps iteration in `asyncio.timeout(_STREAM_MAX_DURATION_S)`. Default 600s; override via `INFERGRID_STREAM_MAX_DURATION_S`. Timeout → status=\"timeout\", finally cleans up, raises so handler returns 504.

### 2. GC-path test
PR #29 only tested `aclose()`. The actual caveat — "client abandons mid-stream without aclose" — wasn't exercised. Test drops the wrapper, runs `gc.collect`, yields the loop, asserts in_flight=0. Passes on CPython 3.13: asyncio's `_asyncgen_finalizer_hook` schedules `aclose()` on the loop. GC IS a fallback, but timing is cooperative — the max-duration fence is the hard upper bound.

## TestStreamingAdmission now has 6 tests
| # | Test | Lands in |
|---|---|---|
| 1 | in_flight held during stream | PR #29 |
| 2 | concurrency cap respected | PR #29 |
| 3 | slot released on aclose | PR #29 |
| 4 | streaming budget accounting (real elapsed + tokens) | PR #32 |
| 5 | max-stream-duration releases slot | PR #33 |
| 6 | slot released after GC without aclose | PR #33 |

## Test plan
- [x] `pytest tests/unit/` — 127 passed (was 125, +2 from PR #33)
- [x] `bash benchmarks/scripts/smoke_bench.sh` — OVERALL PASS