### PR TITLE
fix: 5 Gate-1 blockers surfaced by dress rehearsal

### DIFF
--- a/benchmarks/scripts/benchmark_multi_model.py
+++ b/benchmarks/scripts/benchmark_multi_model.py
@@ -380,7 +380,16 @@ class MultiModelBenchmarkClient:
         aborted_after: int | None = None
         ABORT_THRESHOLD = 5
 
-        async with aiohttp.ClientSession() as session:
+        # Default TCPConnector caps simultaneous connections per host at 100,
+        # which silently clamps any bench run with concurrency > 100. For
+        # Gate 1 we ask for c=128 and c=256 — without this lift the harness
+        # measures the connector limit, not the engine. Sized to 4× the
+        # configured concurrency so neither connector nor pool starves.
+        connector = aiohttp.TCPConnector(
+            limit=max(256, self.concurrency * 4),
+            limit_per_host=max(256, self.concurrency * 4),
+        )
+        async with aiohttp.ClientSession(connector=connector) as session:
             tasks: list[asyncio.Task[MultiModelRequestMetrics]] = []
             for i, (model, req) in enumerate(zip(schedule, requests)):
                 prompt = req.get("prompt", "") if isinstance(req, dict) else str(req)
@@ -1007,8 +1016,20 @@ async def main() -> None:
             "Qwen/Qwen2.5-7B-Instruct",
         ]
 
-    if len(models) < 2:
-        logger.error("Need at least 2 models for multi-model benchmarks")
+    # `concurrent` workload distributes requests across the model list and
+    # works for any N >= 1 (single-model is the realistic Gate 1 setup).
+    # `switch_latency`, `alternating`, `bursty`, `eviction` compare across
+    # models and need at least two.
+    SINGLE_MODEL_OK_WORKLOADS = {"concurrent"}
+    requested = {args.workload} if args.workload != "all" else {
+        "switch_latency", "alternating", "bursty", "concurrent", "eviction",
+    }
+    if len(models) < 2 and not requested.issubset(SINGLE_MODEL_OK_WORKLOADS):
+        logger.error(
+            "Need at least 2 models for workloads %s. Got %d model(s); "
+            "for single-model runs use --workload concurrent.",
+            sorted(requested - SINGLE_MODEL_OK_WORKLOADS), len(models),
+        )
         sys.exit(1)
 
     logger.info("Models: %s", models)

--- a/configs/gate1_admission.yaml
+++ b/configs/gate1_admission.yaml
@@ -11,6 +11,13 @@ admission_queue_size: 1024
 engine_start_timeout_s: 420
 log_level: INFO
 
+# Gate 1 is single-tenant: admission control is the variable under test,
+# not per-tenant budget. Set the default tenant budget high enough that
+# c=256 traffic is gated by max_concurrent above, not by 429 budget rejects.
+tenant_defaults:
+  max_concurrent_requests: 1024
+  rate_limit_rpm: 60000
+
 models:
   - model_id: "meta-llama/Llama-3.1-8B-Instruct"
     short_name: "llama31-8b"

--- a/configs/gate1_admission_off.yaml
+++ b/configs/gate1_admission_off.yaml
@@ -9,6 +9,13 @@ admission_queue_size: 1024
 engine_start_timeout_s: 420
 log_level: INFO
 
+# Match Arm A's tenant_defaults so the only variable is max_concurrent
+# (the admission cap). Without this, both arms hit the 64-default budget
+# at c=128+ and the experiment measures 429-shaped failures, not admission.
+tenant_defaults:
+  max_concurrent_requests: 1024
+  rate_limit_rpm: 60000
+
 models:
   - model_id: "meta-llama/Llama-3.1-8B-Instruct"
     short_name: "llama31-8b"

--- a/scripts/gate1_dress_rehearsal.sh
+++ b/scripts/gate1_dress_rehearsal.sh
@@ -44,8 +44,9 @@ MOCK_KNEE=${MOCK_KNEE:-128}
 MOCK_PER_EXCESS_S=${MOCK_PER_EXCESS_S:-0.012}
 SKIP_DISCRIMINATOR=${SKIP_DISCRIMINATOR:-0}
 
