### PR TITLE
docs: pivot README + pitch.md to tenant-fairness hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,160 +1,147 @@
 # InferGrid
 
-**The missing orchestration layer for LLM inference — intelligent multi-model serving without Kubernetes.**
+**Tenant-fair LLM inference orchestration on a single GPU. No Kubernetes.**
 
-InferGrid is a middleware that jointly optimizes scheduling, KV cache management, and GPU multi-tenancy for LLM inference. It sits on top of existing engines (vLLM, SGLang) and turns 1-4 GPUs into an intelligent inference platform — no Kubernetes, no datacenter infrastructure.
+InferGrid is middleware that sits on top of vLLM/SGLang and gives a quiet user predictable TTFT even when a noisy neighbor is hammering the same shared engine. One pip install. No cluster. No YAML pile.
 
-## The Problem
+## The hero number
 
-Current LLM serving suffers from scheduling quality degradation under load:
+![Quiet-tenant TTFT under noisy-neighbor contention — three arms compared on log scale, with the per-window trace showing zero warmup transients in the token-bucket arm](docs/launch/figures/launch_hero_chart.png)
 
-| Layer | Problem | Impact |
-|-------|---------|--------|
-| **Scheduling** | TTFT degrades 8-15x at saturation (c>128) while GPU stays >95% utilized | Users experience multi-second wait times despite available compute |
-| **KV Cache** | No unified lifecycle management across memory tiers | KV cache evicted and recomputed; no cross-tier offloading |
-| **Multi-Model** | Models loaded/evicted with naive LRU | Cold-start latency spikes when traffic patterns shift |
+Single A100, Llama-3.1-8B, two clients sharing one engine: a flooder at 32 RPS, a quiet user at 1 RPS.
 
-GPU utilization is consistently >95% -- the waste is in **scheduling quality** (TTFT degradation, tail latency), not GPU idleness.
+| | Quiet user TTFT p99 |
+|---|---:|
+| Solo (no contention) | 54.9 ms |
+| Vanilla vLLM under flooder | **28,716 ms** (523× starvation) |
+| InferGrid + token-bucket rate-limit | **74.2 ms** (within 1.35× of solo) |
+
+Ten lines of YAML. No application code change. The quiet user is essentially unaware the flooder exists.
+
+Full writeup: [`results/gate2_fairness_20260419/GATE2_FAIRNESS_OUTCOME.md`](results/gate2_fairness_20260419/GATE2_FAIRNESS_OUTCOME.md) + [`SUPPLEMENT_arm5b.md`](results/gate2_fairness_20260419/GATE2_FAIRNESS_SUPPLEMENT_arm5b.md).
+
+## What InferGrid is and isn't
+
+InferGrid is a thin orchestration layer (~3,500 LOC) that sits between your app and vLLM/SGLang. It adds three things engines can't do internally:
+
+1. **Per-tenant token-bucket rate limiting at the budget gate.** This is the load-bearing mechanism (validated empirically — see Gate 2-FAIRNESS results). Engines have no concept of a tenant; InferGrid does.
+2. **Multi-model lifecycle management** on a single GPU — frequency+recency eviction, hot-swap routing, no-K8s.
+3. **OpenAI-compatible HTTP API** in front of multiple engines, so your app code doesn't change.
+
+It is **not** a vLLM/SGLang replacement. It runs them as subprocesses and proxies to them. It is **not** a Kubernetes alternative for datacenter workloads — Dynamo, llm-d, Mammoth do that better. It is **not** going to magically lower single-tenant TTFT — Gate 1.5 measured a robust DISCONFIRM there; vLLM's continuous batching matches a coarse upstream cap on single-tenant single-model workloads.
 
 ## Why InferGrid
 
-Every existing solution requires either Kubernetes or gives up intelligent scheduling:
+Every existing solution requires Kubernetes or gives up tenant fairness:
 
