### PR TITLE
docs+configs: 4-week plan, Gate 1.5 runbook, Gate 2-lite scaffold

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # InferGrid — Project Progress
 
-**Last updated:** April 17, 2026
+**Last updated:** April 19, 2026
 **Repository:** [coconut-labs/infergrid](https://github.com/coconut-labs/infergrid)
 **Author:** Shrey Patel (patelshrey77@gmail.com)
 
@@ -26,7 +26,7 @@ InferGrid is a middleware orchestration layer for LLM inference that sits on top
 | Unit tests | 128+ pass (was 124 pre-#29; +4 streaming-admission tests in #29/#32/#33; +1 TCP-fragmentation test in #37) |
 | GPU configurations profiled | 3 (vLLM A100, SGLang A100, vLLM H100) |
 | Live GPU bring-ups | 2 (Gate 0, Gate 0.6 — both on A100-SXM4) |
-| PRs merged | 36 (PRs #1-36 minus #18 closed-superseded) |
+| PRs merged | 39 (PRs #1-39 minus #18 closed-superseded) |
 
 ---
 
@@ -211,30 +211,33 @@ InferGrid is a middleware orchestration layer for LLM inference that sits on top
 
 ## What's Next
 
-### Immediate (Gate 0: ~$4.50)
-- [ ] Provision 1x A100 SXM on RunPod
-- [ ] First-ever GPU execution of `infergrid serve` with 2 models
-- [ ] Verify multi-model demo harness works end-to-end
+(See "Strategic Plan — Post-Gate-1" section above for the current 4-week roadmap. This section preserves the original v0 plan for historical context; it has been superseded by the Little's Law rerun and multi-model contention pivot.)
 
-### Gate 1 (~$15)
-- [ ] 1x H100: admission control TTFT reduction benchmark
-- [ ] 3-model eviction comparison (frequency vs LRU)
-- [ ] Multi-model concurrent throughput on H100
+### Gate 0 — ✅ DONE (2026-04-18, ~$5.76)
+- [x] 1× A100 SXM on RunPod, Llama-8B + Qwen-7B co-load, system PASS
 
-### Gate 2 (~$24)
-- [ ] 2x H100: Llama 70B (TP=2, bf16 original quants)
-- [ ] Heterogeneous serving: 70B + 8B on same cluster
+### Gate 1 — ✅ DONE (2026-04-19, ~$1, PLUMBING PASS / HYPOTHESIS UNDER-POWERED)
+- [x] 1× H100 SXM5, admission ON vs OFF, honest TTFT
+- [x] Plumbing verified; admission engaged cleanly on Arm A
+- Hypothesis verdict deferred to Gate 1.5 (Little's Law caveat — see above)
 
-### Gate 3 (~$16.50 buffer)
-- [ ] Ollama comparison benchmark
-- [ ] Re-runs if data is noisy
-- [ ] Optional: 405B on 4x H100
+### Gate 1.5 — NEXT (~$7-10)
+- [ ] 1× H100 SXM5 SECURE, `--num-requests 4000 --concurrency 64,128,192,256` per arm
+- [ ] Pod-restart between Arm A and Arm B (runbook Section "Gate 1.5 Re-Run")
+- [ ] Three outcome buckets: CONFIRM / robust DISCONFIRM / overload-protection emergence
 
-### After GPU benchmarks
-- [ ] arXiv preprint draft (scheduling cliff + admission control + multi-model)
-- [ ] Demo video recording
+### Gate 2-lite — Wk 2 (~$8)
+- [ ] 1× A100-SXM4, 3 arms (InferGrid vs raw uvicorn vs round-robin)
+- [ ] Llama-3.1-8B + Qwen2.5-7B co-loaded
+- [ ] Two-tenant mixed workload (chat + RAG), 120s sustained
+- [ ] Design doc: `docs/launch/gate2_design.md`
+
+### Launch — Tue 2026-05-12
+- [ ] PyPI `infergrid` placeholder (LAUNCH-BLOCKER, user action)
+- [ ] Cloudflare Worker for waitlist (LAUNCH-BLOCKER, user action)
+- [ ] Quickstart polish
+- [ ] Launch-post reframe (product-led lead, meta-honesty as supporting beat)
 - [ ] HN/Reddit launch
-- [ ] Community signal collection → decide: fundraise or academic path
 
 ---
 
@@ -277,8 +280,10 @@ InferGrid is a middleware orchestration layer for LLM inference that sits on top
 | #35 | Cost-cap 3-layer defense in `gate_pod_bootstrap.sh`: MAX_POD_SECS self-destruct timer, /workspace/ABORT sentinel, phase wall-clock budget | Merged | Apr 19, 2026 |
 | #36 | docs: PROGRESS catch-up + Gate 1 runbook | Merged | Apr 19, 2026 |
 | #37 | shadow-review followups: real cost-cap fix (in-pod poweroff is best-effort, not the primary cap; trap kills timer; CPU smoke), router buffered SSE-frame parser (chunk_count was network-fragmentation-unstable; tokens_out now stable), CORRECTIONS C5, doc fixes | Merged | Apr 19, 2026 |
+| #38 | Gate 1 H100 SXM5 raw results (Arm A+B tarballs, GATE1_OUTCOME.md, ~$1 spend) | Merged | Apr 19, 2026 |
+| #39 | Gate 1 OUTCOME Little's Law caveat: 10s bench wall did not sustain cap pressure; headline 1.04× B/A is short-bench under-power, not DISCONFIRM. Softened "FAIL" → "AMBIGUOUS"; points to `--num-requests 4000` rerun (Gate 1.5) | Merged | Apr 19, 2026 |
 
-PR #18 closed (conflict-dead, superseded by #19). PR #20 open as DRAFT (Gate 0 launch post, ship-gated).
+PR #18 closed (conflict-dead, superseded by #19). PR #20 open as DRAFT (Gate 0 launch post, framing-pending-Gate-1.5).
 
 ---
 
@@ -353,10 +358,85 @@ PR #35 added a 3-layer cost-cap defense to `gate_pod_bootstrap.sh` (self-destruc
 | `bash scripts/gate1_dress_rehearsal.sh` (NUM_REQUESTS=300, SKIP_DISCRIMINATOR=1) | ✅ OVERALL: PASS — Arm A peak in_flight=128 + queue_depth=128, Arm B peak in_flight=256 |
 | Cost-cap hardening in pod bootstrap | ✅ 3-layer defense |
 | H100 SXM5 spot price ≤ $4/hr | Verify before provisioning |
-| User greenlight on $7-10 spend | Pending |
+| User greenlight on $7-10 spend | ✅ granted 2026-04-19, executed |
 
 **Gate 1 launch runbook:** `docs/launch/gate1_runbook.md`.
 
 **Hypothesis discriminator:** Arm A TTFT p99 @ c=256 ≤ 2× Arm A @ c=128, AND Arm B TTFT p99 @ c=256 ≥ 4× Arm A @ c=256.
 
 **Caveat to flag in any analysis:** the dress rehearsal's load-aware mock is *linear* in latency (`base + max(0, excess) * per_excess`). If Gate 1 on H100 reports near-identical TTFTs across arms, that's a **disconfirmation of the hypothesis** — the c=128→c=256 cliff Phase 1 saw (185ms → 1293ms, 7×) may have been measurement artifact (pre-PR-#28 TTFT bug). Either outcome is publishable; don't read a flat result as a plumbing failure.
+
+## Gate 1 — Outcome and Little's Law Caveat (2026-04-19)
+
+Gate 1 shipped on H100 SXM5 SECURE ($2.99/hr, ~$1 total). Both arms completed 800/800 requests with 0 failures. Plumbing passed (admission engaged cleanly on Arm A: 272 queued / 854s total wait; open on Arm B). TTFT honest (post-PR #28/#31). Raw numbers:
+
+| | c=128 p99 | c=256 p99 | Ratio |
+|---|---:|---:|---:|
+| Arm A (cap=128) | 3374 ms | 5964 ms | 1.77× |
+| Arm B (cap=1024) | 3426 ms | 6177 ms | 1.80× |
+| **B/A @ c=256** | — | — | **1.04×** |
+
+The naive read (B/A=1.04×, needed ≥4×) looks like DISCONFIRM. **But post-run Little's Law review caught a methodology bug:** the 10s bench wall per `(arm × concurrency)` cell did not produce sustained cap pressure.
+
+- Arm A c=128: `avg_in_flight ≈ throughput × avg_latency / requests_per_cell ≈ 103` — **below** cap=128.
+- Arm A c=256: avg in-flight ≈ 198 over 10.7s wall — cap engaged in bursts, not steady state.
+- Admission histogram: **only 272 of 801 admissions (~34%) queued at all.** Sustained cap+ load would expect >50% queued at c=256.
+
+The 1.04× ratio is therefore **short-bench under-power, not a real DISCONFIRM**. Published as `results/gate1_20260419/GATE1_OUTCOME.md` with a "Methodology caveat (Little's Law)" section; hypothesis row softened from `FAIL` → `AMBIGUOUS` (PR #39).
+
+**Operational finding:** PR #35's in-pod cost-cap (`poweroff`) does NOT free GPU memory reliably — Arm A's vLLM subprocess leaked 67.9 GiB past `pkill -9`, and `nvidia-smi --gpu-reset` is "Not Supported" on containerized pods. Recovery for Gate 1 Arm B required `runpod.stop_pod + resume_pod` (pod overlay fs wipes `/workspace` on restart — re-scp env + bootstrap). **Gate 1.5 runbook bakes pod-restart between arms explicitly.**
+
+## Strategic Plan — Post-Gate-1 (2026-04-19)
+
+Synthesized from advisor + god-planner review of the Gate 1 Little's Law caveat. Full plan in `.claude/agent-memory-local/god-planner/project_4week_plan_apr19.md`.
+
+**Headline:** Gate 1.5 (this week) + Gate 2-lite (next week) → launch Tue 2026-05-12. Total compute budget $30-40 of $50 cap.
+
+### Gate 1.5 — Powered rerun (next)
+
+Same hypothesis, properly sized. Uses `configs/gate1_admission.yaml` + `configs/gate1_admission_off.yaml` unchanged — statistical power comes from sample size, not config.
+
+**Bench args per arm:**
+```
+--concurrency 64,128,192,256  --num-requests 4000
+```
+
+4 concurrency steps × ~1000 req each = clean Little's Law per cell (vs. 400 total split across 2 cells in Gate 1). c=64 and c=192 added to locate the cliff knee, not just stride past it.
+
+**Budget envelope:** ~$7-10 expected (~2.5h pod-wall @ $2.99/hr). $15 hard ceiling. MAX_POD_SECS=5400 per arm.
+
+**Abort rules:**
+- c=64 cell > 18 min → drop c=192 and rerun, keep 3 steps only.
+- Engine bring-up > 15 min with no log progress → `touch /workspace/ABORT`.
+- `infergrid_admission_in_flight` stuck at 0 during c=256 → admission regression, abort.
+- `/workspace/COST_CAP_HIT` appears → manual RunPod-console terminate.
+
+**Pod-restart between arms baked in** (see Gate 1.5 Re-Run section of runbook). Arm A ends → rsync → RunPod.stop_pod + resume_pod → re-scp env + bootstrap → Arm B. Prevents Arm B CUDA-OOM from leaked Arm A context.
+
+**Outcome buckets:**
+1. **CONFIRM** — Arm A flattens, Arm B explodes. Pitch holds.
+2. **Robust DISCONFIRM** — both arms explode similarly at steady state. Admission doesn't help tail TTFT on this hardware/workload. Pivot pitch.
+3. **Overload-protection emergence** — Arm B queues to OOM / 500s; Arm A degrades gracefully. Different, arguably stronger narrative.
+
+### Gate 2-lite — Multi-model contention (the actual InferGrid differentiator)
+
+Gate 0/0.5/0.6/1 all ran single-model under varied admission. InferGrid's actual differentiator is **multi-model orchestration on 1-4 GPUs without K8s** — never benchmarked. Design doc: `docs/launch/gate2_design.md`.
+
+**3 arms on 1× A100-SXM4** (reuse Gate 0.6 bootstrap):
+- Arm 1: InferGrid (Llama-3.1-8B + Qwen2.5-7B co-loaded, admission ON, WorkloadRouter mediates). Config: `configs/gate2_multi_tenant.yaml`.
+- Arm 2: Raw uvicorn serving Llama-3.1-8B only (baseline: what do users get without middleware?).
+- Arm 3: Round-robin WorkloadRouter without admission or KV lifecycle (baseline: what does the InferGrid "thin proxy" part contribute vs full stack?). Config: `configs/gate2_round_robin.yaml`.
+
+**Workload:** two-tenant mixed (chat-style short prompts + RAG-style 8K-prompt bursts), 120s sustained wall. New bench script: `benchmarks/scripts/benchmark_two_tenant.py` (scaffold in this PR; implementation next session).
+
+**Success criterion:** per-tenant p99 TTFT within 1.5× of solo-engine baseline AND no OOMs. Failure criterion: InferGrid ≈ round-robin ≈ raw uvicorn → thin proxy isn't load-bearing, rethink pitch.
+
+**Budget:** $8 ceiling on A100-SXM4 @ ~$1.89/hr × ~4h.
+
+### Week 3-4 — Launch prep
+
+- **LAUNCH-BLOCKER #1 (user):** PyPI `infergrid` placeholder upload (squat protection).
+- **LAUNCH-BLOCKER #2 (user):** Cloudflare Worker deploy for waitlist (`window.WAITLIST_API = ''` in landing page line 447).
+- Quickstart polish (install → 2 models → request in <5 min).
+- Launch-post framing: product-led title ("Run two LLMs on one A100 without K8s") with meta-honesty (shadow-review catches) as supporting beat. PR #20 draft needs reframe after Gate 1.5 lands.
+- **Launch target: Tuesday 2026-05-12** (HN timing).

--- a/configs/gate2_multi_tenant.yaml
+++ b/configs/gate2_multi_tenant.yaml
@@ -1,0 +1,43 @@
+# Gate 2-lite Arm 1 — InferGrid full stack with two co-loaded models.
+# Llama-3.1-8B + Qwen2.5-7B on a single A100-SXM4 80GB. Admission ON,
+# per-tenant budget enforced. WorkloadRouter mediates which engine
+# handles which model.
+#
+# See docs/launch/gate2_design.md for the full hypothesis and arm contract.
+
+host: 0.0.0.0
+port: 8000
+gpu_budget_fraction: 0.92
+
+# Tighter than Gate 1's 128: two engines share the GPU compute pipeline,
+# so the per-engine effective concurrency cap should be ~half. 96 leaves
+# headroom for short-prompt chat tenant bursts without starving RAG.
+max_concurrent: 96
+admission_queue_size: 1024
+engine_start_timeout_s: 600   # 10 min — two models load in parallel
+log_level: INFO
+
+# Two-tenant workload: chat (high-RPS short prompts) + RAG (low-RPS long
+# prompts with bursts). 48-each splits the budget evenly; if a tenant
+# wants more it must be explicitly granted via per-tenant override.
+tenant_defaults:
+  max_concurrent_requests: 48
+  rate_limit_rpm: 30000
+
+models:
+  - model_id: "meta-llama/Llama-3.1-8B-Instruct"
+    short_name: "llama31-8b"
+    engine: "vllm"
+    dtype: "bfloat16"
+    # 0.40+0.40=0.80 leaves 0.20 for KV cache + activations on 80GB A100.
+    # PR #15 review flagged 0.42 as "tight"; 0.40 each is the safer point.
+    gpu_memory_utilization: 0.40
+    max_model_len: 8192   # bumped from Gate 1's 4096 for the RAG tenant's 8K prompts
+    tensor_parallel_size: 1
+  - model_id: "Qwen/Qwen2.5-7B-Instruct"
+    short_name: "qwen25-7b"
+    engine: "vllm"
+    dtype: "bfloat16"
+    gpu_memory_utilization: 0.40
+    max_model_len: 8192
+    tensor_parallel_size: 1

--- a/configs/gate2_round_robin.yaml
+++ b/configs/gate2_round_robin.yaml
@@ -1,0 +1,41 @@
+# Gate 2-lite Arm 3 — Thin proxy baseline. Same two co-loaded models
+# but admission and per-tenant budget are effectively OFF. This isolates
+# what the WorkloadRouter + AdmissionController + TenantManager STACK
+# contributes vs just multiplexing two engines on one GPU.
+#
+# If Arm 1 (gate2_multi_tenant.yaml) ≈ Arm 3 on all metrics, the
+# scheduling-intelligence layer isn't load-bearing for multi-model and
+# the launch pitch needs rethinking.
+#
+# See docs/launch/gate2_design.md.
+
+host: 0.0.0.0
+port: 8000
+gpu_budget_fraction: 0.92
+
+# 9999 = effectively unbounded; whatever the engines can take.
+max_concurrent: 9999
+admission_queue_size: 1
+engine_start_timeout_s: 600
+log_level: INFO
+
+# Per-tenant budget also effectively OFF.
+tenant_defaults:
+  max_concurrent_requests: 9999
+  rate_limit_rpm: 999999
+
+models:
+  - model_id: "meta-llama/Llama-3.1-8B-Instruct"
+    short_name: "llama31-8b"
+    engine: "vllm"
+    dtype: "bfloat16"
+    gpu_memory_utilization: 0.40
+    max_model_len: 8192
+    tensor_parallel_size: 1
+  - model_id: "Qwen/Qwen2.5-7B-Instruct"
+    short_name: "qwen25-7b"
+    engine: "vllm"
+    dtype: "bfloat16"
+    gpu_memory_utilization: 0.40
+    max_model_len: 8192
+    tensor_parallel_size: 1

--- a/docs/launch/gate1_runbook.md
+++ b/docs/launch/gate1_runbook.md
@@ -157,3 +157,136 @@ B_vs_A  = B_p99(c=256) / A_p99(c=256)
 3. Update `CORRECTIONS.md` if any new caveats surfaced.
 4. Update `PROGRESS.md` Gate 1 section.
 5. Decide on the launch post (PR #20 DRAFT) — Gate 0 vs Gate 1 framing.
+
+---
+
+## Gate 1.5 Re-Run — Powered version of Gate 1 (added 2026-04-19)
+
+**Why:** Gate 1 ran ~10s wall per `(arm × concurrency)` cell. By Little's Law, Arm A c=128 only averaged ~103 in-flight (BELOW cap=128), and only 272/801 admits queued (~34%). The headline B/A=1.04× was short-bench under-power, **not** a real DISCONFIRM. See `results/gate1_20260419/GATE1_OUTCOME.md` "Methodology caveat" section. Gate 1.5 re-runs the same hypothesis with 10× the sample size to actually exercise sustained cap pressure.
+
+**Hardware:** 1× NVIDIA H100 SXM5 80GB on RunPod (SECURE pod), $2.99/hr.
+**Wall:** ~2.5h expected.
+**Cost:** ~$7-10 expected; **$15 hard ceiling**.
+**main tip required:** `99935b3` or later (PR #39 caveat in OUTCOME doc).
+
+### Pre-flight delta vs Gate 1
+
+Same pre-flight as Gate 1 above, plus:
+
+7. **Confirm Gate 1.5 budget posture.** $15 hard ceiling, calendar alarm at 2.5h.
+8. **Decide Arm A concurrency steps before launch.** Default plan: `64,128,192,256`. If c=64 cell takes >18 min in Arm A, downgrade to `64,128,256` only and rerun (see "Abort-early rules" below).
+
+### Launch (4 commands — one extra for the inter-arm pod restart)
+
+#### 1. Provision the pod (same as Gate 1, with `MAX_POD_SECS=5400`)
+
+```bash
+cd ~/Personal\ Projects/infergrid_implementation_poc/infergrid
+python3 scripts/provision_runpod.py \
+  --gpu "NVIDIA H100 80GB HBM3" \
+  --ports "22/tcp,8000/http" \
+  --image "runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04" \
+  --tag gate1_5
+```
+
+Capture pod IP, SSH port, and **pod_id** (you will need pod_id for the inter-arm restart).
+
+#### 2. Push env + bootstrap, run Arm A (note `MAX_POD_SECS=5400`)
+
+```bash
+cat > /tmp/.gate1_5_env <<EOF
+export HF_TOKEN=$HF_TOKEN
+export MAX_POD_SECS=5400
+EOF
+
+scp -P $POD_PORT /tmp/.gate1_5_env root@$POD_IP:/root/.gate_env
+scp -P $POD_PORT scripts/gate_pod_bootstrap.sh root@$POD_IP:/workspace/
+
+ssh -p $POD_PORT root@$POD_IP <<'REMOTE'
+nohup bash /workspace/gate_pod_bootstrap.sh \
+  --run-name gate1_5A_$(date -u +%Y%m%d_%H%M%S) \
+  --config configs/gate1_admission.yaml \
+  --bench-script benchmarks/scripts/benchmark_multi_model.py \
+  --bench-args "--url http://localhost:8000 --models meta-llama/Llama-3.1-8B-Instruct --workload concurrent --concurrency 64,128,192,256 --num-requests 4000 --output-dir RDIR/benchmarks --seed 42" \
+  > /workspace/bootstrap.console 2>&1 &
+disown
+REMOTE
+```
+
+When `=== Bootstrap end: ... status=DONE ===`, rsync:
+
+```bash
+mkdir -p results/gate1_5_$(date -u +%Y%m%d)/armA
+rsync -avz -e "ssh -p $POD_PORT" \
+  root@$POD_IP:/workspace/gate1_5A_*_results.tar.gz \
+  results/gate1_5_$(date -u +%Y%m%d)/armA/
+```
+
+#### 3. **CRITICAL — restart the pod between arms** (this is what Gate 1 missed)
+
+Gate 1 documented (`GATE1_OUTCOME.md` line 90) that Arm A's vLLM subprocess leaked 67.9 GiB of GPU memory past `pkill -9`, and `nvidia-smi --gpu-reset` is "Not Supported" on containerized pods. Arm B then CUDA-OOM'd on engine pre-load. **Recovery required `runpod.stop_pod + resume_pod`**. Bake this in:
+
+```bash
+python3 - <<EOF
+import runpod, os
+runpod.api_key = os.environ["RUNPOD_API_KEY"]
+runpod.stop_pod("$POD_ID")
+import time; time.sleep(45)   # wait for stop to settle
+runpod.resume_pod("$POD_ID")
+EOF
+```
+
+Wait ~90s for SSH to come back. **The pod's `/workspace` is on container overlay fs — contents are LOST on stop+resume.** Re-scp env + bootstrap:
+
+```bash
+# SSH port may have changed after resume — re-fetch from RunPod console
+export POD_PORT=$NEW_PORT
+
+scp -P $POD_PORT /tmp/.gate1_5_env root@$POD_IP:/root/.gate_env
+scp -P $POD_PORT scripts/gate_pod_bootstrap.sh root@$POD_IP:/workspace/
+
+# Confirm GPU clean before launching Arm B
+ssh -p $POD_PORT root@$POD_IP 'nvidia-smi --query-gpu=memory.used --format=csv,noheader'
+# Expect: 0 MiB
+```
+
+#### 4. Run Arm B (admission OFF, fresh GPU state)
+
+```bash
+ssh -p $POD_PORT root@$POD_IP <<'REMOTE'
+nohup bash /workspace/gate_pod_bootstrap.sh \
+  --run-name gate1_5B_$(date -u +%Y%m%d_%H%M%S) \
+  --config configs/gate1_admission_off.yaml \
+  --bench-script benchmarks/scripts/benchmark_multi_model.py \
+  --bench-args "--url http://localhost:8000 --models meta-llama/Llama-3.1-8B-Instruct --workload concurrent --concurrency 64,128,192,256 --num-requests 4000 --output-dir RDIR/benchmarks --seed 42" \
+  > /workspace/bootstrapB.console 2>&1 &
+disown
+REMOTE
+```
+
+Rsync Arm B results, then **terminate the pod** in the RunPod console.
+
+### Abort-early rules (Gate 1.5-specific)
+
+| Trigger | Action |
+|---|---|
+| c=64 cell takes > 18 min in Arm A | Abort, drop c=192 from the args, restart Arm A with `64,128,256` only |
+| Engine bring-up > 15 min, no log progress | `ssh pod 'touch /workspace/ABORT'` |
+| `infergrid_admission_in_flight` stuck at 0 during c=256 (Arm A) | Admission isn't engaging — file an issue, do not run Arm B |
+| Arm A wall-clock projected > 75 min | Abort — hypothesis isn't admission-cliff-shaped at this concurrency profile |
+| `/workspace/COST_CAP_HIT` appears | Manually terminate from RunPod console immediately |
+
+### Reading the Gate 1.5 result
+
+Three outcome buckets, all publishable:
+
+1. **CONFIRM** — `A_p99(c=256) ≤ 2 × A_p99(c=128)` AND `B_p99(c=256) ≥ 4 × A_p99(c=256)`. Original hypothesis survives. Ship the launch post on this number.
+2. **Robust DISCONFIRM** — both arms produce near-identical TTFTs across all concurrency steps even at sustained pressure. Admission genuinely doesn't help tail TTFT on this workload shape. Pivot pitch to multi-model arbitration (Gate 2-lite) or queue-wait-spike avoidance.
+3. **Overload-protection emergence** — Arm B's vLLM degenerates (queues to OOM, returns 500s, or TTFT explodes >10×) at some concurrency level; Arm A stays graceful. This is a different and arguably stronger story than "Arm A has lower p99": "we prevent the engine from melting under load."
+
+### After Gate 1.5
+
+1. Copy artifacts into `results/gate1_5_$(date)/`.
+2. Write `GATE1_5_OUTCOME.md` with Little's Law analysis baked in (avg in-flight per cell, queue-engagement %).
+3. Update `PROGRESS.md` Gate 1.5 section + the strategic plan.
+4. Decide launch-post framing per outcome bucket above.

--- a/docs/launch/gate2_design.md
+++ b/docs/launch/gate2_design.md
@@ -1,0 +1,97 @@
+# Gate 2-lite — Multi-Model Contention Design Doc
+
+**Date:** 2026-04-19
+**Status:** SCAFFOLD (configs + design committed; bench script + runbook to follow next session)
+**Owner:** Shrey Patel
+**Budget:** ~$8 ceiling on 1× A100-SXM4 @ ~$1.89/hr × ~4h
+
+---
+
+## Why this exists
+
+Gates 0, 0.5, 0.6, and 1 all measured InferGrid as a **single-model + admission control** thing. But the actual InferGrid pitch is **lightweight multi-model orchestration on 1-4 GPUs without K8s** (Gap #2 in `docs/inference_orchestration_gaps_report.md`). That has never been benchmarked. Without Gate 2-lite, the launch post is anchored on a side feature, not the differentiator.
+
+## Hypothesis
+
+When two models are co-loaded on a single 80GB GPU under mixed two-tenant workload (chat short-prompt + RAG 8K-prompt), InferGrid keeps per-tenant p99 TTFT within **1.5× of solo-engine baseline**, while raw uvicorn fronting two `vllm serve` processes either OOMs or shows >2× per-tenant degradation, and a thin round-robin proxy with no admission/lifecycle logic falls between the two.
+
+If this holds: the WorkloadRouter + AdmissionController + TenantManager stack is doing real work; the pitch is justified.
+If both baselines tie InferGrid: the thin proxy isn't load-bearing and the pitch needs rethinking before launch.
+
+## Arms
+
+### Arm 1 — InferGrid full stack
+- Config: `configs/gate2_multi_tenant.yaml`
+- Llama-3.1-8B + Qwen2.5-7B co-loaded, `gpu_memory_utilization: 0.40` each (0.80 total + 0.20 KV/activation headroom on 80GB A100, per PR #15 review notes).
+- Admission ON (`max_concurrent: 96` — tighter than Gate 1's 128 because two engines share the GPU compute pipeline).
+- Per-tenant budget enforced (`tenant_defaults.max_concurrent_requests: 48`).
+- WorkloadRouter mediates which engine handles which model.
+
+### Arm 2 — Raw uvicorn (vLLM single-model, no middleware)
+- No InferGrid binary. Run `python -m vllm.entrypoints.openai.api_server` directly with Llama-3.1-8B only on port 8000.
+- Bench targets only the Llama tenant; the Qwen tenant has nowhere to go.
+- This is the "what does a user get with no orchestration" baseline. We expect Arm 2 to look great on solo Llama latency but fail-by-omission on multi-model — so the pitch is "Arm 2 cannot serve both models at all on 1 GPU; Arm 1 can".
+- **Failure mode this arm tests:** if Arm 2 outperforms Arm 1 on the Llama tenant by >2×, InferGrid's overhead is unacceptable.
+
+### Arm 3 — Round-robin thin proxy
+- Config: `configs/gate2_round_robin.yaml`
+- Same two models co-loaded, but `max_concurrent: 9999` (admission effectively OFF), `tenant_defaults.max_concurrent_requests: 9999` (per-tenant budget OFF), no priority queueing.
+- Routes to whichever engine the request asks for, no scheduling intelligence.
+- This is the "what if InferGrid were just a multiplexer" baseline.
+- **Failure mode this arm tests:** if Arm 3 ≈ Arm 1, the WorkloadRouter + AdmissionController + TenantManager stack isn't load-bearing — the value is purely "we co-load two engines and proxy", which is a 50-line script, not a product.
+
+## Workload
+
+Two tenants, both streaming, run in parallel for 120 seconds sustained per arm:
+
+- **Tenant A (chat):** Llama-3.1-8B target. Short prompts (~256 tokens), short outputs (~128 tokens), 8 RPS sustained.
+- **Tenant B (RAG):** Qwen2.5-7B target. Long prompts (~8000 tokens, near `max_model_len=4096` boundary — will need to bump max_model_len to 8192 for both models, see config), short outputs (~256 tokens), 2 RPS sustained but with bursts up to 6 RPS.
+
+120 seconds × 8 RPS = 960 chat requests + 120 × 2 RPS ≈ 240 RAG requests per arm. Long enough for steady-state Little's Law math (avoid the Gate 1 mistake).
+
+**Why this shape:** chat tenant is the "easy" workload that vLLM handles well. RAG tenant is the "hard" workload that should make vLLM's KV cache thrash, contending with the chat tenant for GPU time. This is where admission control and per-tenant fairness should matter.
+
+## Success / failure criteria
+
+**SUCCESS (pitch validated):**
+- Arm 1 per-tenant p99 TTFT within 1.5× of Arm 2's solo-Llama baseline AND 1.5× of a solo-Qwen baseline (run separately, or estimate from Gate 0.6's per-model numbers).
+- Arm 1 has zero OOMs, zero 5xx.
+- Arm 3 shows EITHER OOM under burst OR >2× per-tenant TTFT degradation vs Arm 1 on the RAG tenant during burst.
+
+**FAILURE (pitch broken, rethink before launch):**
+- Arm 1 ≈ Arm 3 on all metrics → admission + tenant management isn't load-bearing in the multi-model regime either.
+- Arm 1's Llama p99 > 2× Arm 2's Llama p99 → the multi-model overhead is too high; users would prefer to pin one model per GPU.
+
+**AMBIGUOUS (publishable, but not as the headline):**
+- Arm 1 wins on burst handling but loses on solo latency → pitch becomes "InferGrid for spiky multi-tenant, raw vLLM for steady-state single-model". Narrower but still real.
+
+## Bench script
+
+New: `benchmarks/scripts/benchmark_two_tenant.py` (to be written next session). Skeleton requirements:
+
+- Two `aiohttp.ClientSession` instances, one per tenant, with proper `TCPConnector(limit=256, limit_per_host=256)` (Gate 1 lesson PR #34).
+- Per-tenant Poisson arrivals at the target RPS, with a configurable burst window for tenant B.
+- 120s sustained wall, fixed seed (42).
+- Outputs per-tenant CSV (`tenant_chat.csv`, `tenant_rag.csv`) with `req_id, ts_submit, ttft_ms, total_latency_ms, tokens_out`.
+- Reuses the buffered SSE-frame parser from `benchmark_multi_model.py` (PR #37) for stable `tokens_out`.
+- Workload-aware: `--workload two_tenant` so the existing single-model gate (PR #34 R5) doesn't reject it.
+
+## Cost ceiling
+
+A100-SXM4 SECURE on RunPod: ~$1.89/hr × ~4h = ~$7.56. **$8 hard ceiling.** Engine bring-up for two co-loaded models: ~10 min (two HF downloads in parallel, ~10 GB total). Each arm: ~3 min bench wall + ~5 min teardown. Total per arm: ~20 min. Three arms: ~60 min. Add 60 min for engine bring-up + iteration → ~2h. Buffer to $8 covers unexpected reruns.
+
+`MAX_POD_SECS=14400` (4h) per pod spin. Pod-restart between Arm 1 and Arm 3 is **not** required (both use InferGrid's own server which cleans up on shutdown), but recommended between Arm 2 and Arm 1/3 (Arm 2 uses raw vLLM; same memory-leak risk as Gate 1 documented).
+
+## What this PR ships
+
+- This design doc.
+- `configs/gate2_multi_tenant.yaml` (Arm 1).
+- `configs/gate2_round_robin.yaml` (Arm 3).
+- Arm 2 needs no InferGrid config (it bypasses the binary entirely).
+
+## What lands next session
+
+- `benchmarks/scripts/benchmark_two_tenant.py`
+- `docs/launch/gate2_runbook.md` (wraps the launch + abort-rules + reading-the-result loop)
+- Gate 2-lite dress rehearsal script (CPU-only mock, like `gate1_dress_rehearsal.sh`)
+- Runbook execution after Gate 1.5 lands.

--- a/research_roadmap.md
+++ b/research_roadmap.md
@@ -1,6 +1,6 @@
 # Research Roadmap: InferGrid
 
-> **Status update (April 2026):** Phase 1 profiling is complete. Several original hypotheses were refuted by data — see below. The thesis has been updated to reflect measured reality. See [Phase 1 Findings](docs/phase1_findings.md) for full results.
+> **Status update (April 19, 2026):** Phase 1 profiling complete. Gate 0 (system bring-up) and Gate 1 (admission control hypothesis) shipped. **The Phase 1 "scheduling cliff" claim was measured with a broken TTFT path** (PR #28/#31 fixed it: pre-fix bench timed SSE first-frame RTT, not first non-empty token). Gate 1 on H100 SXM5 with honest TTFT did NOT reproduce the 7× cliff at c=128→c=256 — but Gate 1's bench wall (10s/cell) was too short to test the hypothesis under sustained cap pressure (Little's Law, see `results/gate1_20260419/GATE1_OUTCOME.md`). **Gate 1.5 (rerun with `--num-requests 4000`) is the next cliff-test**; Gate 2-lite (multi-model contention) is the next test of the actual InferGrid pitch. See `PROGRESS.md` "Strategic Plan" section for the 4-week roadmap.
 
 ## Revised Thesis: Middleware-Level Admission Control and Multi-Model Lifecycle for LLM Inference
 
@@ -8,16 +8,18 @@
 
 | Original Claim | Measured Reality | Status |
 |----------------|-----------------|--------|
-| vLLM trails SGLang by 29% | <5% throughput gap (engines converged) | **Refuted** |
+| vLLM trails SGLang by 29% | <5% throughput gap (engines converged on throughput; SGLang still 2.2× better TTFT at c=256) | **Refuted on throughput** |
 | 81.6% compound GPU waste | GPU utilization 95-99% across all configs | **Refuted** |
 | Middleware scheduling reduces TTFT 50-70% | HTTP proxy cannot modify engine-internal scheduling | **Refuted** |
-| Scheduling cliff at high concurrency | c=128→c=256: +2% throughput, +1434% TTFT | **Confirmed** |
-| SGLang better at saturation | SGLang 2.2x better TTFT at c=256 vs vLLM | **Confirmed (new finding)** |
-| Cliff is hardware-independent | Same pattern on A100 SXM and H100 SXM | **Confirmed** |
+| Scheduling cliff at high concurrency | Phase 1's "+2% throughput, +1434% TTFT" used the pre-#28 broken TTFT (timed SSE first-frame RTT, not first token). Gate 1 with honest TTFT on H100 SXM5: c=128→c=256 ratio = 1.77× (NOT 14.34×). | **Phase 1 cliff number invalid; Gate 1 ran short bench, Gate 1.5 (4000 req) is the next test** |
+| SGLang better at saturation | SGLang 2.2× better TTFT at c=256 vs vLLM (Phase 1; not re-tested on honest TTFT yet) | **Confirmed (Phase 1, with TTFT caveat)** |
+| Cliff is hardware-independent | Pattern needs re-validation post-Gate-1.5 | **Pending re-test** |
 
-### Updated Problem Statement
+### Updated Problem Statement (post-Gate-1, 2026-04-19)
 
-The scheduling cliff is real, hardware-independent, and unmanaged by any existing tool. At concurrency >128 on an 80GB GPU, inference engines enter a regime where doubling load yields marginal throughput (+2%) at massive latency cost (+1434% TTFT). No existing system prevents requests from entering this regime.
+The Phase 1 "+1434% TTFT" cliff number was a measurement artifact (broken TTFT, fixed in PR #28/#31). Gate 1 with honest TTFT on H100 SXM5 saw a 1.77× ratio at c=128→c=256, not 14×. Whether the cliff is real *under sustained cap pressure* is the open question Gate 1.5 will answer (Gate 1's 10s/cell wall was Little's-Law under-powered; rerun with `--num-requests 4000` is queued).
+
+Independent of the cliff question, no lightweight tool provides intelligent multi-model lifecycle management (load, evict, hot-swap based on traffic patterns) on bare metal without Kubernetes. Gate 2-lite tests this — the actual InferGrid differentiator that has never been benchmarked.
 
 Separately, no lightweight tool provides intelligent multi-model lifecycle management (load, evict, hot-swap based on traffic patterns) on bare metal without Kubernetes.
 
@@ -36,15 +38,19 @@ Three components, one runtime:
 - Benchmark 3: Model switch latency and eviction policy effectiveness
 - Benchmark 4: InferGrid proxy overhead measurement
 
-### Timeline (revised)
+### Timeline (revised 2026-04-19)
 
 | Phase | Activity | Status |
 |-------|----------|--------|
-| Phase 1 | Profile vLLM/SGLang on A100/H100 | **Complete** |
-| Phase 2 | Build WorkloadRouter + admission control | **Complete** |
-| Phase 3 | Multi-model GPU benchmark | **Next** |
-| Phase 4 | arXiv preprint | Weeks 3-4 |
-| Phase 5 | OSS launch (HN, Reddit) | Week 4 |
+| Phase 1 | Profile vLLM/SGLang on A100/H100 | **Complete** (TTFT numbers under-counted by ~30ms, see CORRECTIONS C2) |
+| Phase 2 | Build WorkloadRouter + admission control + per-tenant budget | **Complete** |
+| Gate 0 | First live GPU bring-up (system PASS) | **Complete** ($5.76, 2026-04-18) |
+| Gate 0.5 | Bench harness resilience | **Complete** (local) |
+| Gate 0.6 | Real-vLLM bench validation | **Complete** ($3.17, 2026-04-19) |
+| Gate 1 | Admission ON vs OFF, single model, H100 | **Complete but under-powered** ($1, 2026-04-19, see GATE1_OUTCOME.md) |
+| Gate 1.5 | Powered rerun (`--num-requests 4000`) | **Next** ($7-10) |
+| Gate 2-lite | Multi-model contention (3-arm: InferGrid vs uvicorn vs round-robin) | Wk 2 ($8) |
+| Launch | OSS launch (HN, Reddit) | **Tue 2026-05-12** |
 
 ### Target
 


### PR DESCRIPTION
## Summary
Operationalizes the post-Gate-1 strategic plan synthesized by advisor + god-planner. Single PR for the doc set + Arm 1/Arm 3 configs so the plan ships as a unit.

- **PROGRESS.md**: Gate 1 outcome with Little's Law caveat (avg in-flight ≈103 below cap=128; 272/801 admits queued); Strategic Plan section with Gate 1.5 (~\$7-10) → Gate 2-lite (~\$8) → launch Tue 2026-05-12; What's Next rewritten with concrete checkboxes per gate.
- **docs/launch/gate1_runbook.md**: New "Gate 1.5 Re-Run" section with 4 launch commands (extra one for the RunPod stop_pod/resume_pod between arms, baked in because Gate 1 documented `pkill -9` doesn't free GPU memory and `nvidia-smi --gpu-reset` is "Not Supported" on containers). Abort-early rules table. Three outcome buckets all publishable.
- **docs/launch/gate2_design.md (NEW)**: Hypothesis (per-tenant p99 within 1.5× of solo baseline), 3-arm contract, two-tenant workload (chat + RAG), success/failure criteria, \$8 budget. Bench script deferred to next session.
- **configs/gate2_multi_tenant.yaml (NEW)**: Arm 1 — InferGrid full stack, Llama-8B + Qwen-7B co-loaded, 0.40 GPU mem util each, max_concurrent 96, tenant budget 48 each.
- **configs/gate2_round_robin.yaml (NEW)**: Arm 3 — same models but admission + tenant budget effectively OFF, isolates what the scheduling stack contributes vs mere multiplexing.
- **research_roadmap.md**: Phase 1 "+1434% TTFT" cliff now flagged as measurement-artifact; Gate 1's 1.77× honest-TTFT ratio surfaced; timeline updated with Gates 0/0.5/0.6/1/1.5/2-lite + launch date.

## Why one PR (not three)
Docs are atomic — splitting creates a window where PROGRESS.md says "Gate 1.5" but no runbook exists. Configs paired with their design doc means a reviewer sees the full scaffold contract.

## What this PR does NOT change
No code (no src/, no tests/). No bootstrap or orchestration script changes — pod-restart between arms is operator instructions in the runbook, not a script change, to keep the trap+bundle behavior stable (no risk of regressing PR #34's fixes).

## Test plan
- [x] PROGRESS.md PR table includes #38 + #39
- [x] Gate 1.5 runbook references the Gate 1 GATE1_OUTCOME.md operational finding
- [x] Both gate2 YAMLs use 0.40 gpu_memory_utilization (PR #15 review note)
- [x] gate2_design.md success criteria are pre-committed before any A100 spin
- [ ] Future: write benchmarks/scripts/benchmark_two_tenant.py + Gate 2-lite dress rehearsal
- [ ] Future: run Gate 1.5 on H100 SXM5 per the new runbook section