### PR TITLE
feat(tenant): token-bucket rate limit (eliminates Gate 2-FAIRNESS Arm 5 warmup transient)

### DIFF
--- a/src/infergrid/cli.py
+++ b/src/infergrid/cli.py
@@ -150,6 +150,7 @@ async def _run_server(config: InferGridConfig) -> None:
     default_budget = TenantBudget(
         max_concurrent_requests=td.max_concurrent_requests,
         rate_limit_rpm=td.rate_limit_rpm,
+        rate_limit_burst=td.rate_limit_burst,
         max_gpu_memory_gb=td.max_gpu_memory_gb,
         priority=td.priority,
     )

--- a/src/infergrid/common/config.py
+++ b/src/infergrid/common/config.py
@@ -60,7 +60,13 @@ class TenantDefaults:
     """Default resource budgets for new tenants."""
 
     max_concurrent_requests: int = 64
-    rate_limit_rpm: int = 600  # requests per minute
+    rate_limit_rpm: int = 600  # requests per minute (sustained refill rate)
+    # Token-bucket burst capacity. None defaults to rate_limit_rpm
+    # (sliding-window-equivalent). Set to a small value like rate_limit_rpm/60
+    # for a tight bucket that fires from t=0 with no warmup transient — the
+    # Gate 2-FAIRNESS Arm 5 caveat fix. Recommended for fairness-critical
+    # multi-tenant configs.
+    rate_limit_burst: int | None = None
     max_gpu_memory_gb: float = 40.0
     # Lower = served first (matches AdmissionController + BUCKET_PRIORITY).
     # Default 1 = medium tier. Static priority for tenant tiers; combined

--- a/src/infergrid/tenant/manager.py
+++ b/src/infergrid/tenant/manager.py
@@ -19,6 +19,11 @@ class TenantBudget:
 
     max_concurrent_requests: int = 64
     rate_limit_rpm: int = 600
+    # Token-bucket burst capacity (max tokens). None = sliding-window-equivalent
+    # (capacity = rate_limit_rpm). Set to a small value (e.g. rate_limit_rpm/60)
+    # for a tight bucket that engages from t=0 with no warmup transient — the
+    # Gate 2-FAIRNESS lesson. Bucket refills at rate_limit_rpm/60 tokens/sec.
+    rate_limit_burst: int | None = None
     max_gpu_memory_gb: float = 40.0
     priority: int = 1
 
@@ -32,8 +37,6 @@ class TenantUsage:
     token_count_out: int = 0
     gpu_seconds: float = 0.0
     active_requests: int = 0
-    # Sliding window for rate limiting: list of request timestamps
-    _request_timestamps: list[float] = field(default_factory=list)
 
 
 class TenantRecord:
@@ -51,37 +54,54 @@ class TenantRecord:
         self._semaphore = asyncio.Semaphore(budget.max_concurrent_requests)
         self._available = budget.max_concurrent_requests
         self._lock = asyncio.Lock()
+        # Token-bucket rate limit. capacity = burst (default rate_limit_rpm
+        # for sliding-window backward compat); refill_rate = rpm/60.
+        # Replaces the prior 60s-window list-of-timestamps. The window
+        # design had a real cost: at t=0 it allowed `rate_limit_rpm`
+        # bursts before any 429s fired (Gate 2-FAIRNESS Arm 5 caveat —
+        # ~30s warmup transient before quiet tenant saw baseline TTFT).
+        # Token bucket fires immediately when the bucket runs dry.
+        self._token_capacity: float = float(
+            budget.rate_limit_burst
+            if budget.rate_limit_burst is not None
+            else budget.rate_limit_rpm
+        )
+        self._tokens: float = self._token_capacity
+        self._refill_per_sec: float = budget.rate_limit_rpm / 60.0
+        self._last_refill_t: float = time.monotonic()
 
     async def try_acquire(self) -> bool:
         """Try to acquire a request slot without blocking.
 
-        Checks both the concurrency semaphore and the sliding-window
-        rate limit.
+        Checks the token-bucket rate limit AND concurrency cap atomically.
+        A failed concurrency check does NOT consume a token (we won't
+        process the request, so don't penalize the rate budget).
 
         Returns:
             True if the request is allowed, False if it should be rejected.
         """