-| System | K8s Required | Multi-Model | KV Tiering | Intelligent Scheduling |
-|--------|:------------:|:-----------:|:----------:|:---------------------:|
-| NVIDIA Dynamo v1.0 | Yes | Yes | Yes | Yes |
-| llm-d v0.5 (CNCF) | Yes | 1 model/pool | Yes | Yes |
-| Mammoth (Modular) | Yes | Yes | Yes | Yes |
-| AIBrix v0.6 | Yes | Yes | Yes | Yes |
-| Ollama | No | LRU only | No | No |
-| LocalAI | No | LRU only | No | No |
-| **InferGrid** | **No** | **Yes** | **Planned** | **Yes** |
+| System | K8s Required | Multi-Model | Per-Tenant Fairness | Hardware |
+|---|:---:|:---:|:---:|---|
+| NVIDIA Dynamo v1.0 | Yes | Yes | No | NVIDIA only, datacenter |
+| llm-d v0.5 (CNCF) | Yes | 1/pool | No | NVIDIA, datacenter |
+| Mammoth (Modular) | Yes | Yes | No | NVIDIA + AMD, datacenter |
+| AIBrix v0.6 | Yes | Yes | No | NVIDIA, datacenter |
+| Ollama | No | LRU eviction | No | Multi, single node |
+| Vanilla vLLM/SGLang | No | One model per process | No | Single node |
+| **InferGrid** | **No** | **Yes (frequency+recency)** | **Yes (token bucket + DRR)** | **Single node, 1-4 GPUs** |
 
-InferGrid is the only system that provides intelligent multi-model orchestration, KV cache tiering, and per-tenant isolation on bare metal without Kubernetes.
+The "multi-tenant on a small shared box without K8s" cell is empty. That's the gap InferGrid fills.
+
+## Quickstart
+
+```bash
+pip install -e .          # PyPI placeholder pending; until then, install from source
+infergrid serve --config configs/quickstart_fairness.yaml
+
+# Hit it as two tenants on the same model:
+curl localhost:8000/v1/completions -H "X-Tenant-ID: noisy" \
+  -d '{"model":"llama31-8b","prompt":"...","max_tokens":64,"stream":true}'
+curl localhost:8000/v1/completions -H "X-Tenant-ID: quiet" \
+  -d '{"model":"llama31-8b","prompt":"...","max_tokens":64,"stream":true}'
+
+# Watch the rate-limit fire and the engine queue stay composed:
+curl localhost:8000/metrics | grep -E "tenant_rejected|admission_queue_depth"
+```
+
+The [`quickstart_fairness.yaml`](configs/quickstart_fairness.yaml) is heavily commented. For a deeper "when to use which lever" treatment, see the [Tuning Guide](docs/tuning_guide.md) — every recommendation in it traces back to a specific experiment.
 
 ## Architecture
 
 ```
                     +---------------------+
-                    |   WorkloadRouter    |  <-- request profiling, SLO-aware routing
+                    |   WorkloadRouter    |  request profiling, length-bucket scheduling
                     +--------+------------+
                              |
               +--------------+--------------+
               |              |              |
      +--------v--------+ +--v---+ +--------v--------+
-     |  CacheManager   | |Shared| | TenantManager   |
-     | GPU -> CPU -> SSD| |State | |Resource budgets |
+     |  CacheManager   | |Shared| | TenantManager   |  per-tenant token bucket + budget
+     |  (KV lifecycle) | |State | | rate_limit_burst|
      +-----------------+ +------+ +-----------------+
               |                            |
      +--------v----------------------------v--------+
-     |          vLLM / SGLang Engine                 |
+     |          vLLM / SGLang Engines (1-N)         |
      +----------------------------------------------+
 ```
 
-**WorkloadRouter** — Length-aware, frequency-based model loading and request scheduling. Not LRU — learns from traffic patterns.
+| Component | What it does | Source |
+|---|---|---|
+| WorkloadRouter | Length-bucketed admission queue, length-aware scheduling, model lifecycle (freq+recency, not LRU), OpenAI-compatible HTTP API | `src/infergrid/router/router.py` (655 LOC) |
+| AdmissionController | Concurrency cap with priority queue (lower=served first), Prometheus metrics, sub-ms fast-path | `src/infergrid/router/admission.py` (309 LOC) |
+| CacheManager | KV cache block tracking across GPU/CPU/SSD tiers, weighted eviction (planned LMCache integration) | `src/infergrid/cache/manager.py` (487 LOC) |
+| TenantManager | Per-tenant budgets, **token-bucket rate limiting** (refill + burst capacity), DRR priority scoring | `src/infergrid/tenant/manager.py` (267 LOC) |
+| Engine Adapters | Subprocess management for vLLM/SGLang, health checks, HTTP proxying | `src/infergrid/engines/` (277 LOC) |
 
