### PR TITLE
fix: serialize concurrent ensure_model_loaded() calls per-model

### DIFF
--- a/src/infergrid/router/router.py
+++ b/src/infergrid/router/router.py
@@ -208,6 +208,16 @@ class WorkloadRouter:
         self._workers: list[asyncio.Task[None]] = []
         self._running = False
 
+        # Per-model load locks. Serializes concurrent load_model() calls
+        # for the same model_id; without this, N concurrent requests on a
+        # cold model spawn N engine subprocesses in parallel (each sees
+        # the cache empty in `ensure_model_loaded` and races into
+        # `load_model`). On a 32-RPS flooder hitting a cold engine, this
+        # is a 5-10x fork explosion that OOMs the GPU before any request
+        # can complete.
+        self._load_locks: dict[str, asyncio.Lock] = {}
+        self._load_locks_guard = asyncio.Lock()
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -354,12 +364,17 @@ class WorkloadRouter:
                 f"Known models: {list(self._model_configs.keys())}"
             )
 
-        # If we are at capacity, evict first
-        max_models = max(1, len(self.config.models))
-        if len(self._models) >= max_models:
-            await self.evict_model()
+        async with self._load_locks_guard:
+            lock = self._load_locks.setdefault(model_id, asyncio.Lock())
 
-        return await self.load_model(config)
+        async with lock:
+            # Re-check under lock — another waiter may have completed.
+            if model_id in self._models:
+                return self._models[model_id]
+            max_models = max(1, len(self.config.models))
+            if len(self._models) >= max_models:
+                await self.evict_model()
+            return await self.load_model(config)
 
     # ------------------------------------------------------------------
     # Request routing

--- a/tests/unit/test_router_ensure_model_loaded_race.py
+++ b/tests/unit/test_router_ensure_model_loaded_race.py
@@ -1,0 +1,111 @@
+"""Regression test for the ensure_model_loaded TOCTOU race.
+
+Before the fix: N concurrent requests for a cold model triggered N
+parallel load_model() calls (each calling adapter.start()). With 32
+in-flight on a cold engine that's a 32x subprocess explosion and a
+guaranteed OOM before any request completes.
+
+After the fix: concurrent ensure_model_loaded() calls for the same
+model serialize through a per-model asyncio.Lock; exactly one
+load_model() call fires and every waiter gets the same ModelState.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from infergrid.common.config import InferGridConfig, ModelConfig
+from infergrid.router.router import WorkloadRouter
+
+
+@pytest.mark.asyncio
+async def test_ensure_model_loaded_serializes_concurrent_calls(monkeypatch):
+    """32 concurrent ensure_model_loaded() calls → exactly 1 load_model()."""
+    cfg = InferGridConfig(
+        models=[
+            ModelConfig(
+                model_id="llama31-8b",
+                short_name="llama31-8b",
+                engine="vllm",
+                dtype="bfloat16",
+            )
+        ],
+    )
+    router = WorkloadRouter(cfg)
+
+    load_call_count = 0
+    load_started = asyncio.Event()
+    release_load = asyncio.Event()
+
+    async def slow_load(config):
+        nonlocal load_call_count
+        load_call_count += 1
+        load_started.set()
+        # Block until the test releases us; this gives the other coros
+        # a chance to race into load_model() if the lock is missing.
+        await release_load.wait()
+        # Fake a ModelState
+        state = MagicMock()
+        state.config = config
+        router._models[config.model_id] = state
+        return state
+
+    monkeypatch.setattr(router, "load_model", slow_load)
+
+    # Fan out 32 concurrent ensure_model_loaded() calls.
+    tasks = [asyncio.create_task(router.ensure_model_loaded("llama31-8b")) for _ in range(32)]
+
+    # Wait for the first load to start.
+    await asyncio.wait_for(load_started.wait(), timeout=1.0)
+    # Give the other 31 coros a chance to race.
+    await asyncio.sleep(0.05)
+    # Release the load.
+    release_load.set()
+
+    results = await asyncio.gather(*tasks)
+
+    assert load_call_count == 1, (
+        f"expected exactly 1 load_model() call, got {load_call_count} — the race is NOT fixed"
+    )
+    assert all(r is results[0] for r in results), "all waiters must receive the same ModelState"
+
+
+@pytest.mark.asyncio
+async def test_ensure_model_loaded_lock_is_per_model(monkeypatch):
+    """Two different model_ids load concurrently — not serialized by the lock."""
+    cfg = InferGridConfig(
+        models=[
+            ModelConfig(model_id="llama31-8b", short_name="l", engine="vllm", dtype="bfloat16"),
+            ModelConfig(model_id="qwen25-7b", short_name="q", engine="vllm", dtype="bfloat16"),
+        ],
+    )
+    router = WorkloadRouter(cfg)
+
+    in_flight = 0
+    max_in_flight = 0
+    release = asyncio.Event()
+
+    async def overlapping_load(config):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await release.wait()
+        state = MagicMock()
+        state.config = config
+        router._models[config.model_id] = state
+        in_flight -= 1
+        return state
+
+    monkeypatch.setattr(router, "load_model", overlapping_load)
+
+    t1 = asyncio.create_task(router.ensure_model_loaded("llama31-8b"))
+    t2 = asyncio.create_task(router.ensure_model_loaded("qwen25-7b"))
+    await asyncio.sleep(0.05)
+    release.set()
+    await asyncio.gather(t1, t2)
+
+    assert max_in_flight == 2, (
+        f"different models should load concurrently; got max_in_flight={max_in_flight}"
+    )


### PR DESCRIPTION
## Summary
Fixes a TOCTOU race in `WorkloadRouter.ensure_model_loaded()` that triggered a vLLM subprocess fork-bomb under cold-start flood. Under 32 concurrent first-touch requests, each caller saw the model cache empty and spawned its own engine. 6+ simultaneous vLLM processes OOM'd the 80GB A100 before any request could complete.

## Root cause
The check-then-load pattern had an await between check and load, making it concurrent-unsafe. With N concurrent callers and no lock, each fires its own `load_model()` which each spawns a subprocess.

## Fix
Per-model `asyncio.Lock` (guarded by an outer lock on the dict). Check-re-check pattern. Different model_ids still load concurrently.

## Evidence
Caught during Track A Arm 1 (Pod `8ldnojj8xq8abg`): `server.log` shows repeated `TimeoutError: vLLM server did not become healthy within 420s` and bench `summary.json` has `count_ok=0, count_err=303` for the quiet tenant — every request failed with 500.

## Test plan
- [x] `test_ensure_model_loaded_serializes_concurrent_calls` — 32 → 1 load calls
- [x] `test_ensure_model_loaded_lock_is_per_model` — different models don't serialize
- [x] Full suite 150/150 passing
- [ ] Re-run Track A Arm 1 + Arm 5b on Pod 2 with the fix