### PR TITLE
feat: per-tenant TTFT histogram + fairness Grafana dashboard

### DIFF
--- a/dashboards/infergrid-fairness.json
+++ b/dashboards/infergrid-fairness.json
@@ -1,0 +1,155 @@
+{
+  "uid": "infergrid-fairness-v1",
+  "title": "InferGrid — Per-tenant fairness",
+  "schemaVersion": 39,
+  "version": 1,
+  "tags": ["infergrid", "fairness", "tenant"],
+  "timezone": "browser",
+  "refresh": "10s",
+  "time": {"from": "now-15m", "to": "now"},
+  "templating": {
+    "list": [
+      {
+        "name": "model",
+        "label": "Model",
+        "type": "query",
+        "datasource": {"type": "prometheus", "uid": "prometheus"},
+        "query": "label_values(infergrid_tenant_ttft_seconds_bucket, model)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": false,
+        "current": {"text": "All", "value": "$__all"}
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Per-tenant TTFT p99 (the hero metric)",
+      "description": "p99 TTFT per tenant. The launch claim — quiet within 1.35× of solo — lives here. Watch the gap between tenants widen under contention.",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 9, "w": 24, "x": 0, "y": 0},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.99, sum by (tenant, le) (rate(infergrid_tenant_ttft_seconds_bucket{model=~\"$model\"}[1m])))",
+          "legendFormat": "p99 — {{tenant}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {"lineWidth": 2, "fillOpacity": 5},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 0.2},
+              {"color": "red", "value": 1.0}
+            ]
+          }
+        }
+      },
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right", "calcs": ["mean", "max", "lastNotNull"]},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Per-tenant TTFT p50 vs p99 (starvation spread)",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 9},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.5, sum by (tenant, le) (rate(infergrid_tenant_ttft_seconds_bucket{model=~\"$model\"}[1m])))",
+          "legendFormat": "p50 — {{tenant}}"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.99, sum by (tenant, le) (rate(infergrid_tenant_ttft_seconds_bucket{model=~\"$model\"}[1m])))",
+          "legendFormat": "p99 — {{tenant}}"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "s", "custom": {"lineWidth": 1.5}}}
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Tenant rate-limit rejections (429s)",
+      "description": "When a tenant trips its token bucket. Count surge here = the rate-limit doing its job.",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 9},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (tenant) (rate(infergrid_tenant_requests_rejected_total[1m]))",
+          "legendFormat": "{{tenant}}"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "reqps"}}
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Quiet/loud TTFT-p99 ratio (fairness score)",
+      "description": "Ratio = max(p99) / min(p99) across tenants. 1.0 = perfect fairness. >10 = severe starvation.",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 0, "y": 17},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max(histogram_quantile(0.99, sum by (tenant, le) (rate(infergrid_tenant_ttft_seconds_bucket[1m])))) / clamp_min(min(histogram_quantile(0.99, sum by (tenant, le) (rate(infergrid_tenant_ttft_seconds_bucket[1m])))), 0.001)",
+          "legendFormat": "p99 ratio"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 2.0},
+              {"color": "red", "value": 10.0}
+            ]
+          }
+        }
+      },
+      "options": {"colorMode": "background", "graphMode": "area", "textMode": "value_and_name"}
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Admission queue depth",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 8, "y": 17},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "infergrid_admission_queue_depth",
+          "legendFormat": "queue depth"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Tenant request throughput",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "gridPos": {"h": 6, "w": 8, "x": 16, "y": 17},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (tenant) (rate(infergrid_tenant_requests_total[1m]))",
+          "legendFormat": "{{tenant}}"
+        }
+      ],
+      "fieldConfig": {"defaults": {"unit": "reqps"}}
+    }
+  ]
+}

--- a/src/infergrid/common/metrics.py
+++ b/src/infergrid/common/metrics.py
@@ -108,6 +108,19 @@ class MetricsCollector:
             labelnames=["tenant", "reason"],
             registry=self._registry,
         )