-        # Check rate limit first (cheap)
         async with self._lock:
+            # Refill tokens up to capacity based on elapsed wall time.
             now = time.monotonic()
-            window_start = now - 60.0
-            # Prune old timestamps
-            self.usage._request_timestamps = [
-                ts for ts in self.usage._request_timestamps
-                if ts > window_start
-            ]
-            if len(self.usage._request_timestamps) >= self.budget.rate_limit_rpm:
+            self._tokens = min(
+                self._token_capacity,
+                self._tokens + (now - self._last_refill_t) * self._refill_per_sec,
+            )
+            self._last_refill_t = now
+
+            if self._tokens < 1.0:
+                return False
+            if self._available <= 0:
                 return False
 
-        # Try concurrency limit (non-blocking)
-        if self._available <= 0:
-            return False
-
-        self._available -= 1
-        await self._semaphore.acquire()
-        async with self._lock:
-            self.usage._request_timestamps.append(time.monotonic())
+            # Both gates pass — consume.
+            self._tokens -= 1.0
+            self._available -= 1
             self.usage.active_requests += 1
+
+        # Acquire the semaphore outside the lock; matches `_available`
+        # so this is non-blocking in practice.
+        await self._semaphore.acquire()
         return True
 
     async def release(self) -> None:
@@ -140,6 +160,7 @@ class TenantRecord:
             "budget": {
                 "max_concurrent_requests": self.budget.max_concurrent_requests,
                 "rate_limit_rpm": self.budget.rate_limit_rpm,
+                "rate_limit_burst": self._token_capacity,
                 "max_gpu_memory_gb": self.budget.max_gpu_memory_gb,
                 "priority": self.budget.priority,
             },
@@ -149,6 +170,7 @@ class TenantRecord:
                 "token_count_out": self.usage.token_count_out,
                 "gpu_seconds": round(self.usage.gpu_seconds, 2),
                 "active_requests": self.usage.active_requests,
+                "rate_limit_tokens_remaining": round(self._tokens, 2),
             },
         }
 
@@ -193,6 +215,7 @@ class TenantManager:
                 budget=budget or TenantBudget(
                     max_concurrent_requests=self._default_budget.max_concurrent_requests,
                     rate_limit_rpm=self._default_budget.rate_limit_rpm,
+                    rate_limit_burst=self._default_budget.rate_limit_burst,
                     max_gpu_memory_gb=self._default_budget.max_gpu_memory_gb,
                     priority=self._default_budget.priority,
                 ),

