### PR TITLE
feat(tenant): DRR-priority admission via tenant active-request deficit

### DIFF
--- a/src/infergrid/common/config.py
+++ b/src/infergrid/common/config.py
@@ -62,7 +62,15 @@ class TenantDefaults:
     max_concurrent_requests: int = 64
     rate_limit_rpm: int = 600  # requests per minute
     max_gpu_memory_gb: float = 40.0
-    priority: int = 1  # higher = more priority
+    # Lower = served first (matches AdmissionController + BUCKET_PRIORITY).
+    # Default 1 = medium tier. Static priority for tenant tiers; combined
+    # with active_requests deficit when scheduling="drr".
+    priority: int = 1
+    # Admission scheduling discipline:
+    #   "fifo" — current behavior, prioritize by request length bucket only
+    #   "drr"  — deficit round-robin: tenants with more active requests
+    #            wait behind quieter tenants (TenantRecord.priority_score)
+    scheduling: str = "fifo"
 
 
 @dataclass

--- a/src/infergrid/router/router.py
+++ b/src/infergrid/router/router.py
@@ -406,10 +406,21 @@ class WorkloadRouter:
                 f"Tenant {tenant_id!r} has exceeded its request budget"
             )
 
-        # Determine admission priority from request length bucket
+        # Determine admission priority. Two disciplines:
+        #   "fifo" (default) — length-bucketed priority only (short < long)
+        #   "drr" — deficit round-robin: tenant with more in-flight requests
+        #     waits behind quieter tenants. priority_score() already counts
+        #     this request (try_acquire above incremented active_requests).
         max_tokens = payload.get("max_tokens", 256)
         bucket = classify_request_length(max_tokens)