+        # Per-tenant TTFT histogram. The hero metric — quiet-tenant
+        # starvation manifests at p99 here. Buckets span solo baseline
+        # (~50ms) to severe starvation (>10s).
+        self.tenant_ttft_seconds = Histogram(
+            "infergrid_tenant_ttft_seconds",
+            "Time to first token by tenant + model (Prometheus histogram)",
+            labelnames=["model", "tenant"],
+            buckets=(
+                0.025, 0.05, 0.075, 0.1, 0.15, 0.25, 0.5, 1.0, 2.5,
+                5.0, 10.0, 30.0, 60.0,
+            ),
+            registry=self._registry,
+        )
 
         # --- GPU ---
         self.gpu_memory_used_bytes = Gauge(
@@ -147,6 +160,19 @@ class MetricsCollector:
             self.tokens_input.labels(model=model).inc(tokens_in)
         if tokens_out > 0:
             self.tokens_generated.labels(model=model).inc(tokens_out)
+
+    def record_ttft(self, model: str, tenant: str, ttft_s: float) -> None:
+        """Record per-tenant TTFT. Call exactly once per request, on the
+        first non-empty SSE token (sse_frames transition 0→1).
+
+        Args:
+            model: Model identifier.
+            tenant: Tenant identifier.
+            ttft_s: Time to first token in seconds.
+        """
+        if ttft_s < 0:
+            return
+        self.tenant_ttft_seconds.labels(model=model, tenant=tenant).observe(ttft_s)
 
     def record_cache_access(self, hit: bool, tier: str = "gpu") -> None:
         """Record a cache hit or miss.

--- a/src/infergrid/router/router.py
+++ b/src/infergrid/router/router.py
@@ -560,6 +560,12 @@ class WorkloadRouter:
                         if body == b"[DONE]":
                             continue
                         sse_frames += 1
+                        if sse_frames == 1:
+                            self.metrics.record_ttft(
+                                model=model_id,
+                                tenant=tenant_id,
+                                ttft_s=time.monotonic() - start_time,
+                            )
                     yield chunk
             status = "ok"
         except asyncio.TimeoutError:

--- a/tests/unit/test_metrics_ttft.py
+++ b/tests/unit/test_metrics_ttft.py
@@ -1,0 +1,59 @@
+"""Tests for per-tenant TTFT histogram in MetricsCollector."""
+from __future__ import annotations
+
+from prometheus_client import CollectorRegistry
+
+from infergrid.common.metrics import MetricsCollector
+
+
+def _ttft_count(metrics: MetricsCollector, *, model: str, tenant: str) -> int:
+    """Sum the _count sample for a given (model, tenant) pair."""
+    for fam in metrics._registry.collect():
+        if fam.name != "infergrid_tenant_ttft_seconds":
+            continue
+        for sample in fam.samples:
+            if sample.name == "infergrid_tenant_ttft_seconds_count" and \
+                    sample.labels.get("model") == model and \
+                    sample.labels.get("tenant") == tenant:
+                return int(sample.value)
+    return 0
+
+
+def test_record_ttft_increments_count():
+    m = MetricsCollector(registry=CollectorRegistry())
+    m.record_ttft(model="llama31-8b", tenant="quiet", ttft_s=0.05)
+    m.record_ttft(model="llama31-8b", tenant="quiet", ttft_s=0.1)
+    m.record_ttft(model="llama31-8b", tenant="noisy", ttft_s=2.5)
+    assert _ttft_count(m, model="llama31-8b", tenant="quiet") == 2
+    assert _ttft_count(m, model="llama31-8b", tenant="noisy") == 1
+
+
+def test_record_ttft_negative_ignored():
+    m = MetricsCollector(registry=CollectorRegistry())
+    m.record_ttft(model="llama31-8b", tenant="quiet", ttft_s=-0.1)
+    assert _ttft_count(m, model="llama31-8b", tenant="quiet") == 0
+
+
+def test_record_ttft_buckets_present_in_prometheus_output():
+    m = MetricsCollector(registry=CollectorRegistry())
+    m.record_ttft(model="llama31-8b", tenant="quiet", ttft_s=0.04)
+    out = m.prometheus_output().decode()
+    assert "infergrid_tenant_ttft_seconds" in out
+    # Hero buckets we care about for the launch story
+    assert 'le="0.05"' in out
+    assert 'le="0.1"' in out
+    assert 'le="10.0"' in out
+
+
+def test_record_ttft_per_tenant_independence():
+    m = MetricsCollector(registry=CollectorRegistry())
+    # Quiet tenant: all sub-100ms (the hero scenario)
+    for v in [0.04, 0.05, 0.06, 0.07, 0.08]:
+        m.record_ttft(model="llama31-8b", tenant="quiet", ttft_s=v)
+    # Noisy tenant: long-tail
+    for v in [0.5, 1.5, 5.0, 12.0, 28.0]:
+        m.record_ttft(model="llama31-8b", tenant="noisy", ttft_s=v)
+    out = m.prometheus_output().decode()
+    # Independence check: each tenant should have its own series
+    assert 'tenant="quiet"' in out
+    assert 'tenant="noisy"' in out


### PR DESCRIPTION
## Summary
- Add `infergrid_tenant_ttft_seconds` Prometheus Histogram with `model`+`tenant` labels
- Record TTFT at the SSE first-non-empty-frame transition in `router.py:540-564` (single observation per request)
- Ship `dashboards/infergrid-fairness.json` — 6-panel Grafana board for the fairness story (per-tenant p99 hero panel, p50/p99 spread, 429 surges, fairness ratio gauge, queue depth, throughput)
- 4 new unit tests; full suite 148/148 passing

This is Track B of the pre-launch sprint per the god-planner plan in `.claude/agent-memory-local/god-planner/prelaunch_sprint_apr19.md`. Makes the launch claim observable in production, not just the bench.

## Test plan
- [x] `PYTHONPATH=src pytest tests/unit/test_metrics_ttft.py -v` — 4/4 pass
- [x] `PYTHONPATH=src pytest tests/unit/` — 148/148 pass
- [ ] Smoke test on Track A pod once Arm 5b finishes — confirm Histogram populated under real traffic