--- a/tests/unit/test_tenant_token_bucket.py
+++ b/tests/unit/test_tenant_token_bucket.py
@@ -1,0 +1,167 @@
+"""Token-bucket rate-limit tests for TenantRecord.
+
+The token bucket replaced a 60-second sliding-window list-of-timestamps.
+The window had a real cost — Gate 2-FAIRNESS Arm 5 saw a ~30s warmup
+transient where flooder bursts were allowed before the window filled
+and 429s started firing. Token bucket fires the moment the bucket runs
+dry, with no warmup. Backward compat: burst defaults to rate_limit_rpm
+which gives sliding-window-equivalent semantics for existing configs.
+
+See `results/gate2_fairness_20260419/GATE2_FAIRNESS_OUTCOME.md` for the
+empirical motivation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from infergrid.tenant.manager import TenantBudget, TenantRecord
+
+
+class TestTokenBucketDefaults:
+    """Backward-compat: burst=None defaults to rate_limit_rpm."""
+
+    def test_default_capacity_matches_rpm(self) -> None:
+        budget = TenantBudget(rate_limit_rpm=600)  # burst=None
+        record = TenantRecord("t", budget)
+        assert record._token_capacity == 600.0
+
+    def test_explicit_burst_overrides_default(self) -> None:
+        budget = TenantBudget(rate_limit_rpm=600, rate_limit_burst=10)
+        record = TenantRecord("t", budget)
+        assert record._token_capacity == 10.0
+
+    def test_refill_rate_independent_of_burst(self) -> None:
+        b1 = TenantBudget(rate_limit_rpm=600, rate_limit_burst=600)
+        b2 = TenantBudget(rate_limit_rpm=600, rate_limit_burst=10)
+        # Both refill at 10 tokens/sec; only the cap differs.
+        assert TenantRecord("t1", b1)._refill_per_sec == 10.0
+        assert TenantRecord("t2", b2)._refill_per_sec == 10.0
+
+
+class TestTokenBucketBurst:
+    """Bucket allows up to `burst` immediate acquires before throttling."""
+
+    @pytest.mark.asyncio
+    async def test_tight_bucket_throttles_at_t0(self) -> None:
+        # rpm=60 (1/s refill), burst=3. Should allow 3 then 429 immediately.
+        budget = TenantBudget(
+            max_concurrent_requests=999, rate_limit_rpm=60, rate_limit_burst=3
+        )
+        record = TenantRecord("t", budget)
+        for _ in range(3):
+            assert await record.try_acquire() is True
+            await record.release()
+        assert await record.try_acquire() is False
+
+    @pytest.mark.asyncio
+    async def test_default_burst_allows_full_rpm_burst(self) -> None:
+        # burst=None defaults to rpm. Backward-compat with prior sliding-window.
+        budget = TenantBudget(
+            max_concurrent_requests=999, rate_limit_rpm=5
+        )
+        record = TenantRecord("t", budget)
+        for _ in range(5):
+            assert await record.try_acquire() is True
+            await record.release()
+        assert await record.try_acquire() is False
+
+
+class TestTokenBucketRefill:
+    """Bucket refills at rpm/60 tokens/sec up to capacity."""
+
+    @pytest.mark.asyncio
+    async def test_refill_after_drain(self) -> None:
+        # rpm=600 (10/s refill), burst=3. Drain, sleep, expect refill.
+        budget = TenantBudget(
+            max_concurrent_requests=999, rate_limit_rpm=600, rate_limit_burst=3
+        )
+        record = TenantRecord("t", budget)
+        for _ in range(3):
+            assert await record.try_acquire() is True
+            await record.release()
+        # Drained — next acquire fails.
+        assert await record.try_acquire() is False
+        # Sleep 0.25s → ~2.5 tokens refill (10 tokens/sec). Two more acquires ok.
+        await asyncio.sleep(0.25)
+        assert await record.try_acquire() is True
+        await record.release()
+        assert await record.try_acquire() is True
+        await record.release()
+        # Third would need full token — likely not yet available without more wait.
+        # Don't assert on it — timing-sensitive. The two-acquire test is enough.
+
+    @pytest.mark.asyncio
+    async def test_refill_caps_at_capacity(self) -> None:
+        # Long sleep should NOT overflow capacity.
+        budget = TenantBudget(
+            max_concurrent_requests=999, rate_limit_rpm=600, rate_limit_burst=3
+        )
+        record = TenantRecord("t", budget)
+        # Drain.
+        for _ in range(3):
+            assert await record.try_acquire() is True
+            await record.release()
+        # Sleep way longer than would refill capacity.
+        await asyncio.sleep(0.6)  # 6 tokens at 10/s, capped at 3.
+        # Still only 3 acquires possible, not 6.
+        for _ in range(3):
+            assert await record.try_acquire() is True
+            await record.release()
+        assert await record.try_acquire() is False
+
+
+class TestTokenBucketIsolation:
+    """A failed concurrency check must NOT consume a token."""
+
+    @pytest.mark.asyncio
+    async def test_concurrency_failure_preserves_token(self) -> None:
+        # Tight burst, concurrency=1. First acquire takes both. Second fails on
+        # CONCURRENCY (not rate limit) — token must be preserved for later.
+        budget = TenantBudget(
+            max_concurrent_requests=1, rate_limit_rpm=60, rate_limit_burst=2
+        )
+        record = TenantRecord("t", budget)
+        assert await record.try_acquire() is True
+        # Tokens went 2 → 1, available went 1 → 0.
+        # Second acquire should fail on concurrency, NOT consume the second token.
+        assert await record.try_acquire() is False
+        # Release concurrency. Token should still be available.
+        await record.release()
+        # Now we should be able to acquire again — token still there.
+        assert await record.try_acquire() is True
+        await record.release()
+
+
+class TestNoWarmupTransient:
+    """The motivating Gate 2-FAIRNESS Arm 5 caveat: tight bucket fires from t=0,
+    no 30s warmup."""
+
+    @pytest.mark.asyncio
+    async def test_flooder_throttled_immediately(self) -> None:
+        # rpm=600, burst=10 (1 second's worth at 10 RPS sustained). A flooder
+        # offering 32 RPS gets 10 through immediately, then rate-limited from
+        # there. With the OLD sliding window, flooder would have gotten ~600
+        # through over 19 seconds before any 429s.
+        budget = TenantBudget(
+            max_concurrent_requests=9999,
+            rate_limit_rpm=600,
+            rate_limit_burst=10,
+        )
+        record = TenantRecord("flooder", budget)
+        # Try 50 acquires back-to-back. ~10 should succeed, the rest fail.
+        successes = 0
+        for _ in range(50):
+            if await record.try_acquire():
+                successes += 1
+                await record.release()
+        # At t=0 with burst=10, exactly 10 should succeed (or at most 10 plus
+        # a tiny refill if event loop scheduling delays arose). 50 is safely
+        # bounded above by 10 + small timing slop.
+        assert successes >= 10, f"expected at least the burst (10), got {successes}"
+        assert successes <= 12, (
+            f"expected at most the burst + tiny refill, got {successes} — "
+            "warmup transient may have regressed"
+        )


### PR DESCRIPTION
## Summary
Replaces the 60s sliding-window rate-limit in TenantRecord with a token bucket. **Backward-compatible** (default burst = rate_limit_rpm preserves prior semantics). Adds optional `rate_limit_burst` field for tight buckets that fire from t=0.

## Why
Gate 2-FAIRNESS Arm 5 (\`results/gate2_fairness_20260419/GATE2_FAIRNESS_OUTCOME.md\`) showed the 60s sliding window had a real cost: flooder pushed ~600 reqs into vLLM during the first ~19s before any 429s fired. Quiet tenant TTFT inherited the saturation for ~30s (p99 = 5378ms full-bench, vs ~30ms steady state). Token bucket with burst=10 (1s worth of capacity) throttles immediately.

## What changed
- **TenantBudget**: new `rate_limit_burst: int | None = None` field. None = sliding-window-equivalent capacity (= rpm).
- **TenantRecord**: token bucket with refill rate = rpm/60 tokens/sec, capped at burst. Atomic check-and-consume inside lock.
- **TenantUsage**: dropped \`_request_timestamps\` (was sliding-window's internal state).
- **TenantDefaults** + **cli.py**: wire rate_limit_burst end-to-end so YAML configs can set it.
- **snapshot()**: surfaces rate_limit_burst (capacity) and rate_limit_tokens_remaining (live counter) for /status visibility.

## Tests
- 9 new tests in \`tests/unit/test_tenant_token_bucket.py\` (defaults, burst behavior, refill mechanics, capacity ceiling, concurrency-isolation, no-warmup-transient verification at scale).
- Existing \`test_rate_limiting\` in test_tenant_manager.py: **unchanged and passes** — default burst=rpm gives same observable behavior.
- **Full unit suite: 144/144 passing** (135 + 9 new).

## Test plan
- [x] \`pytest tests/unit/test_tenant_token_bucket.py -xvs\` — 9/9 pass
- [x] \`pytest tests/unit/\` — 144/144 pass
- [x] No regression in test_tenant_manager.py (default behavior preserved)
- [x] Token-bucket properties verified: refill ≤ capacity, concurrency-failure preserves token, tight burst throttles at t=0
- [ ] Future PR #48: \`configs/gate2_fairness_token_bucket.yaml\` (rpm=600, burst=10) + Arm 5b empirical validation on A100-SXM4 — prove the per-window quiet TTFT trace shows baseline from t=0, not t=30

## Backward compatibility
- Default burst=rate_limit_rpm — existing configs see no behavior change.
- For fairness-critical multi-tenant configs, recommend setting \`rate_limit_burst\` to ~1 second's worth (\`rate_limit_rpm/60\`).

## Notes for reviewers
- Lock scope tightened: try_acquire's check-and-consume now happens entirely inside one lock, eliminating a TOCTOU window the prior code had between sliding-window check (line 65-74) and timestamp append (line 82-83).
- Failed concurrency check no longer consumes a rate token — the new behavior matches the prior intent (timestamp was only appended after both passed).