-        priority = BUCKET_PRIORITY.get(bucket, 1)
+        bucket_priority = BUCKET_PRIORITY.get(bucket, 1)
+        if self.config.tenant_defaults.scheduling == "drr":
+            tenant_record = await self.tenant_manager.get_tenant(tenant_id)
+            tenant_score = tenant_record.priority_score() if tenant_record else 1
+            # Tenant deficit dominates; bucket breaks ties within tenant tier.
+            priority = tenant_score * 100 + bucket_priority
+        else:
+            priority = bucket_priority
 
         # Admission control -- wait for engine capacity
         admitted = await self.admission_controller.acquire(

--- a/src/infergrid/tenant/manager.py
+++ b/src/infergrid/tenant/manager.py
@@ -91,6 +91,25 @@ class TenantRecord:
         async with self._lock:
             self.usage.active_requests = max(0, self.usage.active_requests - 1)
 
+    def priority_score(self) -> int:
+        """Deficit-Round-Robin priority for the AdmissionController.
+
+        Lower returned value = served first (matches AdmissionController and
+        BUCKET_PRIORITY convention). A tenant that has hogged more in-flight
+        slots gets a higher score and waits behind a quieter tenant. Ties
+        broken by FIFO sequence inside the AdmissionController.
+
+        Formula: ``active_requests * 10 + budget.priority``.
+        - ``active_requests * 10`` is the deficit weight: each in-flight
+          request pushes the tenant's next request 10 priority "rungs" back.
+        - ``budget.priority`` is the per-tenant baseline (lower is more
+          important; default 1). Use it for static tenant tiers.
+
+        Read-only — does not mutate state, no lock required. The
+        ``active_requests`` int read is atomic in CPython.
+        """
+        return self.usage.active_requests * 10 + self.budget.priority
+
     async def record_completion(
         self,
         tokens_in: int = 0,

--- a/tests/unit/test_tenant_priority.py
+++ b/tests/unit/test_tenant_priority.py
@@ -1,0 +1,199 @@
+"""Unit tests for tenant DRR priority admission.
+
+Covers TenantRecord.priority_score() formula and the wired-through behavior
+where the AdmissionController uses tenant deficit to rescue starved tenants
+under contention. See `docs/launch/gate2_fairness_runbook.md` for the
+end-to-end experiment this enables.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from infergrid.router.admission import AdmissionController
+from infergrid.tenant.manager import TenantBudget, TenantRecord
+
+
+# ---------------------------------------------------------------------------
+# priority_score formula
+# ---------------------------------------------------------------------------
+
+
+class TestPriorityScore:
+    """Tests for the deficit-weighted priority formula."""
+
+    def test_idle_tenant_uses_budget_priority(self) -> None:
+        record = TenantRecord("alice", TenantBudget(priority=1))
+        assert record.priority_score() == 1
+
+    def test_one_active_request_adds_ten(self) -> None:
+        record = TenantRecord("bob", TenantBudget(priority=1))
+        record.usage.active_requests = 1
+        assert record.priority_score() == 11
+
+    def test_many_active_requests_dominates_over_budget_tier(self) -> None:
+        flooder = TenantRecord("flooder", TenantBudget(priority=1))
+        flooder.usage.active_requests = 5
+        # Even a higher-priority tier (priority=2) tenant still wins if quiet.
+        quiet_lower_tier = TenantRecord("quiet", TenantBudget(priority=2))
+        quiet_lower_tier.usage.active_requests = 0
+        assert quiet_lower_tier.priority_score() < flooder.priority_score()
+
+
+# ---------------------------------------------------------------------------
+# Admission integration: DRR rescues starved tenants
+# ---------------------------------------------------------------------------
+
+
+class TestDRRAdmissionIntegration:
+    """End-to-end: feed AdmissionController real DRR priorities, verify the
+    quiet tenant jumps the queue when contention starts.
+    """
+
+    @pytest.mark.asyncio
+    async def test_quiet_tenant_jumps_flooder_queue(self) -> None:
+        """Under cap=1 contention, a quiet tenant arriving after 5 flooder
+        waiters should be admitted on the very next release(), not 5th.
+        """
+        controller = AdmissionController(max_concurrent=1, queue_size=128)
+
+        # Slot 1: flooder takes the in-flight slot
+        flooder = TenantRecord("flooder", TenantBudget(priority=1))
+        flooder.usage.active_requests = 1
+        first = await controller.acquire(priority=flooder.priority_score(), timeout=1.0)
+        assert first is True
+
+        # Now 5 more flooder requests arrive — they queue (cap=1 is full)
+        flooder_tasks = []
+        for i in range(5):
+            flooder.usage.active_requests = 2 + i
+            score = flooder.priority_score()  # 21, 31, 41, 51, 61
+            flooder_tasks.append(
+                asyncio.create_task(
+                    controller.acquire(priority=score, timeout=10.0)
+                )
+            )
+
+        # Give the event loop a chance to enqueue all flooder waiters.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        # Then a quiet tenant arrives — never been seen, 0 active requests
+        quiet = TenantRecord("quiet", TenantBudget(priority=1))
+        # Before acquire, quiet has 0 active requests (try_acquire hasn't run
+        # in this controller-only test). Score = 1, way below flooder's 21+.
+        quiet_task = asyncio.create_task(
+            controller.acquire(priority=quiet.priority_score(), timeout=10.0)
+        )
+        await asyncio.sleep(0)
+
+        # Release the in-flight slot. Next admit MUST be the quiet tenant
+        # (priority 1 < flooder's 21+), not the first-enqueued flooder.
+        controller.release()
+
+        # Quiet should be admitted immediately, before any flooder.
+        await asyncio.wait_for(quiet_task, timeout=1.0)
+        assert quiet_task.result() is True
+
+        # Flooder waiters should still be pending (none admitted yet).
+        for t in flooder_tasks:
+            assert not t.done(), "flooder admitted before quiet — DRR broken"
+
+        # Drain
+        controller.release()
+        for t in flooder_tasks:
+            controller.release()
+            await asyncio.sleep(0)
+        for t in flooder_tasks:
+            try:
+                await asyncio.wait_for(t, timeout=1.0)
+            except asyncio.TimeoutError:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_fifo_within_equal_tenant_priority(self) -> None:
+        """Two requests from the SAME tenant at the same priority_score
+        should still preserve FIFO order (sequence tie-breaker).
+        """
+        controller = AdmissionController(max_concurrent=1, queue_size=128)
+        # Take the slot
+        await controller.acquire(priority=1, timeout=1.0)
+
+        # Enqueue two with identical priority
+        order = []
+        async def waiter(label: str) -> None:
+            ok = await controller.acquire(priority=11, timeout=5.0)
+            assert ok
+            order.append(label)
+
+        t1 = asyncio.create_task(waiter("first"))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        t2 = asyncio.create_task(waiter("second"))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        controller.release()
+        await asyncio.sleep(0)
+        controller.release()
+        await asyncio.gather(t1, t2)
+        assert order == ["first", "second"]
+
+    @pytest.mark.asyncio
+    async def test_ex_quiet_tenant_falls_behind_after_burst(self) -> None:
+        """If the previously-quiet tenant fills its own quota, subsequent
+        requests should fall behind a freshly-quiet tenant. Ensures the
+        priority is dynamic, not snapshot-at-arrival.
+        """
+        controller = AdmissionController(max_concurrent=1, queue_size=128)
+        await controller.acquire(priority=1, timeout=1.0)
+
+        # alice was quiet, just took her first slot — score now 11
+        alice = TenantRecord("alice", TenantBudget(priority=1))
+        alice.usage.active_requests = 1
+
+        # bob just arrived, no active requests — score = 1
+        bob = TenantRecord("bob", TenantBudget(priority=1))
+        # bob's priority score (1) should beat alice's (11).
+        assert bob.priority_score() < alice.priority_score()
+
+
+# ---------------------------------------------------------------------------
+# BUCKET_PRIORITY still wins inside one tenant
+# ---------------------------------------------------------------------------
+
+
+class TestBucketStillTieBreaks:
+    """Inside the SAME tenant tier, length-bucket priority still wins."""
+
+    @pytest.mark.asyncio
+    async def test_short_request_beats_long_within_same_tenant(self) -> None:
+        """When two same-tenant requests arrive simultaneously, short
+        bucket (priority=0) should be admitted before long (priority=2).
+        Models the wired-through priority = tenant_score * 100 + bucket.
+        """
+        controller = AdmissionController(max_concurrent=1, queue_size=128)
+        await controller.acquire(priority=0, timeout=1.0)
+
+        # alice is the same tenant for both requests, score=11
+        order = []
+        async def waiter(label: str, bucket_p: int) -> None:
+            await controller.acquire(
+                priority=11 * 100 + bucket_p, timeout=5.0
+            )
+            order.append(label)
+
+        long_task = asyncio.create_task(waiter("long", 2))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        short_task = asyncio.create_task(waiter("short", 0))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        controller.release()
+        await asyncio.sleep(0)
+        controller.release()
+        await asyncio.gather(short_task, long_task)
+        assert order == ["short", "long"]


### PR DESCRIPTION
## Summary
Per-tenant fairness via deficit-round-robin admission priority. ~24 LOC production + 7 unit tests. **Default behavior unchanged** (`scheduling="fifo"`); DRR opts in via `tenant_defaults.scheduling: drr`.

This is the 30-LOC core of the upcoming **Gate 2-FAIRNESS** experiment (single-model, two-tenant: flooder 32 RPS vs quiet 1 RPS on a shared A100). Gate 2-FAIRNESS is the strategic pivot after Gate 1.5 showed single-model admission caps don't help TTFT — but engines have no tenant concept, so per-tenant fairness is structurally above the engine and the right home for middleware value.

## Why
`results/gate1_5_20260419/GATE1_5_OUTCOME.md`: Gate 1.5 robust DISCONFIRM. B/A=1.04× at c=256; at c=192 the cap actively HURTS by 69% at p99.9. vLLM's continuous batching beats a coarse upstream cap on single-model workloads.

The next-best middleware value-prop is per-tenant fairness (vLLM/SGLang can't do this in-engine — they don't know about tenants). God-planner synthesized this pivot and advisor-pressure-tested it. See `.claude/agent-memory-local/god-planner/project_creative_pivot_apr19.md`.

## Code
- **src/infergrid/tenant/manager.py**: `TenantRecord.priority_score()` returns `active_requests * 10 + budget.priority`. Lower = served first (matches `BUCKET_PRIORITY` and `AdmissionController` conventions). Read-only, no lock (CPython int read is atomic).
- **src/infergrid/router/router.py**: `route_request` now branches on `config.tenant_defaults.scheduling`. `"fifo"` path unchanged. `"drr"` path multiplies `tenant_score` by 100 so tenant deficit dominates, bucket breaks ties within tenant tier.
- **src/infergrid/common/config.py**: `TenantDefaults.scheduling: str = "fifo"`. Priority comment fixed to match rest of codebase ("lower = served first").

## Tests (7 new, all passing; 135/135 suite)
- `TestPriorityScore` — formula itself: idle uses budget.priority; +1 active → +10; many active dominates higher-tier budget.
- `TestDRRAdmissionIntegration::test_quiet_tenant_jumps_flooder_queue` — the core claim: under cap=1, a newly-arriving quiet tenant behind 5 flooder waiters gets admitted on the very next release(), not 6th.
- `TestDRRAdmissionIntegration::test_fifo_within_equal_tenant_priority` — tie-break preserved.
- `TestDRRAdmissionIntegration::test_ex_quiet_tenant_falls_behind_after_burst` — priority is dynamic (snapshot-at-arrival would break DRR).
- `TestBucketStillTieBreaks` — short bucket (0) still beats long (2) within one tenant.

## Test plan
- [x] `pytest tests/unit/test_tenant_priority.py -xvs` — 7/7 pass
- [x] `pytest tests/unit/` — 135/135 pass (was 128/128 pre-PR; +7 new)
- [x] No regression in `test_tenant_manager.py` (checks default `priority == 1` still)
- [x] No regression in `test_admission.py` (priority int still accepted)
- [ ] Future: PR #43 scaffolds the bench, runbook, configs for Gate 2-FAIRNESS
- [ ] Future: A100-SXM4 spin (~$3-4, $8 ceiling) validates the DRR win under real load

## Notes for reviewers
- Priority semantics flip in `TenantDefaults` comment: was "higher = more priority" (incorrect; nothing consumed it that way). Now "lower = served first", matching the rest of the codebase. Default value `1` unchanged — no behavior regression for existing configs.
- `try_acquire_for_tenant` already increments `active_requests` BEFORE `acquire()` is called, so `priority_score()` at priority-time includes the current request. This is correct DRR semantics (the tenant is already one-deeper-in-debt when it asks).