### PR TITLE
docs: PROGRESS catch-up (PRs #27-35) + Gate 1 launch runbook

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -266,6 +266,15 @@ InferGrid is a middleware orchestration layer for LLM inference that sits on top
 | #24 | Gate 1 configs (admission ON/OFF) + smoke_bench pre-flight | Merged | Apr 19, 2026 |
 | #25 | R5 harness phase-abort + checked-in `scripts/gate_pod_bootstrap.sh` (D2) | Merged | Apr 19, 2026 |
 | #26 | Gate 0.6 multi-model bench validation on real vLLM | Merged | Apr 19, 2026 |
+| #27 | PROGRESS.md catch-up through Gate 0.6 | Merged | Apr 19, 2026 |
+| #28 | real-TTFT v1 (C2 fix): bench timed first SSE frame, not first non-empty content | Merged | Apr 19, 2026 |
+| #29 | admission-streaming-bypass fix: route_request released slot before stream consumed; cap was a no-op for streaming. Wrapper holds slot for stream lifetime; smoke_bench /metrics poller; 3 unit tests | Merged | Apr 19, 2026 |
+| #30 | aclose inner generator in stream-wrapper finally (closes engine HTTP connection on client abort) | Merged | Apr 19, 2026 |
+| #31 | TTFT v2: `bool(" ")` truthy + chat-completions `delta.content` + JSONDecodeError → continue. 3-case discriminator. Smoke poller 50ms→10ms (Nyquist). Bonus: `scripts/gate1_dress_rehearsal.sh` | Merged | Apr 19, 2026 |
+| #32 | Streaming budget accounting: tenant.record_completion got `gpu_seconds=0.07ms` at handoff pre-fix; now in wrapper finally with real elapsed + chunk count | Merged | Apr 19, 2026 |
+| #33 | Max-stream-duration fence (`INFERGRID_STREAM_MAX_DURATION_S=600`) + GC-path test confirms asyncgen finalizer hook releases slot | Merged | Apr 19, 2026 |
+| #34 | 5 Gate-1 blockers from dress rehearsal: bash REPO_ROOT precedence; bench `len(models)<2` gate; cli.py never wired tenant_defaults to TenantManager; gate1 configs missing tenant_defaults; aiohttp `TCPConnector.limit_per_host=100` clamped c=256 to 100 | Merged | Apr 19, 2026 |
+| #35 | Cost-cap 3-layer defense in `gate_pod_bootstrap.sh`: MAX_POD_SECS self-destruct timer, /workspace/ABORT sentinel, phase wall-clock budget | Merged | Apr 19, 2026 |
 
 PR #18 closed (conflict-dead, superseded by #19). PR #20 open as DRAFT (Gate 0 launch post, ship-gated).
 
@@ -307,3 +316,45 @@ A100-SXM4-80GB, ~2h, ~$3.17 spend. Cloned `main@a610a14` (all PR #16-23 fixes ac
 (TTFT numbers in artifacts are SSE-frame RTT, not real first-token — see `results/CORRECTIONS.md` C2.)
 
 See `results/gate06_20260419/GATE06_OUTCOME.md`.
+
+## Pre-Gate-1 Measurement-Honesty Pass (2026-04-19)
+
+Between Gate 0.6 and Gate 1, two questions surfaced that turned the planned $7-10 H100 spend into a likely waste:
+
+**(1) Was the bench measuring TTFT honestly?** No. PR #28 fixed the obvious case (TTFT was the SSE first-frame, not first non-empty content). A Jay-style shadow review of #28 then surfaced two more silent failure modes: `bool(" ")` is truthy in Python so whitespace-only frames still counted as the first token, and chat-completions endpoints emit `delta.content` not `text` so the v1 check always saw "" and TTFT silently collapsed to total_latency_ms. PR #31 fixed both. The discriminator now has three cases; on pre-fix code, whitespace and chat-shape both fail loudly.
+
+**(2) Was admission control engaged at all for streaming traffic?** No — and this was the bigger find. `route_request` awaited `forward_request`, which for `stream=True` returned the async generator object immediately, then released the admission slot in `finally` — microseconds after acquire. The `smoke_bench` `/metrics` poller (added in #29) confirmed: 149 samples during a c=32 phase reported peak `in_flight=0` with `cap=16`. **The Gate 1 hypothesis (Arm A `cap=128` vs Arm B `cap=1024`) was unmeasurable**: both arms would have admitted all 256 reqs simultaneously and produced identical numbers. PR #29 wraps the iterator so admission releases when the stream truly ends; post-fix smoke shows peak `in_flight=16, queue_depth=16`.
+
+PRs #30, #32, #33 closed three follow-ups Jay flagged in the review of #29: (a) the wrapper didn't `aclose()` the inner engine generator, leaking the engine-side HTTP connection on client abort; (b) accounting was logged at handoff with `gpu_seconds=0.07ms, tokens_out=0`, never corrected post-stream; (c) PR #29's "client abandons mid-stream" caveat had no test and no max-duration fence. All three landed.
+
+PR #34 then surfaced and fixed five separate Gate-1 blockers in one go after the dress-rehearsal script (added in #31) actually ran end-to-end for the first time:
+
+| # | Where | What was wrong |
+|---|---|---|
+| 1 | `scripts/gate1_dress_rehearsal.sh` | Bash precedence bug: `git ... \|\| cd ... && pwd` parsed as `(git \|\| cd) && pwd`, so REPO_ROOT got `pwd` output appended on a newline. |
+| 2 | `benchmarks/scripts/benchmark_multi_model.py` | Hard `len(models) < 2` gate would have killed Gate 1 (single-model Llama). Now workload-aware. |
+| 3 | `src/infergrid/cli.py` | `config.tenant_defaults` was parsed but never passed to `TenantManager()`. Default `max_concurrent=64` rejected c=128+ traffic with 429. |
+| 4 | `configs/gate1_admission*.yaml` | No `tenant_defaults` set — relied on the broken default in #3. |
+| 5 | `benchmarks/scripts/benchmark_multi_model.py` | aiohttp default `TCPConnector.limit_per_host=100` silently clamped c=256 to 100. Pre-fix Arm B reported peak_in_flight=100 (the connector limit, not the engine). |
+
+PR #35 added a 3-layer cost-cap defense to `gate_pod_bootstrap.sh` (self-destruct timer at `MAX_POD_SECS=10800`, `/workspace/ABORT` sentinel, phase wall-clock budget that aborts before bench if engine bring-up ate > MAX/2).
+
+`results/CORRECTIONS.md` updated with C2 v1+v2 history and a new C5 entry (admission was a no-op for streaming pre-#29; Gate 0/0.5/0.6 conclusions stand because they didn't depend on admission engagement, but Gate 1 onward critically does).
+
+## Gate 1 Readiness (2026-04-19)
+
+| Item | State |
+|---|---|
+| `main` contains all measurement-honest fixes | ✅ at `5b64b4c` |
+| Unit tests | ✅ 127 passing |
+| `bash benchmarks/scripts/smoke_bench.sh` | ✅ OVERALL: PASS, peak in_flight=16 |
+| `bash scripts/gate1_dress_rehearsal.sh` (NUM_REQUESTS=300, SKIP_DISCRIMINATOR=1) | ✅ OVERALL: PASS — Arm A peak in_flight=128 + queue_depth=128, Arm B peak in_flight=256 |
+| Cost-cap hardening in pod bootstrap | ✅ 3-layer defense |
+| H100 SXM5 spot price ≤ $4/hr | Verify before provisioning |
+| User greenlight on $7-10 spend | Pending |
+
+**Gate 1 launch runbook:** `docs/launch/gate1_runbook.md`.
+
+**Hypothesis discriminator:** Arm A TTFT p99 @ c=256 ≤ 2× Arm A @ c=128, AND Arm B TTFT p99 @ c=256 ≥ 4× Arm A @ c=256.
+
+**Caveat to flag in any analysis:** the dress rehearsal's load-aware mock is *linear* in latency (`base + max(0, excess) * per_excess`). If Gate 1 on H100 reports near-identical TTFTs across arms, that's a **disconfirmation of the hypothesis** — the c=128→c=256 cliff Phase 1 saw (185ms → 1293ms, 7×) may have been measurement artifact (pre-PR-#28 TTFT bug). Either outcome is publishable; don't read a flat result as a plumbing failure.

--- a/docs/launch/gate1_runbook.md
+++ b/docs/launch/gate1_runbook.md
@@ -1,0 +1,158 @@
+# Gate 1 Launch Runbook
+
+**Audience:** the human spending the $7-10. Do these in order. Don't skip the pre-flight.
+
+**Hardware:** 1× NVIDIA H100 SXM5 80GB on RunPod (SECURE pod).
+**Wall:** ~1.8h.
+**Cost:** ~$7-10 expected; hard ceiling ~$12 via PR #35's `MAX_POD_SECS=10800` self-destruct timer.
+**main tip required:** `5b64b4c` or later.
+
+---
+
+## Pre-flight (do not skip — each check has burned budget historically)
+
+1. **Source of truth for fixes.** `git -C ~/Personal\ Projects/infergrid_implementation_poc/infergrid log --oneline -10` should show PR #28 through #35 in `main`.
+2. **Local CPU dress rehearsal exits PASS.**
+   ```bash
+   cd ~/Personal\ Projects/infergrid_implementation_poc/infergrid
+   NUM_REQUESTS=300 SKIP_DISCRIMINATOR=1 bash scripts/gate1_dress_rehearsal.sh
+   ```
+   Look for `OVERALL: PASS — Gate 1 plumbing is wired correctly`. If it fails, **do not provision the pod.** Debug locally first.
+3. **HF_TOKEN is valid for Llama.**
+   ```bash
+   curl -fsS -H "Authorization: Bearer $HF_TOKEN" \
+     https://huggingface.co/api/models/meta-llama/Llama-3.1-8B-Instruct \
+     | head -c 200
+   ```
+   If this 401s, fix HF access before provisioning.
+4. **RunPod balance ≥ $25.** (3× expected spend; spot pods may need to reschedule.)
+5. **H100 SXM5 spot price.** Check the RunPod console; if > $4/hr, wait or switch to a different region.
+6. **Calendar block 2.5h.** First 30 min are the critical window — engine bring-up is the historical failure mode.
+
+---
+
+## Launch (3 commands)
+
+Per advisor: **don't** bundle these into a one-button script. The first time, run them by hand so a failure in step N doesn't auto-trigger steps N+1.
+
+### 1. Provision the pod
+
+```bash
+cd ~/Personal\ Projects/infergrid_implementation_poc/infergrid
+python3 scripts/provision_runpod.py \
+  --gpu "NVIDIA H100 80GB HBM3" \
+  --ports "22/tcp,8000/http" \
+  --image "runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04" \
+  --tag gate1
+```
+
+Capture the pod IP and the SSH port. Test:
+```bash
+ssh -p $POD_PORT root@$POD_IP 'nvidia-smi -L'
+# Expect: GPU 0: NVIDIA H100 80GB HBM3 (UUID: ...)
+```
+
+### 2. Push env + bootstrap, run Arm A
+
+```bash
+# Local: prep env file with secrets
+cat > /tmp/.gate1_env <<EOF
+export HF_TOKEN=$HF_TOKEN
+EOF
+
+scp -P $POD_PORT /tmp/.gate1_env root@$POD_IP:/root/.gate_env
+scp -P $POD_PORT scripts/gate_pod_bootstrap.sh root@$POD_IP:/workspace/
+
+# Run Arm A in the background (admission ON, max_concurrent=128)
+ssh -p $POD_PORT root@$POD_IP <<'REMOTE'
+nohup bash /workspace/gate_pod_bootstrap.sh \
+  --run-name gate1A_$(date -u +%Y%m%d_%H%M%S) \
+  --config configs/gate1_admission.yaml \
+  --bench-script benchmarks/scripts/benchmark_multi_model.py \
+  --bench-args "--url http://localhost:8000 --models meta-llama/Llama-3.1-8B-Instruct --workload concurrent --concurrency 128,256 --num-requests 400 --output-dir RDIR/benchmarks --seed 42" \
+  > /workspace/bootstrap.console 2>&1 &
+disown
+REMOTE
+```
+
+The pod's 3h self-destruct timer is now armed. To watch progress:
+```bash
+ssh -p $POD_PORT root@$POD_IP 'tail -f /workspace/bootstrap.log'
+```
+
+To abort cleanly (results still get tarred):
+```bash
+ssh -p $POD_PORT root@$POD_IP 'touch /workspace/ABORT'
+```
+
+When you see `=== Bootstrap end: ... status=DONE ===`, rsync the results:
+```bash
+mkdir -p results/gate1_$(date -u +%Y%m%d)/armA
+rsync -avz -e "ssh -p $POD_PORT" \
+  root@$POD_IP:/workspace/gate1A_*_results.tar.gz \
+  results/gate1_$(date -u +%Y%m%d)/armA/
+```
+
+### 3. Repeat for Arm B (admission OFF, same pod)
+
+```bash
+ssh -p $POD_PORT root@$POD_IP <<'REMOTE'
+nohup bash /workspace/gate_pod_bootstrap.sh \
+  --run-name gate1B_$(date -u +%Y%m%d_%H%M%S) \
+  --config configs/gate1_admission_off.yaml \
+  --bench-script benchmarks/scripts/benchmark_multi_model.py \
+  --bench-args "--url http://localhost:8000 --models meta-llama/Llama-3.1-8B-Instruct --workload concurrent --concurrency 128,256 --num-requests 400 --output-dir RDIR/benchmarks --seed 42" \
+  > /workspace/bootstrapB.console 2>&1 &
+disown
+REMOTE
+```
+
+Rsync Arm B results, then **terminate the pod** in the RunPod console.
+
+---
+
+## Reading the result
+
+For each arm, parse `concurrent_c{128,256}_summary.json::ttft_p99_ms` from the rsynced tarballs. Compute:
+
+```
+A_ratio = A_p99(c=256) / A_p99(c=128)
+B_vs_A  = B_p99(c=256) / A_p99(c=256)
+```
+
+### Hypothesis CONFIRMED if:
+- `A_ratio ≤ 2` — admission flattens the cliff
+- `B_vs_A ≥ 4` — uncapped engine hits the cliff hard
+
+→ Write up as Gate 1 PASS, ship the results-driven launch post.
+
+### Hypothesis DISCONFIRMED if:
+- Both arms produce near-identical TTFTs across c=128/256
+
+→ This is **a real negative result, not a plumbing bug**. The c=128→c=256 cliff Phase 1 saw (185ms → 1293ms, 7×) may have been an artifact of the pre-PR-#28 TTFT bug (which timed SSE-frame RTT, sensitive to system load in ways real first-token isn't). Publishable as: "we instrumented honestly and the cliff didn't reproduce; admission's value at this scale is smaller than projected."
+
+### Plumbing sanity (look at this BEFORE deciding which of the above):
+- Arm A `prometheus_dump.txt` should show `infergrid_admission_in_flight` near 128 at c=256 and `infergrid_admission_queue_depth > 0` for sustained periods. If both are 0, admission isn't engaging — file an issue, don't trust the TTFT numbers.
+- Arm B `prometheus_dump.txt` should show `infergrid_admission_in_flight` reaching 256+. If clamped at 100 or 128, the connector limit (PR #34) regressed.
+
+---
+
+## Failure modes
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| `Failed to pre-load model` in `server.log` within 5 min | HF_TOKEN missing or invalid on pod | Re-scp `/root/.gate_env`, restart bootstrap |
+| Engine bring-up exceeds 90 min | OOM during model load OR vLLM v1 incompatibility | Check `/workspace/results/*/engine_logs/`. PR #16's `VLLM_USE_V1=0` should already be set; if OOM, lower `gpu_memory_utilization` in the config |
+| Cost-cap timer fires (`COST CAP HIT` in bootstrap.log) | Script took longer than `MAX_POD_SECS=10800` | Pod will poweroff after touching ABORT. Check what stage the script was in via `phase_*.ts` files in the run dir |
+| Bench reports many 429s | `tenant_defaults` regression. Should be 1024 max_concurrent_requests in the gate1 yaml | `grep tenant_defaults configs/gate1_admission*.yaml` to verify |
+| All 4 ttft_p99 values come back as -1 | Bench summary JSON malformed | Read the bench.log inside the tarball; PR #34's R5 phase-abort may have triggered |
+
+---
+
+## After Gate 1
+
+1. Copy raw artifacts into `results/gate1_$(date)/`.
+2. Write `GATE1_OUTCOME.md` (template: copy gate06_20260419/GATE06_OUTCOME.md, swap numbers).
+3. Update `CORRECTIONS.md` if any new caveats surfaced.
+4. Update `PROGRESS.md` Gate 1 section.
+5. Decide on the launch post (PR #20 DRAFT) — Gate 0 vs Gate 1 framing.


### PR DESCRIPTION
## Summary
Two doc additions, no code changes.

### PROGRESS.md
- PR History table extended through #35.
- New section **\"Pre-Gate-1 Measurement-Honesty Pass\"** narrating the TTFT-v1/v2 + admission-streaming-bypass story — the discovery that turned the planned \$7-10 H100 spend into a likely waste pre-PR-#29.
- New section **\"Gate 1 Readiness\"** with the local-validation checklist + the linear-mock caveat for interpreting H100 results (a flat result on H100 is a real disconfirmation, not a plumbing regression).

### docs/launch/gate1_runbook.md (new)
The doc the user actually opens before spending the \$7-10:
- Pre-flight checklist (6 items, each historically blocked someone).
- 3 launch commands (provision → Arm A → Arm B), explicitly **NOT** bundled into a one-button script per advisor (so a failure in step N doesn't auto-trigger N+1 on the first run).
- \"How to read the result\" — explicit hypothesis CONFIRMED vs DISCONFIRMED vs PLUMBING-REGRESSION rubric.
- Failure-mode → action table for the historical Gate-0 stumbles.

## Test plan
- [x] PROGRESS.md tail renders correctly (table + sections).
- [x] Runbook references match the actual current scripts (`gate_pod_bootstrap.sh`, `gate1_dress_rehearsal.sh`).
- [x] No code changes; CI not affected.