-**CacheManager** — KV cache lifecycle tracking with planned LMCache integration for cross-tier offloading. Evicts based on predicted reuse, not just recency.
+Total: 2,872 LOC src + 2,400+ LOC tests (144 unit tests passing).
 
-**TenantManager** — Per-tenant resource budgets with request isolation. One tenant's burst doesn't starve others.
+## Empirical results
 
-## Phase 1 Results: The Scheduling Cliff
+Each claim above traces to a specific experiment. Numbers are **honest** — TTFT measurement was rebuilt mid-project after a shadow review caught the original harness was timing SSE first-frame RTT, not first non-empty token (see `results/CORRECTIONS.md` C2/C5).
 
-Profiled on NVIDIA A100 80GB SXM and H100 80GB SXM with Llama 3.1 8B Instruct:
+| Gate | Hardware | Spend | Verdict |
+|---|---|---:|---|
+| Gate 0 (system bring-up) | A100-SXM4 | $5.76 | PASS |
+| Gate 0.6 (real-vLLM bench validation) | A100-SXM4 | $3.17 | PASS |
+| Gate 1 (single-model admission cap, short bench) | H100 SXM5 | $1.00 | DISCONFIRM (under-powered, see Gate 1.5) |
+| Gate 1.5 (powered rerun, 16k req/arm) | H100 SXM5 | $1.30 | **Robust DISCONFIRM** — single-model admission cap is not load-bearing |
+| Gate 2-FAIRNESS (5 arms tenant fairness) | A100-SXM4 | $1.40 | **CONFIRM** — 523× starvation → ~30ms steady state with rate-limit |
+| Gate 2-FAIRNESS Arm 5b (token bucket) | A100-SXM4 | $0.30 | **CLEAN CONFIRM** — quiet within 1.35× of solo, no warmup transient |
+| Gate 2-FAIRNESS Arm 6 (DRR isolation) | A100-SXM4 | $0.30 | DRR not material on this workload — token bucket alone does the work |
 
-### Cross-Engine Throughput (tok/s)
+Total compute spend: ~$13. Full raw artifacts and per-window traces in `results/`.
 