-REPO_ROOT=$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || cd "$(dirname "$0")/.." && pwd)
-cd "$REPO_ROOT"
+REPO_ROOT=$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null \
+            || ( cd "$(dirname "$0")/.." && pwd ))
+cd "$REPO_ROOT" || { echo "FATAL: cannot cd to REPO_ROOT='$REPO_ROOT'"; exit 2; }
 
 ARM_A_CFG="$REPO_ROOT/configs/gate1_admission.yaml"
 ARM_B_CFG="$REPO_ROOT/configs/gate1_admission_off.yaml"

--- a/src/infergrid/cli.py
+++ b/src/infergrid/cli.py
@@ -141,7 +141,19 @@ async def _run_server(config: InferGridConfig) -> None:
     """
     metrics = MetricsCollector()
     cache_manager = CacheManager()
-    tenant_manager = TenantManager()
+    # Wire config.tenant_defaults → TenantManager.default_budget. Without
+    # this, the manager always falls back to its internal 64-concurrent
+    # default and rejects high-concurrency traffic with 429 even when the
+    # config lifts the cap. That blocks Gate 1 (c=256 vs default=64).
+    from infergrid.tenant.manager import TenantBudget
+    td = config.tenant_defaults
+    default_budget = TenantBudget(
+        max_concurrent_requests=td.max_concurrent_requests,
+        rate_limit_rpm=td.rate_limit_rpm,
+        max_gpu_memory_gb=td.max_gpu_memory_gb,
+        priority=td.priority,
+    )
+    tenant_manager = TenantManager(default_budget=default_budget)
 
     router = WorkloadRouter(
         config=config,


### PR DESCRIPTION
## Summary
The Gate 1 dress rehearsal (`scripts/gate1_dress_rehearsal.sh`, the bonus deliverable from PR #31) ran end-to-end for the first time after PR #33 landed. It surfaced **five hard blockers** that would have produced garbage data on the actual H100 spend.

All five are now fixed. Dress rehearsal exits **OVERALL: PASS** with peak `in_flight=128` on Arm A (capped at config), peak `in_flight=256` on Arm B (admission open), `queue_depth=128` on Arm A at c=256 (queueing as expected). The experiment plumbing is now real.

## The 5 blockers

| # | Where | What was wrong |
|---|---|---|
| 1 | `scripts/gate1_dress_rehearsal.sh:47` | `git ... \|\| cd ... && pwd` parses as `(git \|\| cd) && pwd` so `pwd` ran always and its output got appended to REPO_ROOT (newline-joined). |
| 2 | `benchmarks/scripts/benchmark_multi_model.py:1010` | Hard `len(models) < 2` gate would have killed Gate 1 (single-model Llama). Now workload-aware. |
| 3 | `src/infergrid/cli.py:144` | `config.tenant_defaults` was parsed but never passed to `TenantManager()`. Default `max_concurrent=64` rejected c=128+ traffic with 429. |
| 4 | `configs/gate1_admission*.yaml` | No `tenant_defaults` set — relied on the broken default in #3. Now explicit `1024 / 60000`. |
| 5 | `benchmarks/scripts/benchmark_multi_model.py:383` | aiohttp default `TCPConnector.limit_per_host=100` silently clamped c=256 to 100. Pre-fix Arm B reported peak_in_flight=100 (the connector limit, not the engine). Now `max(256, conc*4)`. |

## Dress rehearsal output (post-fix)
```
A c=128: ttft_p99=1589.9ms peak_in_flight=128 peak_qd=0
A c=256: ttft_p99=3043.0ms peak_in_flight=128 peak_qd=128   ← Arm A queues
B c=128: ttft_p99=1586.2ms peak_in_flight=128 peak_qd=0
B c=256: ttft_p99=3056.3ms peak_in_flight=256 peak_qd=0     ← Arm B open
OVERALL: PASS — Gate 1 plumbing is wired correctly. Greenlight pod spin.
```

## Test plan
- [x] `pytest tests/unit/` — 127 passed
- [x] `bash benchmarks/scripts/smoke_bench.sh` — OVERALL: PASS, peak in_flight=16
- [x] `NUM_REQUESTS=300 SKIP_DISCRIMINATOR=1 bash scripts/gate1_dress_rehearsal.sh` — OVERALL: PASS
- [ ] Gate 1 H100 next; the load-aware mock can't validate the actual hypothesis math (only the plumbing).