### PR TITLE
scaffold: Gate 2-FAIRNESS bench + configs + runbook (dress rehearsal passes)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -26,7 +26,7 @@ InferGrid is a middleware orchestration layer for LLM inference that sits on top
 | Unit tests | 128+ pass (was 124 pre-#29; +4 streaming-admission tests in #29/#32/#33; +1 TCP-fragmentation test in #37) |
 | GPU configurations profiled | 3 (vLLM A100, SGLang A100, vLLM H100) |
 | Live GPU bring-ups | 2 (Gate 0, Gate 0.6 — both on A100-SXM4) |
-| PRs merged | 40 (PRs #1-40 minus #18 closed-superseded) |
+| PRs merged | 42 (PRs #1-42 minus #18 closed-superseded) |
 
 ---
 
@@ -231,7 +231,10 @@ InferGrid is a middleware orchestration layer for LLM inference that sits on top
 - [x] At c=192 specifically, cap=128 actively HURTS (p99.9 = 5953 vs 3525, +69% worse than uncapped)
 - [x] Full writeup: `results/gate1_5_20260419/GATE1_5_OUTCOME.md`
 
-### Gate 2-lite — Wk 2 (~$8) — NOW LOAD-BEARING for the launch pitch
+### Gate 2-FAIRNESS — NEXT (~$3-4 actual, $8 ceiling) — pivoted from Gate 2-lite
+Per advisor + god-planner creative scrum after Gate 1.5 DISCONFIRM, the sharper test is per-tenant fairness (vLLM has NO tenant concept — structurally above the engine). Single-model, two-tenant: flooder 32 RPS vs quiet 1 RPS on A100-SXM4. 4 arms (Arm 0 solo baseline / Arm 1 raw vLLM / Arm 2 InferGrid FIFO / Arm 3 InferGrid DRR). Pre-committed CONFIRM: `Arm3.quiet.p99 ≤ 1.5× Arm0` AND `Arm1.quiet.p99 ≥ 4× Arm0`. Runbook: `docs/launch/gate2_fairness_runbook.md`. DRR wiring shipped in PR #42. Scaffold in PR #43.
+
+### Gate 2-lite — Wk 2 fallback (~$8) — plan B if Gate 2-FAIRNESS DISCONFIRMs
 - [ ] 1× A100-SXM4, 3 arms (InferGrid vs raw uvicorn vs round-robin)
 - [ ] Llama-3.1-8B + Qwen2.5-7B co-loaded
 - [ ] Two-tenant mixed workload (chat + RAG), 120s sustained
@@ -288,6 +291,8 @@ InferGrid is a middleware orchestration layer for LLM inference that sits on top
 | #38 | Gate 1 H100 SXM5 raw results (Arm A+B tarballs, GATE1_OUTCOME.md, ~$1 spend) | Merged | Apr 19, 2026 |
 | #39 | Gate 1 OUTCOME Little's Law caveat: 10s bench wall did not sustain cap pressure; headline 1.04× B/A is short-bench under-power, not DISCONFIRM. Softened "FAIL" → "AMBIGUOUS"; points to `--num-requests 4000` rerun (Gate 1.5) | Merged | Apr 19, 2026 |
 | #40 | docs+configs: 4-week plan, Gate 1.5 runbook, Gate 2-lite scaffold (PROGRESS.md Strategic Plan, gate1_runbook.md Gate 1.5 Re-Run section with pod-restart-between-arms, gate2_design.md NEW, gate2_multi_tenant.yaml + gate2_round_robin.yaml NEW, research_roadmap.md cliff claim updated for honest TTFT) | Merged | Apr 19, 2026 |
+| #41 | results: Gate 1.5 H100 SXM5 robust DISCONFIRM (~$1.30 spend). 16000 req/arm × 4 concurrency × ~100s sustained. B/A=1.04× same as Gate 1, under sustained cap pressure. At c=192 cap=128 actively HURTS (+69% p99.9). Runbook resume_pod gpu_count fix. | Merged | Apr 19, 2026 |
+| #42 | feat(tenant): DRR-priority admission via tenant active-request deficit (~24 LOC + 7 tests, 135/135 passing). Wires TenantRecord.priority_score() into AdmissionController when `tenant_defaults.scheduling: drr`. Default (fifo) unchanged. Core of Gate 2-FAIRNESS. | Merged | Apr 19, 2026 |
 
 PR #18 closed (conflict-dead, superseded by #19). PR #20 open as DRAFT (Gate 0 launch post, framing-pending-Gate-2-lite per Gate 1.5 robust DISCONFIRM).
 

--- a/benchmarks/scripts/benchmark_two_tenant_single_model.py
+++ b/benchmarks/scripts/benchmark_two_tenant_single_model.py
@@ -1,0 +1,321 @@
+"""Two-tenant, single-model fairness benchmark for Gate 2-FAIRNESS.
+
+Measures whether a quiet tenant's TTFT survives when a flooder shares
+the same upstream model engine. Three arms of the Gate 2-FAIRNESS
+experiment use this script:
+
+    Arm 0: quiet-only baseline (120-240s sustained, 0 flooder)
+    Arm 1: raw vLLM (InferGrid passthrough, admission=no-op) — starvation baseline
+    Arm 2: InferGrid FIFO scheduling — current behavior (middle arm)
+    Arm 3: InferGrid DRR scheduling (scheduling: drr) — the bet
+
+Per-tenant Poisson arrivals. Fixed wall-clock, not fixed request count
+(Gate 1.5 lesson: you need ≥100s sustained per cell for Little's Law
+to actually exercise the hypothesis). Streaming completions, TTFT is
+time-to-first-non-empty-content (C2/C5-fixed path, buffered SSE parser
+not strictly necessary here because this script doesn't gate a cap on
+token count, but kept aligned with PR #37 for consistency).
+
+Usage:
+    python benchmarks/scripts/benchmark_two_tenant_single_model.py \\
+      --url http://localhost:8000 \\
+      --model meta-llama/Llama-3.1-8B-Instruct \\
+      --flooder-rps 32 --quiet-rps 1 \\
+      --duration-s 120 \\
+      --max-tokens 128 \\
+      --output-dir /workspace/results/gate2_fairness_arm3/benchmarks
+
+The output-dir gets two CSVs (tenant_flooder.csv, tenant_quiet.csv)
+plus summary.json with per-tenant and aggregate p50/p95/p99 TTFT + count
++ throughput. The Gate 2-FAIRNESS runbook prescribes the success and
+failure criteria based on these files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import logging
+import random
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# A small, fixed prompt set. Length kept in the "chat-ish short" regime
+# so the bench measures queue wait, not prompt processing time. Bench
+# intent is to surface starvation, not exercise prefill.
+PROMPTS: list[str] = [
+    "Explain quantum entanglement to a 10-year-old in three sentences.",
+    "Summarize the plot of The Great Gatsby in exactly two sentences.",
+    "What are three reasons to get enough sleep?",
+    "Translate 'I would like a cup of coffee' to French.",
+    "Write a haiku about morning fog rolling over a coast.",
+    "What does 'object-oriented programming' mean in one paragraph?",
+    "Name three famous bridges in the world and one fact about each.",
+    "Explain the difference between affect and effect with one example.",
+]
+
+
+@dataclass
+class RequestResult:
+    tenant: str
+    request_id: int
+    submit_time: float
+    ttft_ms: float
+    total_latency_ms: float
+    tokens_out: int
+    error: str = ""
+
+
+async def send_one(
+    session: aiohttp.ClientSession,
+    base_url: str,
+    tenant_id: str,
+    request_id: int,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    timeout_s: float,
+) -> RequestResult:
+    """Send one streaming completion, measure TTFT + total latency."""
+    url = f"{base_url}/v1/completions"
+    payload = {"model": model, "prompt": prompt, "max_tokens": max_tokens, "stream": True}
+    headers = {"X-Tenant-ID": tenant_id}
+
+    submit = time.time()
+    first_token_time: float | None = None
+    tokens_out = 0
+
+    try:
+        timeout = aiohttp.ClientTimeout(total=timeout_s)
+        async with session.post(url, json=payload, headers=headers, timeout=timeout) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                return RequestResult(
+                    tenant=tenant_id, request_id=request_id, submit_time=submit,
+                    ttft_ms=0.0, total_latency_ms=(time.time() - submit) * 1000,
+                    tokens_out=0, error=f"HTTP {resp.status}: {body[:180]}",
+                )
+            async for line in resp.content:
+                decoded = line.decode("utf-8").strip()
+                if not decoded or not decoded.startswith("data: "):
+                    continue
+                data_str = decoded[6:]
+                if data_str == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(data_str)
+                    choices = chunk.get("choices", [])
+                    if not choices:
+                        continue
+                    content = (
+                        choices[0].get("text")
+                        or choices[0].get("delta", {}).get("content")
+                        or ""
+                    )
+                    # TTFT v2: .strip() rejects whitespace-only frames (PR #31).
+                    if content.strip():
+                        if first_token_time is None:
+                            first_token_time = time.time()
+                        tokens_out += 1
+                except (json.JSONDecodeError, KeyError):
+                    continue
+    except asyncio.TimeoutError:
+        return RequestResult(
+            tenant=tenant_id, request_id=request_id, submit_time=submit,
+            ttft_ms=0.0, total_latency_ms=(time.time() - submit) * 1000,
+            tokens_out=0, error="timeout",
+        )
+    except Exception as exc:
+        return RequestResult(
+            tenant=tenant_id, request_id=request_id, submit_time=submit,
+            ttft_ms=0.0, total_latency_ms=(time.time() - submit) * 1000,
+            tokens_out=0, error=str(exc),
+        )
+
+    end = time.time()
+    total_ms = (end - submit) * 1000
+    ttft_ms = (first_token_time - submit) * 1000 if first_token_time is not None else total_ms
+    return RequestResult(
+        tenant=tenant_id, request_id=request_id, submit_time=submit,
+        ttft_ms=ttft_ms, total_latency_ms=total_ms, tokens_out=tokens_out,
+    )
+
+
+async def tenant_poisson_loop(
+    tenant_id: str,
+    rps: float,
+    duration_s: float,
+    session: aiohttp.ClientSession,
+    base_url: str,
+    model: str,
+    max_tokens: int,
+    timeout_s: float,
+    rng: random.Random,
+    results: list[RequestResult],
+) -> None:
+    """Fire requests with exponential inter-arrival times; collect results."""
+    if rps <= 0:
+        return
+    end_time = time.time() + duration_s
+    request_id = 0
+    in_flight: list[asyncio.Task[RequestResult]] = []
+    mean_interarrival = 1.0 / rps
+
+    while time.time() < end_time:
+        prompt = rng.choice(PROMPTS)
+        task = asyncio.create_task(send_one(
+            session, base_url, tenant_id, request_id, model, prompt,
+            max_tokens, timeout_s,
+        ))
+        in_flight.append(task)
+        request_id += 1
+        await asyncio.sleep(rng.expovariate(1.0 / mean_interarrival))
+
+    # Drain in-flight. timeout_s upper-bounds total drain time.
+    for t in asyncio.as_completed(in_flight, timeout=timeout_s + 10):
+        try:
+            results.append(await t)
+        except Exception as exc:
+            logger.warning("tenant=%s drain failure: %s", tenant_id, exc)
+
+
+def summarize(results: list[RequestResult]) -> dict[str, Any]:
+    """Percentile summary for a list of results. Filters out errors."""
+    ok = [r for r in results if not r.error and r.ttft_ms > 0]
+    errs = [r for r in results if r.error]
+    if not ok:
+        return {
+            "count_ok": 0, "count_err": len(errs),
+            "ttft_p50_ms": -1, "ttft_p95_ms": -1, "ttft_p99_ms": -1, "ttft_max_ms": -1,
+            "total_p50_ms": -1, "total_p99_ms": -1, "tokens_out_mean": 0,
+        }
+    ttfts = sorted(r.ttft_ms for r in ok)
+    totals = sorted(r.total_latency_ms for r in ok)
+    n = len(ok)
+
+    def p(xs: list[float], q: float) -> float:
+        idx = min(n - 1, max(0, int(q * n)))
+        return xs[idx]
+
+    return {
+        "count_ok": n,
+        "count_err": len(errs),
+        "ttft_p50_ms": round(p(ttfts, 0.50), 1),
+        "ttft_p95_ms": round(p(ttfts, 0.95), 1),
+        "ttft_p99_ms": round(p(ttfts, 0.99), 1),
+        "ttft_max_ms": round(ttfts[-1], 1),
+        "total_p50_ms": round(p(totals, 0.50), 1),
+        "total_p99_ms": round(p(totals, 0.99), 1),
+        "tokens_out_mean": round(sum(r.tokens_out for r in ok) / n, 1),
+    }
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    outdir = Path(args.output_dir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    # Gate 1.5 lesson: raise TCPConnector limits per actual offered concurrency.
+    # Flooder 32 RPS × ~5s per-request avg = ~160 in-flight at steady state.
+    # Give 3× headroom so we never silently clamp.
+    concurrency_budget = max(256, int((args.flooder_rps + args.quiet_rps) * args.max_tokens * 0.05))
+    connector = aiohttp.TCPConnector(limit=concurrency_budget, limit_per_host=concurrency_budget)
+
+    logger.info(
+        "Bench config: flooder=%.1f RPS, quiet=%.1f RPS, duration=%ds, model=%s, max_tokens=%d",
+        args.flooder_rps, args.quiet_rps, args.duration_s, args.model, args.max_tokens,
+    )
+    logger.info("TCPConnector limit=%d, limit_per_host=%d", concurrency_budget, concurrency_budget)
+
+    rng_flooder = random.Random(args.seed)
+    rng_quiet = random.Random(args.seed + 1)
+
+    flooder_results: list[RequestResult] = []
+    quiet_results: list[RequestResult] = []
+
+    start_wall = time.time()
+    async with aiohttp.ClientSession(connector=connector) as session:
+        await asyncio.gather(
+            tenant_poisson_loop(
+                "flooder", args.flooder_rps, args.duration_s,
+                session, args.url, args.model, args.max_tokens, args.timeout_s,
+                rng_flooder, flooder_results,
+            ),
+            tenant_poisson_loop(
+                "quiet_user", args.quiet_rps, args.duration_s,
+                session, args.url, args.model, args.max_tokens, args.timeout_s,
+                rng_quiet, quiet_results,
+            ),
+        )
+    wall_s = time.time() - start_wall
+
+    for tenant, results in [("flooder", flooder_results), ("quiet_user", quiet_results)]:
+        csv_path = outdir / f"tenant_{tenant}.csv"
+        with open(csv_path, "w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=list(RequestResult.__dataclass_fields__.keys()))
+            writer.writeheader()
+            for r in results:
+                writer.writerow(asdict(r))
+        logger.info("Wrote %s (%d rows)", csv_path, len(results))
+
+    summary = {
+        "wall_time_s": round(wall_s, 2),
+        "flooder": summarize(flooder_results),
+        "quiet_user": summarize(quiet_results),
+        "bench_args": {
+            "flooder_rps": args.flooder_rps, "quiet_rps": args.quiet_rps,
+            "duration_s": args.duration_s, "max_tokens": args.max_tokens,
+            "model": args.model, "seed": args.seed,
+        },
+    }
+    summary_path = outdir / "summary.json"
+    with open(summary_path, "w") as fh:
+        json.dump(summary, fh, indent=2)
+    logger.info("Wrote %s", summary_path)
+
+    # Print a terminal-readable recap
+    q = summary["quiet_user"]
+    f = summary["flooder"]
+    logger.info("=" * 60)
+    logger.info(
+        "QUIET TTFT  p50=%sms p99=%sms max=%sms (n=%s, err=%s)",
+        q["ttft_p50_ms"], q["ttft_p99_ms"], q["ttft_max_ms"], q["count_ok"], q["count_err"],
+    )
+    logger.info(
+        "FLOOD TTFT  p50=%sms p99=%sms max=%sms (n=%s, err=%s)",
+        f["ttft_p50_ms"], f["ttft_p99_ms"], f["ttft_max_ms"], f["count_ok"], f["count_err"],
+    )
+    logger.info("=" * 60)
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--url", default="http://localhost:8000")
+    p.add_argument("--model", required=True)
+    p.add_argument("--flooder-rps", type=float, default=32.0)
+    p.add_argument("--quiet-rps", type=float, default=1.0)
+    p.add_argument("--duration-s", type=float, default=120.0)
+    p.add_argument("--max-tokens", type=int, default=128)
+    p.add_argument("--timeout-s", type=float, default=60.0)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--output-dir", required=True)
+    args = p.parse_args()
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/configs/gate2_fairness_drr.yaml
+++ b/configs/gate2_fairness_drr.yaml
@@ -1,0 +1,37 @@
+# Gate 2-FAIRNESS Arm 3 — InferGrid DRR (the bet).
+#
+# IDENTICAL to configs/gate2_fairness_fifo.yaml except
+# `tenant_defaults.scheduling: drr`. Every other knob is held constant
+# so the TTFT delta is attributable to scheduling discipline alone.
+#
+# DRR (Deficit Round-Robin): AdmissionController priority =
+#   tenant.active_requests * 10 + tenant.budget.priority + bucket_priority
+# Lower = served first. A quiet tenant's score stays low; a flooder
+# accumulates deficit as their active_requests grows.
+#
+# Hypothesis: under flooder=32 RPS vs quiet=1 RPS contention, DRR keeps
+# the quiet tenant's p99 TTFT within 1.5x of the quiet-only baseline.
+
+host: 0.0.0.0
+port: 8000
+gpu_budget_fraction: 0.92
+
+max_concurrent: 256
+admission_queue_size: 2048
+engine_start_timeout_s: 420
+log_level: INFO
+
+tenant_defaults:
+  max_concurrent_requests: 512
+  rate_limit_rpm: 999999
+  priority: 1
+  scheduling: drr   # <-- the ONLY variable vs Arm 2
+
+models:
+  - model_id: "meta-llama/Llama-3.1-8B-Instruct"
+    short_name: "llama31-8b"
+    engine: "vllm"
+    dtype: "bfloat16"
+    gpu_memory_utilization: 0.85
+    max_model_len: 4096
+    tensor_parallel_size: 1

--- a/configs/gate2_fairness_fifo.yaml
+++ b/configs/gate2_fairness_fifo.yaml
@@ -1,0 +1,37 @@
+# Gate 2-FAIRNESS Arm 2 — InferGrid FIFO (current shipping behavior).
+# Same single model as Gate 1/1.5 (Llama-3.1-8B). Admission cap high
+# enough not to bottleneck at ~33 RPS aggregate. Per-tenant budget
+# high enough not to 429 the flooder. The ONLY variable vs Arm 3
+# (gate2_fairness_drr.yaml) is tenant_defaults.scheduling.
+#
+# See docs/launch/gate2_fairness_runbook.md for the 4-arm experiment.
+
+host: 0.0.0.0
+port: 8000
+gpu_budget_fraction: 0.92
+
+# Cap=256 avoids the c=192 queue-time floor we found in Gate 1.5 — we do
+# NOT want the admission cap to be the bottleneck here; we want the
+# engine to be the bottleneck, and InferGrid's per-tenant scheduling to
+# mediate who gets admitted first.
+max_concurrent: 256
+admission_queue_size: 2048
+engine_start_timeout_s: 420
+log_level: INFO
+
+tenant_defaults:
+  # Generous enough that both tenants can run flat-out without hitting
+  # the 429 path; the EXPERIMENTAL variable is priority scheduling.
+  max_concurrent_requests: 512
+  rate_limit_rpm: 999999
+  priority: 1
+  scheduling: fifo   # current shipping behavior — length-bucket priority only
+
+models:
+  - model_id: "meta-llama/Llama-3.1-8B-Instruct"
+    short_name: "llama31-8b"
+    engine: "vllm"
+    dtype: "bfloat16"
+    gpu_memory_utilization: 0.85
+    max_model_len: 4096
+    tensor_parallel_size: 1

--- a/docs/launch/gate2_fairness_runbook.md
+++ b/docs/launch/gate2_fairness_runbook.md
@@ -1,0 +1,178 @@
+# Gate 2-FAIRNESS Runbook
+
+**Audience:** the human spending ~$3-4. Do these in order.
+**Hardware:** 1× NVIDIA A100-SXM4 80GB on RunPod (SECURE on-demand, ~$1.89/hr).
+**Wall:** ~1.5h expected for all 4 arms.
+**Cost:** ~$3-4 expected, **$8 hard ceiling**. `MAX_POD_SECS=7200` per pod spin.
+**main tip required:** `e3a5261` or later (PR #42, DRR priority wiring).
+
+---
+
+## Why Gate 2-FAIRNESS exists
+
+Gate 1.5 robustly DISCONFIRMED the single-model admission cap hypothesis: vLLM's continuous batching matches a coarse upstream cap on TTFT (B/A=1.04× at c=256; A actively hurt at c=192). See `results/gate1_5_20260419/GATE1_5_OUTCOME.md`.
+
+But engines have no concept of a **tenant**. If one user floods with 32 RPS and another tries to send 1 RPS, vLLM's scheduler will starve the quiet user because it optimizes aggregate throughput, not per-tenant fairness. This is a concrete problem that cannot be solved in-engine — it's structurally a middleware layer above.
+
+Gate 2-FAIRNESS tests whether the DRR (Deficit Round-Robin) priority discipline shipped in PR #42 rescues the quiet tenant.
+
+## Hypothesis
+
+Under **flooder = 32 RPS, quiet = 1 RPS, same model, same A100**:
+
+1. **Arm 0 (quiet only):** `quiet_user.p99_TTFT ≤ ~600ms` (steady-state solo baseline).
+2. **Arm 1 (raw vLLM):** `quiet_user.p99_TTFT ≥ 4× Arm 0` — vLLM's scheduler starves the quiet tenant when a flooder shares the model.
+3. **Arm 2 (InferGrid FIFO):** `quiet_user.p99_TTFT ≈ Arm 1` — current shipping scheduling doesn't help because under contention the queue is still dominated by the flooder's arrival rate.
+4. **Arm 3 (InferGrid DRR):** `quiet_user.p99_TTFT ≤ 1.5× Arm 0` — DRR keeps the quiet tenant near-solo-baseline.
+
+**CONFIRM rule (pre-committed):** `Arm 3.quiet.p99_TTFT ≤ 1.5 × Arm 0.quiet.p99_TTFT` AND `Arm 1.quiet.p99_TTFT ≥ 4 × Arm 0.quiet.p99_TTFT`.
+
+**DISCONFIRM rule:** `Arm 3 > 2 × Arm 0` (DRR didn't help) OR `Arm 1 < 2 × Arm 0` (no starvation to fix — interesting in itself, means vLLM is fairer than expected).
+
+## Pre-flight
+
+1. **Local dress rehearsal passes.**
+   ```bash
+   bash scripts/gate2_fairness_dress_rehearsal.sh
+   ```
+   Look for `OVERALL: PASS`. If it fails, debug locally first — do not provision.
+
+2. **HF_TOKEN valid for Llama.**
+3. **RunPod balance ≥ $15.**
+4. **A100-SXM4 SECURE spot price ≤ $2.50/hr.** If > $2.50, wait or switch region.
+5. **Calendar block 2h.**
+
+## Launch (5 commands — four arms + teardown)
+
+### 1. Provision the A100-SXM4 pod
+
+```bash
+python3 - <<'EOF'
+import os, time, runpod, json
+runpod.api_key = os.environ["RUNPOD_API_KEY"]
+pod = runpod.create_pod(
+    name="infergrid-gate2-fairness",
+    image_name="runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04",
+    gpu_type_id="NVIDIA A100-SXM4-80GB",
+    cloud_type="SECURE",
+    container_disk_in_gb=80, volume_in_gb=0, gpu_count=1,
+    ports="22/tcp,8000/http",
+    env={"HF_TOKEN": os.environ["HF_TOKEN"], "MAX_POD_SECS": "7200"},
+)
+print(f"POD {pod['id']}")
+# Poll runtime.ports for SSH info — see scripts/gate1_5 pattern.
+EOF
+```
+
+Export `POD_IP` and `POD_PORT` from the printout. Smoke test:
+```bash
+ssh -p $POD_PORT root@$POD_IP 'nvidia-smi -L'
+# Expect: GPU 0: NVIDIA A100-SXM4-80GB
+```
+
+### 2. Push env + bootstrap, run Arm 0 (quiet only, 240s for tighter p99)
+
+```bash
+cat > /tmp/.gate2_env <<EOF
+export HF_TOKEN=$HF_TOKEN
+export MAX_POD_SECS=7200
+EOF
+scp -P $POD_PORT /tmp/.gate2_env root@$POD_IP:/root/.gate_env
+scp -P $POD_PORT scripts/gate_pod_bootstrap.sh root@$POD_IP:/workspace/
+
+# Arm 0: flooder_rps=0, quiet_rps=1, duration=240s
+ssh -p $POD_PORT root@$POD_IP <<'REMOTE'
+nohup bash /workspace/gate_pod_bootstrap.sh \
+  --run-name gate2f_arm0_$(date -u +%Y%m%d_%H%M%S) \
+  --config configs/gate2_fairness_fifo.yaml \
+  --bench-script benchmarks/scripts/benchmark_two_tenant_single_model.py \
+  --bench-args "--url http://localhost:8000 --model meta-llama/Llama-3.1-8B-Instruct --flooder-rps 0 --quiet-rps 1 --duration-s 240 --max-tokens 128 --output-dir RDIR/benchmarks --seed 42" \
+  > /workspace/bootstrap_arm0.console 2>&1 &
+disown
+REMOTE
+```
+
+Wait for `_DONE` marker, rsync.
+
+### 3. Arm 1 — raw vLLM (bypass InferGrid admission)
+
+Raw vLLM has no tenant concept. Run the bench against the vLLM engine port directly (InferGrid spawns on 8002+). First confirm the vLLM subprocess port from `server.log`.
+
+Simpler: launch a fresh bootstrap with `max_concurrent: 99999` and `scheduling: fifo` — InferGrid becomes effectively a tenant-unaware passthrough. (Arm 1 is thus operationally `configs/gate2_fairness_fifo.yaml` with max_concurrent bumped to 99999; or use `--admission-bypass` if we grow that flag in a later PR.)
+
+```bash
+# Arm 1: flooder + quiet run together, FIFO scheduling (effectively no-op here)
+ssh -p $POD_PORT root@$POD_IP <<'REMOTE'
+nohup bash /workspace/gate_pod_bootstrap.sh \
+  --run-name gate2f_arm1_$(date -u +%Y%m%d_%H%M%S) \
+  --config configs/gate2_fairness_fifo.yaml \
+  --bench-script benchmarks/scripts/benchmark_two_tenant_single_model.py \
+  --bench-args "--url http://localhost:8000 --model meta-llama/Llama-3.1-8B-Instruct --flooder-rps 32 --quiet-rps 1 --duration-s 120 --max-tokens 128 --output-dir RDIR/benchmarks --seed 42" \
+  > /workspace/bootstrap_arm1.console 2>&1 &
+disown
+REMOTE
+```
+
+**Note on Arm 1 vs Arm 2 separation:** with max_concurrent=256 and aggregate ~33 RPS, the admission cap likely doesn't bind at all in either arm — so Arm 1 and Arm 2 will look identical. That's OK; Arm 2 is a sanity check that no regression vs raw passthrough exists. The decisive delta is Arm 2 vs Arm 3.
+
+### 4. Arm 2 — InferGrid FIFO (same as Arm 1 in practice)
+
+Skip as separate run if you want — use Arm 1's numbers. Keep the arm in the runbook for experimental cleanliness: if your PR #42 accidentally regressed the `fifo` default path, Arm 2 would catch it.
+
+### 5. Arm 3 — InferGrid DRR (the bet)
+
+```bash
+ssh -p $POD_PORT root@$POD_IP <<'REMOTE'
+nohup bash /workspace/gate_pod_bootstrap.sh \
+  --run-name gate2f_arm3_$(date -u +%Y%m%d_%H%M%S) \
+  --config configs/gate2_fairness_drr.yaml \
+  --bench-script benchmarks/scripts/benchmark_two_tenant_single_model.py \
+  --bench-args "--url http://localhost:8000 --model meta-llama/Llama-3.1-8B-Instruct --flooder-rps 32 --quiet-rps 1 --duration-s 120 --max-tokens 128 --output-dir RDIR/benchmarks --seed 42" \
+  > /workspace/bootstrap_arm3.console 2>&1 &
+disown
+REMOTE
+```
+
+Rsync, then **terminate the pod**.
+
+## Reading the result
+
+Per-arm `summary.json` has `quiet_user.ttft_p99_ms` and `flooder.ttft_p99_ms` and aggregate counts.
+
+```
+quiet_baseline = Arm0.quiet_user.ttft_p99_ms
+raw_penalty    = Arm1.quiet_user.ttft_p99_ms / quiet_baseline
+fifo_penalty   = Arm2.quiet_user.ttft_p99_ms / quiet_baseline
+drr_penalty    = Arm3.quiet_user.ttft_p99_ms / quiet_baseline
+```
+
+### CONFIRM
+- `drr_penalty ≤ 1.5` AND `raw_penalty ≥ 4`. DRR rescues a ≥4× starvation. Hero chart: 3 bars (Arm 0 / Arm 1 / Arm 3) + headline multiplier.
+
+### DISCONFIRM (no starvation to fix)
+- `raw_penalty < 2`. vLLM's scheduler was fairer than we expected. Publishable — "we tried to starve vLLM and couldn't, here's why that's interesting" + tells us middleware isn't needed for this workload shape.
+
+### DISCONFIRM (DRR didn't help)
+- `raw_penalty ≥ 4` AND `drr_penalty > 2`. Starvation exists, but DRR doesn't fix it. Indicates the queue isn't where the delay happens — probably engine-internal batching is the bottleneck. Next experiment: per-tenant KV isolation or request interleaving at the engine layer.
+
+### PLUMBING REGRESSION (reject, don't interpret)
+- Arm 2 differs meaningfully from Arm 1 → PR #42's FIFO default path regressed something. Debug.
+- Arm 3 quiet tenant has higher p99 than flooder → priority inversion bug in `priority_score()` or the router wiring. Debug.
+
+## Failure modes
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| Engine pre-load > 10 min | A100 wheel cache cold | Wait up to 15 min; if no progress, `touch /workspace/ABORT` |
+| `count_err > 5%` in any arm | Timeout, rate-limit, or OOM | Check `server.log` for `tenant_rejected` reason; raise `max_concurrent_requests` if budget exceeded |
+| Arm 1 quiet p99 ≈ Arm 0 quiet p99 | No starvation observed — vLLM was fairer than expected OR flooder never loaded enough | Check flooder's summary: if `count_ok < 32 × 120 × 0.7 = 2688`, flooder underfired; bump `--flooder-rps 48` |
+| Arm 3 quiet p99 > Arm 1 quiet p99 | DRR regressed (priority inversion?) | Check `src/infergrid/tenant/manager.py::priority_score` — a sign flip would invert. Bail Gate 2-FAIRNESS, not a launch-blocker to debug |
+| `/workspace/COST_CAP_HIT` | Pod exceeded MAX_POD_SECS | Terminate from RunPod console immediately |
+
+## After Gate 2-FAIRNESS
+
+1. Copy artifacts into `results/gate2_fairness_YYYYMMDD/`.
+2. Write `GATE2_FAIRNESS_OUTCOME.md` with per-arm table + hero multiplier.
+3. Update `PROGRESS.md` Gate 2-FAIRNESS section.
+4. If CONFIRM → draft the launch post pivot ("Run two tenants on one A100 without K8s"). Launch target: Tue 2026-05-12.
+5. If DISCONFIRM → consult advisor + god-planner on next experiment. Plan B: prompt-shape-aware scheduling. Plan C: ship Gate 2-lite-as-scoped.

--- a/scripts/gate2_fairness_dress_rehearsal.sh
+++ b/scripts/gate2_fairness_dress_rehearsal.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# gate2_fairness_dress_rehearsal.sh -- LOCAL, NO-GPU validation of the
+# Gate 2-FAIRNESS experiment's plumbing.
+#
+# Goal: prove that before we spend ~$3-4 on an A100-SXM4, the end-to-end
+# wiring works: both gate2_fairness yamls load, the two-tenant bench
+# harness runs and produces tenant_*.csv + summary.json, X-Tenant-ID
+# headers make it to TenantManager, and DRR priority_score() is invoked
+# on the hot path when scheduling="drr" (verified via log-grep, not
+# functional — a mock engine can't reproduce the GPU-contention TTFT
+# delta between FIFO and DRR).
+#
+# What this DOES validate:
+#   - infergrid serve loads gate2_fairness_fifo.yaml AND _drr.yaml
+#   - benchmark_two_tenant_single_model.py runs end-to-end against a mock
+#     engine with flooder_rps=4, quiet_rps=1, duration=20s
+#   - tenant_flooder.csv, tenant_quiet.csv, summary.json are produced
+#   - summary.json has the expected keys (quiet_user.ttft_p99_ms, etc.)
+#   - X-Tenant-ID header reaches the router (server.log contains both
+#     tenant_id=flooder and tenant_id=quiet_user entries)
+#
+# What this does NOT validate:
+#   - real TTFT deltas between FIFO and DRR (mock is not contended)
+#   - the 4× starvation hypothesis (needs real vLLM)
+#   - per-tenant fairness under real GPU contention
+#
+# Pass criteria:
+#   - both configs serve OK
+#   - both bench runs complete within TIMEOUT_S (default 90s per arm)
+#   - both arms produce tenant_flooder.csv + tenant_quiet.csv + summary.json
+#   - summary.json has count_ok > 0 for BOTH tenants in BOTH arms
+#   - server.log shows tenant_id=flooder AND tenant_id=quiet_user in BOTH arms
+#   - DRR arm's server.log shows "scheduling=drr" (or similar indicator)
+#
+# Usage:  bash scripts/gate2_fairness_dress_rehearsal.sh
+# Env:
+#   DURATION_S=20               # bench wall per arm
+#   TIMEOUT_S=90                # per-arm upper bound
+#   FLOODER_RPS=4               # reduced for local CPU mock
+#   QUIET_RPS=1
+#   LOGDIR=/tmp/gate2f_dress
+
+set -u
+
+DURATION_S=${DURATION_S:-20}
+TIMEOUT_S=${TIMEOUT_S:-90}
+FLOODER_RPS=${FLOODER_RPS:-4}
+QUIET_RPS=${QUIET_RPS:-1}
+LOGDIR=${LOGDIR:-/tmp/gate2f_dress}
+
+REPO_ROOT=$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null \
+            || ( cd "$(dirname "$0")/.." && pwd ))
+cd "$REPO_ROOT" || { echo "FATAL: cannot cd to REPO_ROOT='$REPO_ROOT'"; exit 2; }
+
+ARM_FIFO_CFG="$REPO_ROOT/configs/gate2_fairness_fifo.yaml"
+ARM_DRR_CFG="$REPO_ROOT/configs/gate2_fairness_drr.yaml"
+BENCH="$REPO_ROOT/benchmarks/scripts/benchmark_two_tenant_single_model.py"
+
+for f in "$ARM_FIFO_CFG" "$ARM_DRR_CFG" "$BENCH"; do
+  [ -f "$f" ] || { echo "FATAL: missing $f"; exit 2; }
+done
+
+MODEL_ID=$(python3 -c "
+import yaml
+print(yaml.safe_load(open('$ARM_FIFO_CFG'))['models'][0]['model_id'])
+")
+[ -n "$MODEL_ID" ] || { echo "FATAL: could not parse model_id"; exit 2; }
+
+rm -rf "$LOGDIR"
+mkdir -p "$LOGDIR"
+
+MOCK_PORT=18003
+SERVE_PORT=8000
+
+cleanup() {
+  [ -n "${SERVE_PID:-}" ] && kill "$SERVE_PID" 2>/dev/null || true
+  [ -n "${MOCK_PID:-}"  ] && kill "$MOCK_PID"  2>/dev/null || true
+  pkill -f "infergrid.cli serve.*gate2_fairness" 2>/dev/null || true
+  pkill -f "gate2f_dress_mock.py" 2>/dev/null || true
+  sleep 1
+}
+trap cleanup EXIT
+
+# --- Mock engine: cheap OpenAI-compatible server, one short SSE frame + done ---
+MOCK_PY="$LOGDIR/gate2f_dress_mock.py"
+cat > "$MOCK_PY" <<'PYEOF'
+import argparse, asyncio, json, time
+from aiohttp import web
+
+MODEL = None
+
+async def models(_):
+    return web.json_response({"object":"list","data":[
+        {"id": MODEL, "object":"model","created":int(time.time()),"owned_by":"mock"}
+    ]})
+
+async def health(_): return web.json_response({"status":"ok"})
+
+async def completions(request):
+    body = await request.json()
+    max_tokens = int(body.get("max_tokens", 16))
+    stream = bool(body.get("stream", False))
+    resp = web.StreamResponse(status=200, headers={
+        "Content-Type":"text/event-stream","Cache-Control":"no-cache",
+    })
+    await resp.prepare(request)
+    # small TTFT simulation
+    await asyncio.sleep(0.02)
+    for i in range(min(max_tokens, 8)):
+        await asyncio.sleep(0.005)
+        chunk = {"id":"c","object":"text_completion.chunk","created":int(time.time()),
+                 "model": MODEL,
+                 "choices":[{"index":0,"text":"x ","finish_reason":None}]}
+        await resp.write(b'data: ' + json.dumps(chunk).encode() + b'\n\n')
+    await resp.write(b'data: [DONE]\n\n')
+    await resp.write_eof()
+    return resp
+
+async def chat(request):
+    return await completions(request)
+
+def make_app():
+    app = web.Application(client_max_size=4*1024*1024)
+    app.router.add_get("/v1/models", models)
+    app.router.add_get("/health", health)
+    app.router.add_post("/v1/completions", completions)
+    app.router.add_post("/v1/chat/completions", chat)
+    return app
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--port", type=int, required=True)
+    p.add_argument("--model", required=True)
+    a = p.parse_args()
+    MODEL = a.model
+    web.run_app(make_app(), host="127.0.0.1", port=a.port, print=None)
+PYEOF
+
+echo "--- Phase 1: mock engine on :$MOCK_PORT ---"
+python3 "$MOCK_PY" --port "$MOCK_PORT" --model "$MODEL_ID" \
+    > "$LOGDIR/mock.log" 2>&1 &
+MOCK_PID=$!
+sleep 2
+curl -sf "http://127.0.0.1:$MOCK_PORT/v1/models" >/dev/null \
+  || { echo "FATAL: mock did not start"; tail -30 "$LOGDIR/mock.log"; exit 1; }
+
+RESULTS_JSON="$LOGDIR/dress_summary.json"
+echo '{"arms": []}' > "$RESULTS_JSON"
+
+run_arm() {
+  local arm="$1" cfg_in="$2"
+  local cfg_out="$LOGDIR/${arm}_config.yaml"
+  local run_dir="$LOGDIR/results_${arm}"
+
+  mkdir -p "$run_dir"
+
+  # Materialize tmp config with per-model port pinned to the mock.
+  python3 -c "
+import yaml
+c = yaml.safe_load(open('$cfg_in'))
+c['models'][0]['port'] = $MOCK_PORT
+yaml.safe_dump(c, open('$cfg_out','w'))
+"
+  echo "--- Phase 2 [$arm]: infergrid serve --config $cfg_out ---"
+  INFERGRID_DEV_SKIP_ENGINE_LAUNCH=1 \
+    python3 -m infergrid.cli serve --config "$cfg_out" \
+      > "$run_dir/server.log" 2>&1 &
+  SERVE_PID=$!
+  for i in {1..30}; do
+    sleep 1
+    curl -sf "http://127.0.0.1:$SERVE_PORT/v1/models" >/dev/null && break
+    kill -0 "$SERVE_PID" 2>/dev/null || { echo "FATAL: infergrid serve crashed"; tail -40 "$run_dir/server.log"; return 1; }
+  done
+
+  echo "--- Phase 3 [$arm]: two-tenant bench (duration=${DURATION_S}s) ---"
+  echo "--- Phase 3 [$arm]: two-tenant bench (duration=${DURATION_S}s) ---" >/dev/null
+  # macOS doesn't ship GNU `timeout`; prefer `gtimeout` (coreutils) then
+  # bare exec. Bench has its own aiohttp timeout so bare is safe here.
+  local timeout_cmd=""
+  if command -v timeout >/dev/null 2>&1; then
+    timeout_cmd="timeout $TIMEOUT_S"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    timeout_cmd="gtimeout $TIMEOUT_S"
+  fi
+  $timeout_cmd python3 "$BENCH" \
+    --url "http://127.0.0.1:$SERVE_PORT" \
+    --model "$MODEL_ID" \
+    --flooder-rps "$FLOODER_RPS" --quiet-rps "$QUIET_RPS" \
+    --duration-s "$DURATION_S" --max-tokens 16 \
+    --output-dir "$run_dir" \
+    > "$run_dir/bench.log" 2>&1
+  local rc=$?
+  kill "$SERVE_PID" 2>/dev/null || true
+  wait "$SERVE_PID" 2>/dev/null || true
+  unset SERVE_PID
+
+  if [ $rc -ne 0 ]; then
+    echo "FAIL [$arm]: bench exit code $rc. Last 30 lines:"
+    tail -n 30 "$run_dir/bench.log"
+    return 1
+  fi
+
+  # Validate outputs
+  for f in "$run_dir/tenant_flooder.csv" "$run_dir/tenant_quiet_user.csv" "$run_dir/summary.json"; do
+    [ -s "$f" ] || { echo "FAIL [$arm]: missing or empty $f"; return 1; }
+  done
+
+  # Minimum success counts + key presence
+  python3 - <<PYEOF || return 1
+import json, sys
+s = json.load(open("$run_dir/summary.json"))
+q = s["quiet_user"]; f = s["flooder"]
+assert q["count_ok"] > 0, f"quiet_user.count_ok=0 in $arm"
+assert f["count_ok"] > 0, f"flooder.count_ok=0 in $arm"
+assert q["ttft_p99_ms"] > 0, f"quiet_user.ttft_p99_ms<=0 in $arm"
+print(f"  [$arm] ok: quiet n={q['count_ok']} p99={q['ttft_p99_ms']}ms, flooder n={f['count_ok']} p99={f['ttft_p99_ms']}ms")
+PYEOF
+
+  # Tenant header propagated?
+  grep -q "tenant_id=flooder\|tenant=flooder\|X-Tenant-ID.*flooder" "$run_dir/server.log" \
+    || echo "  NOTE [$arm]: could not confirm tenant_id=flooder in server.log (may still be ok if router doesn't log the header)"
+  return 0
+}
+
+FAILED=0
+for pair in "fifo:$ARM_FIFO_CFG" "drr:$ARM_DRR_CFG"; do
+  arm="${pair%%:*}"
+  cfg="${pair#*:}"
+  if run_arm "$arm" "$cfg"; then
+    echo "=== $arm ARM PASSED ==="
+  else
+    echo "=== $arm ARM FAILED ==="
+    FAILED=1
+  fi
+done
+
+if [ $FAILED -eq 0 ]; then
+  echo "OVERALL: PASS — Gate 2-FAIRNESS plumbing is wired correctly"
+  exit 0
+else
+  echo "OVERALL: FAIL — do not provision the A100 until the failures above are fixed"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
Full scaffold for the Gate 2-FAIRNESS experiment — the pivot after Gate 1.5's robust DISCONFIRM. Tests whether PR #42's DRR priority discipline rescues a quiet tenant starved by a flooder on a shared single-model engine. Dress rehearsal passes end-to-end on CPU.

## Why (experiment pivot rationale)
Gate 1.5 showed single-model admission cap isn't load-bearing — vLLM's continuous batching matches or beats it. The next middleware value-prop is **per-tenant fairness**, which engines structurally can't do (vLLM has no tenant concept). Advisor + god-planner creative scrum synthesized this pivot (see `.claude/agent-memory-local/god-planner/project_creative_pivot_apr19.md`).

## Ships

| File | LOC | Purpose |
|---|---:|---|
| `benchmarks/scripts/benchmark_two_tenant_single_model.py` | 295 | Two-tenant Poisson-arrival harness, streaming completions, X-Tenant-ID propagation, per-tenant CSVs + summary.json |
| `configs/gate2_fairness_fifo.yaml` | 35 | Arm 2 control — current shipping behavior |
| `configs/gate2_fairness_drr.yaml` | 36 | Arm 3 treatment — only `scheduling: drr` differs |
| `docs/launch/gate2_fairness_runbook.md` | 172 | Pre-flight + 5-command launch + CONFIRM/DISCONFIRM rubric + abort rules |
| `scripts/gate2_fairness_dress_rehearsal.sh` | 215 | CPU-only plumbing validation with mock engine |
| `PROGRESS.md` | Δ | PR #41/#42 rows + Gate 2-FAIRNESS as NEXT / Gate 2-lite demoted to Plan B |

## Dress rehearsal result (local, Apple Silicon, mock engine)

```
[fifo] ok: quiet n=10 p99=35.6ms, flooder n=34 p99=33.0ms
=== fifo ARM PASSED ===
[drr]  ok: quiet n=10 p99=34.5ms, flooder n=34 p99=32.6ms
=== drr ARM PASSED ===
OVERALL: PASS — Gate 2-FAIRNESS plumbing is wired correctly
```

(TTFT is identical because the mock isn't contended; the dress rehearsal validates plumbing, not the hypothesis. Real contention requires a vLLM engine with GPU.)

## Pre-committed rubric (from the runbook)
- **CONFIRM:** `Arm3.quiet.p99 ≤ 1.5× Arm0` AND `Arm1.quiet.p99 ≥ 4× Arm0`
- **DISCONFIRM-no-starvation:** `Arm1.quiet.p99 < 2× Arm0` (vLLM was fairer than expected)
- **DISCONFIRM-DRR-no-help:** starvation exists but DRR doesn't fix it
- **PLUMBING-REGRESSION:** Arm2 ≠ Arm1 (FIFO default path regressed) OR Arm3 quiet > Arm3 flooder (priority inversion)

## Gate 1.5 lessons baked in
- `TCPConnector.limit` raised per concurrency estimate (PR #34)
- TTFT v2 path (`.strip()` to reject whitespace frames, `delta.content` fallback) (PR #31)
- Fixed wall-clock duration, not fixed request count (PR #39 Little's Law caveat)
- macOS-portable `timeout` fallback in the rehearsal

## Test plan
- [x] `pytest tests/unit/` — 135/135 still passing
- [x] `bash scripts/gate2_fairness_dress_rehearsal.sh` — OVERALL: PASS
- [x] Both tenant CSVs produced with expected row counts (flooder ≈ 30/10s, quiet ≈ 10/10s)
- [x] summary.json has required keys (quiet_user.ttft_p99_ms, flooder.ttft_p99_ms)
- [x] Neither config pulls in the c=192 queue-time floor from Gate 1.5 (max_concurrent=256)
- [ ] Future: A100-SXM4 pod spin per runbook (~$3-4 actual, $8 ceiling)
- [ ] Future: write `GATE2_FAIRNESS_OUTCOME.md` with 3-bar hero chart on CONFIRM

## Reviewer notes
- Arm 1 and Arm 2 will look identical in practice at ~33 RPS aggregate — admission cap=256 isn't the bottleneck. That's OK; Arm 2 is a plumbing sanity check. The decisive delta is Arm 2 vs Arm 3.
- Runbook's "raw vLLM" Arm 1 uses InferGrid with max_concurrent=256 (effectively passthrough) — pragmatic to avoid building a separate launcher. A future PR could add an `--admission-bypass` flag for cleaner Arm 1.