-| Concurrency | vLLM A100 SXM | SGLang A100 SXM | vLLM H100 SXM |
-|:-----------:|:-------------:|:---------------:|:--------------:|
-| 1 | 90 | 84 | 150 |
-| 8 | 690 | 691 | 1,142 |
-| 32 | 2,060 | 2,155 | 3,590 |
-| 64 | 3,314 | 3,348 | 6,365 |
-| 128 | 5,334 | 5,276 | 10,341 |
-| 256 | 5,353 | 5,214 | 10,545 |
-
-**vLLM vs SGLang throughput gap does not exist** -- the engines are within <5% across all concurrency levels on identical hardware. The real difference is in scheduling quality.
-
-### TTFT at Saturation
-
-| Config | TTFT p50 (ms) |
-|--------|:-------------:|
-| vLLM A100 c=128 | 150.9 |
-| vLLM A100 c=256 | 2,315.2 |
-| SGLang A100 c=128 | 102.4 |
-| SGLang A100 c=256 | 1,052.8 |
-| vLLM H100 c=128 | 184.8 |
-| vLLM H100 c=256 | 1,293.4 |
-
-**The scheduling cliff is universal:** On all hardware and both engines, doubling concurrency past the saturation point yields <3% more throughput but 8-15x worse TTFT. GPU utilization stays >95% -- the bottleneck is scheduling quality, not compute.
-
-**SGLang has 2.2x better TTFT at saturation** (1,053ms vs 2,315ms at c=256 on A100 SXM), showing that scheduler implementation quality matters more than raw throughput.
-
-**InferGrid's intervention:** Admission control and multi-queue scheduling to maintain TTFT SLOs at saturation, with expected 2-4x p99 improvement. Multi-model lifecycle management to reduce cold-start latency during traffic shifts.
-
-## Quick Start
+## Tests
 
 ```bash
-pip install -e ".[dev,profiling]"
-```
-
-## Running Benchmarks
-
-### Cloud GPU (RunPod / Lambda Labs)
-
-```bash
-# Clone and set up
-git clone https://github.com/coconut-labs/infergrid.git
-cd infergrid
-
-# Option A: Universal benchmark runner (one engine per run)
-export HF_TOKEN="your_token"
-export ENGINE="vllm"  # or "sglang"
-export GPU_LABEL="a100-sxm"
-bash scripts/cloud_benchmark.sh
-
-# Option B: Full baseline collection
-source scripts/setup_venv.sh
-bash scripts/setup_gpu_env.sh --model-config configs/models/llama31_8b.yaml
-bash scripts/run_all_baselines.sh --model-config configs/models/llama31_8b.yaml
-```
-
-### Docker (local multi-GPU)
-
-```bash
-docker compose -f docker/docker-compose.yml up
-python benchmarks/scripts/run_baseline_comparison.py \
-    --vllm-url http://localhost:8000 \
-    --sglang-url http://localhost:8001 \
-    --concurrency 1,8,32,64,128,256 \
-    --workload all
-```
-
-### Tests
-
-```bash
-pytest tests/unit/ -v        # No GPU required
-pytest tests/integration/ -v # Requires aiohttp
+pytest tests/unit/        # 144 tests, no GPU required, ~10 s
 ```
 
 ## Roadmap
 
-| Phase | Status | Description |
-|-------|--------|-------------|
-| Phase 1 | Done | Profiling vLLM/SGLang scheduling overhead on A100/H100 |
-| Phase 2 | In Progress | WorkloadRouter: frequency-based model management, priority scheduling |
-| Phase 3 | Planned | CacheManager: GPU/CPU/SSD KV cache tiering |
-| Phase 4 | Planned | TenantManager: multi-tenant isolation with resource budgets |
-| Phase 5 | Planned | Integration benchmarks, arXiv preprint |
+| Phase | Status | Notes |
+|---|---|---|
+| Phase 1 — vLLM/SGLang profiling | ✅ Done | TTFT numbers under-counted by ~30ms (CORRECTIONS C2); honest TTFT shipped in PR #28/#31 |
+| Phase 2 — Core implementation | ✅ Done | WorkloadRouter, AdmissionController, TenantManager, CacheManager, CLI |
+| Gate 0 — first GPU bring-up | ✅ Done | A100-SXM4, system PASS |
+| Gate 0.6 — bench harness validation | ✅ Done | Real vLLM end-to-end |
+| Gate 1.5 — single-model admission test | ✅ Done | Falsified the original "scheduling cliff" pitch |
+| Gate 2-FAIRNESS — multi-tenant fairness | ✅ Done | Hero number; this README's lead chart |
+| **Launch** | **Tue 2026-05-12** | HN + r/LocalLLaMA + landing page; ship-gated on PyPI placeholder + Cloudflare Worker |
+| Gate 2-lite — multi-model contention | Post-launch | InferGrid's other differentiator vs Ollama; never benchmarked |
+| KV cache tiering (LMCache integration) | Post-launch | Phase 3 of original roadmap |
+| Multi-engine routing (vLLM ↔ SGLang) | Post-launch | Phase 1 hinted SGLang 2.2× better at TTFT at c=256 |
 
-## Research
+## Research artifacts
 
-- [Inference Orchestration Gap Analysis](docs/inference_orchestration_gaps_report.md) — 7 verified gaps in the LLM inference landscape (April 2026)
-- [Phase 1 Findings](docs/phase1_findings.md) — Scheduling overhead profiling results
-- [Strategic Analysis](docs/strategic_analysis.md) — Paper vs product decision framework
+- [Gate 2-FAIRNESS OUTCOME](results/gate2_fairness_20260419/GATE2_FAIRNESS_OUTCOME.md) + [SUPPLEMENT (Arm 5b)](results/gate2_fairness_20260419/GATE2_FAIRNESS_SUPPLEMENT_arm5b.md) + [SUPPLEMENT (Arm 6)](results/gate2_fairness_20260419/GATE2_FAIRNESS_SUPPLEMENT_arm6.md)
+- [Gate 1.5 OUTCOME](results/gate1_5_20260419/GATE1_5_OUTCOME.md)
+- [Gate 1 OUTCOME (with Little's Law caveat)](results/gate1_20260419/GATE1_OUTCOME.md)
+- [Tuning Guide](docs/tuning_guide.md) — when to use which lever, with empirical evidence
+- [Inference Orchestration Gap Analysis](docs/inference_orchestration_gaps_report.md) — competitive landscape (April 2026)
+- [Corrections / measurement honesty log](results/CORRECTIONS.md) — every metric we under-counted and the fix
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md). Bug reports especially welcome with a `prometheus_dump.txt` and `server.log` — that's worth more to us than a star.
 
 ## License
 

--- a/docs/pitch.md
+++ b/docs/pitch.md
@@ -2,73 +2,86 @@
 
 ## Problem
 
-LLM inference orchestration today requires Kubernetes and datacenter infrastructure. Developers running 1-4 GPUs on bare metal have exactly two options: Ollama (naive LRU eviction, no scheduling intelligence) or manual vLLM instances (one model per process, no shared memory). There is no intelligent multi-model orchestration layer for small-scale deployments.
+When two clients share a single inference engine on a single GPU — the canonical setup for any small team without datacenter infrastructure — the engine has no concept of *who* is asking. A noisy neighbor running 32 requests/sec starves a quiet user running 1 request/sec by **523× at p99 TTFT** (28,716 ms vs 54.9 ms in solo). Vanilla vLLM, vanilla SGLang. The engines don't know about tenants.
 
-Meanwhile, every inference engine hits a **scheduling cliff** at high concurrency: doubling load from 128 to 256 concurrent requests yields only +2% throughput but +718% worse time-to-first-token. Requests pile up in the scheduler queue and users experience multi-second delays. No existing tool manages this.
+Every existing fix is either (a) a Kubernetes-mandatory datacenter orchestrator (Dynamo, llm-d, Mammoth) or (b) Ollama-class single-tenant tooling. The 1-4 GPU, multi-tenant developer segment is unserved.
 
 ## Solution
 
-**InferGrid** is middleware that sits on top of vLLM and SGLang. One command to serve multiple models with intelligent orchestration:
+**InferGrid** is middleware that sits in front of vLLM/SGLang and adds the one thing engines structurally cannot do: per-tenant fairness. One pip install:
 
 ```
 pip install infergrid
-infergrid serve llama-8b qwen-7b --gpu-budget 80%
+infergrid serve --config configs/quickstart_fairness.yaml
 ```
 
-- **Multi-model lifecycle management** -- frequency+recency eviction, not LRU
-- **Admission control** -- keeps TTFT under SLO targets by shedding load before the scheduling cliff
-- **KV cache tiering** -- GPU HBM, CPU DRAM, NVMe SSD (planned, via LMCache integration)
-- **Per-tenant isolation** -- software resource budgets without static GPU partitioning
-- **No Kubernetes. No YAML. No cluster.**
+A token-bucket rate limit at the budget gate (10-line YAML config) brings the same starved quiet user to **74 ms p99 — within 1.35× of solo baseline** under the same flooder. The quiet user is essentially unaware the flooder exists.
+
+![Quiet-tenant TTFT under noisy-neighbor contention](figures/launch_hero_chart.png)
+
+Source: `results/gate2_fairness_20260419/GATE2_FAIRNESS_OUTCOME.md` + `SUPPLEMENT_arm5b.md`. Single A100, Llama-3.1-8B, 120s sustained per arm.
+
+InferGrid also ships:
+- **Multi-model lifecycle management** — frequency+recency eviction (not LRU), hot-swap routing, no-K8s
+- **OpenAI-compatible HTTP API** in front of multiple engines, so application code doesn't change
+- **Per-tenant DRR admission priority + Prometheus metrics** for production observability
 
 ## Market Validation
 
-The market for inference orchestration is proven and growing:
+- **Gimlet Labs** — $92M Menlo Ventures Series A, eight-figure revenues, top-3 frontier lab + top-3 hyperscaler customers. Validates inference orchestration as a category.
+- **Modular** — acquired BentoML, launched Mammoth, valued at $1.6B. Datacenter K8s play.
+- **NVIDIA Dynamo v1.0** — shipped March 2026 with 18+ deployment partners. NVIDIA-only, datacenter-only.
+- **llm-d** — entered CNCF Sandbox (March 2026), backed by Red Hat, Google Cloud, IBM, CoreWeave. K8s-mandatory.
 
-- **Gimlet Labs** raised $92M (Menlo Ventures-led Series A), reports eight-figure revenues, serves a top-3 frontier lab and a top-3 hyperscaler. Validates heterogeneous inference as a real business.
-- **Modular** acquired BentoML, launched Mammoth orchestrator, valued at $1.6B. K8s-native datacenter play.
-- **NVIDIA Dynamo v1.0** shipped March 2026 with 18+ deployment partners. NVIDIA-only, datacenter-only.
-- **llm-d** entered CNCF Sandbox (March 2026), backed by Red Hat, Google Cloud, IBM, CoreWeave. K8s-mandatory.
-
-All of these require Kubernetes or managed cloud. The 1-4 GPU developer segment is unserved.
+All require Kubernetes or managed cloud. The 1-4 GPU multi-tenant developer segment is unserved.
 
 ## Traction
 
-**Phase 1 profiling complete** on A100 SXM and H100 SXM GPUs with two novel findings:
-
-**1. The Scheduling Cliff** -- At concurrency >128, vLLM delivers +2% throughput but +718% worse TTFT (22ms to 2.6s). This cliff exists on all hardware and both engines. InferGrid's admission controller prevents requests from entering this regime.
-
-![Scheduling cliff detail](figures/scheduling_cliff_detail.png)
-
-**2. Engine Convergence** -- The vLLM-SGLang throughput gap does not exist (<5% difference). This contradicts 2024 findings and means the optimization opportunity is in scheduling quality, not engine selection. SGLang has 2.2x better TTFT at saturation.
-
-![Engine convergence](figures/engine_convergence.png)
-
-**Core system implemented:** 3,453 LOC across WorkloadRouter, CacheManager, TenantManager, and CLI. 1,257 LOC admission controller with concurrency-aware load shedding.
-
-![Throughput vs concurrency](figures/throughput_vs_concurrency.png)
+| Item | State |
+|---|---|
+| Core implementation | 2,872 LOC src + 144 unit tests passing (WorkloadRouter, AdmissionController, TenantManager, CacheManager) |
+| Honest TTFT measurement harness | Rebuilt mid-project after shadow review (PRs #28/#31); see `results/CORRECTIONS.md` |
+| Single-model admission cap claim | **Falsified** by Gate 1.5 (16,000 req H100 SXM5, B/A=1.04× — engines absorb overload as well as a coarse upstream cap does) |
+| Per-tenant fairness claim | **Confirmed** by Gate 2-FAIRNESS Arm 5b: 523× starvation → 74ms p99 (within 1.35× of solo) |
+| Total empirical compute spend | ~$13 across 11 GPU runs (A100/H100, RunPod) |
+| Ready-to-ship launch artifacts | Launch post (1559w, advisor-pressure-tested), hero chart PNG, quickstart yaml, tuning guide doc |
 
 ## Differentiation
 
-| | K8s Required | Multi-Model | KV Tiering | Admission Control | Target Scale |
-|---|:---:|:---:|:---:|:---:|---|
-| **InferGrid** | **No** | **Intelligent** | **Planned** | **Yes** | 1-4 GPUs |
-| Dynamo v1.0 | Yes | Yes | KVBM | No | Datacenter |
-| llm-d v0.5 | Yes | 1 model/pool | LMCache | No | Datacenter |
-| Mammoth (Modular) | Yes | Yes | Via backends | No | Datacenter |
-| Ollama | No | LRU only | No | No | Single node |
-| Gimlet Labs | Managed cloud | Yes | Yes | Unknown | Cloud |
+| | K8s Required | Multi-Model | Per-Tenant Fairness | Target Scale |
+|---|:---:|:---:|:---:|---|
+| **InferGrid** | **No** | **Yes (freq+recency)** | **Yes (token bucket + DRR)** | **1-4 GPUs, multi-tenant** |
+| Dynamo v1.0 | Yes | Yes | No | Datacenter |
+| llm-d v0.5 | Yes | 1 model/pool | No | Datacenter |
+| Mammoth (Modular) | Yes | Yes | No | Datacenter |
+| Ollama | No | LRU only | No | Single-tenant single-node |
+| Vanilla vLLM/SGLang | No | One model per process | No | Single-node |
 
-InferGrid is the only project combining no-K8s deployment with intelligent scheduling and KV cache tiering.
+InferGrid is the only project combining no-K8s deployment with **measured per-tenant fairness** on shared engines.
+
+## Honest scope (what we are NOT claiming)
+
+- Single hardware: A100-SXM4 80GB. Smaller models, multi-GPU tensor-parallel, H100 contended (vs uncontended), consumer GPUs — not measured.
+- Single engine: vLLM. SGLang has the matching adapter shipped but the fairness experiment hasn't been re-run on it.
+- Synthetic two-tenant workload (32 RPS flooder vs 1 RPS quiet). Real multi-tenant with >2 clients, bursty arrivals, mixed prompt lengths — not measured at this scale.
+- Per-arm n=113 quiet samples. Tight at p99; defense is the per-window distribution + max observation. Preprint-grade re-runs at 5+ minutes per arm are queued for post-launch.
 
 ## Ask
 
-Seed funding for a 12-week sprint to public beta:
+Seed funding to convert validated tenant-fairness pitch into a product:
 
-- **Weeks 1-4:** Multi-model demo with 70B parameter models (Llama 3.1 70B, Qwen 72B)
-- **Weeks 5-8:** KV cache tiering integration (LMCache), comprehensive benchmarks vs. Ollama and manual vLLM
-- **Weeks 9-12:** arXiv preprint, HN launch, public beta release
+- **Weeks 1-4 (post-launch):** Multi-model contention experiment (Gate 2-lite scoped but not yet run); enterprise-grade tenant tiers (gold/silver/bronze) on top of existing budget infra.
+- **Weeks 5-8:** KV cache tiering integration (LMCache); larger-scale fairness benchmarks with N>2 tenants; SGLang adapter parity validation.
+- **Weeks 9-12:** Reference deployments with 3-5 design partners; arXiv preprint covering the full 7-arm Gate 2-FAIRNESS experimental arc; public beta announcement.
 
 ## Team
 
-**Shrey Patel** -- Founder. Built the core system, ran all profiling, authored the gap analysis. Focused on closing the space between Ollama simplicity and datacenter orchestration intelligence.
+**Shrey Patel** — Founder. Built the core system, ran all empirical work, authored the gap analysis and tuning guide. Prior background informs the "engineer-grade rigor over marketing veneer" approach taken throughout the project.
+
+## Why now
+
+The frontier-engine race (vLLM 0.x, SGLang 0.x) has converged on continuous batching. Engine-internal scheduling is approaching local optima — the next gains come from layers above. InferGrid's empirical work shows that *per-tenant* fairness specifically is a layer engines structurally can't reach (they have no tenant concept). That niche has no incumbent and no Kubernetes-tax.
+
+---
+
+**Repo:** [github.com/coconut-labs/infergrid](https://github.com/coconut-labs/infergrid) · **Hero data:** `results/gate2_fairness_20260419/` · **Tuning guide:** `docs/tuning_guide.md` · **License:** MIT


### PR DESCRIPTION
Both anchored on the falsified 'scheduling cliff' narrative with broken pre-#28 TTFT numbers. Replaces with the Gate 2-FAIRNESS empirical hero (523× starvation → 74ms p99) and the validated architectural finding. Honest scope sections added — explicitly enumerates what is NOT measured.