### PR TITLE
docs: README + pyproject + quickstart — destale PyPI refs, align v3 numbers, honest CacheManager wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The "multi-tenant on a small shared box without K8s" cell is empty. That's the g
 ## Quickstart
 
 ```bash
-pip install -e .          # PyPI placeholder pending; until then, install from source
+pip install infergrid
 infergrid serve --config configs/quickstart_fairness.yaml
 
 # Wait until /health returns 200. The first call returns 503 with a
@@ -132,7 +132,7 @@ pytest tests/unit/        # 144 tests, no GPU required, ~10 s
 | Gate 0.6 — bench harness validation | ✅ Done | Real vLLM end-to-end |
 | Gate 1.5 — single-model admission test | ✅ Done | Falsified the original "scheduling cliff" pitch |
 | Gate 2-FAIRNESS — multi-tenant fairness | ✅ Done | Hero number; this README's lead chart |
-| **Launch** | **Tue 2026-05-12** | HN + r/LocalLLaMA + landing page; ship-gated on PyPI placeholder + Cloudflare Worker |
+| **Launch** | **Tue 2026-05-12** | HN + r/LocalLLaMA + landing page; ship-gated on waitlist backend (Cloudflare Worker) |
 | Gate 2-lite — multi-model contention | Post-launch | InferGrid's other differentiator vs Ollama; never benchmarked |
 | KV cache tiering (LMCache integration) | Post-launch | Phase 3 of original roadmap |
 | Multi-engine routing (vLLM ↔ SGLang) | Post-launch | Phase 1 hinted SGLang 2.2× better at TTFT at c=256 |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The [`quickstart_fairness.yaml`](configs/quickstart_fairness.yaml) is heavily co
 |---|---|---|
 | WorkloadRouter | Length-bucketed admission queue, length-aware scheduling, model lifecycle (freq+recency, not LRU), OpenAI-compatible HTTP API | `src/infergrid/router/router.py` (655 LOC) |
 | AdmissionController | Concurrency cap with priority queue (lower=served first), Prometheus metrics, sub-ms fast-path | `src/infergrid/router/admission.py` (309 LOC) |
-| CacheManager | KV cache block tracking across GPU/CPU/SSD tiers, weighted eviction (planned LMCache integration) | `src/infergrid/cache/manager.py` (487 LOC) |
+| CacheManager | Per-model cache lifecycle (free-on-unload, snapshot) + tiered-eviction scaffold; LMCache integration planned for per-request KV tracking | `src/infergrid/cache/manager.py` (487 LOC) |
 | TenantManager | Per-tenant budgets, **token-bucket rate limiting** (refill + burst capacity), DRR priority scoring | `src/infergrid/tenant/manager.py` (267 LOC) |
 | Engine Adapters | Subprocess management for vLLM/SGLang, health checks, HTTP proxying | `src/infergrid/engines/` (277 LOC) |
 

--- a/configs/quickstart_fairness.yaml
+++ b/configs/quickstart_fairness.yaml
@@ -5,9 +5,11 @@
 # per-tenant token-bucket rate limiting at the budget gate so a noisy
 # neighbor cannot starve a quiet tenant.
 #
-# Empirical anchor (from results/gate2_fairness_20260419/):
-#   Vanilla vLLM under flooder: quiet p99 = 28,716 ms (523× starvation)
-#   This config:                quiet p99 = 74 ms (1.35× of solo baseline)
+# Empirical anchor (from results/gate2_preprint_v3/, vLLM 0.19.1, 300s steady state):
+#   InferGrid FIFO under flooder, no rate-limit: quiet p99 = 1,585 ms
+#   This config (token-bucket rate-limit):       quiet p99 = 61.5 ms (1.14× solo)
+# Historical (vLLM 0.8.5, 120s — results/gate2_fairness_20260419/):
+#   Vanilla vLLM under flooder showed 523× starvation; fix still matters on 0.19.1.
 #
 # Try it:
 #   infergrid serve --config configs/quickstart_fairness.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,27 @@
 [project]
 name = "infergrid"
 version = "0.1.0"
-description = "Adaptive inference orchestration for LLM serving"
+description = "Tenant-fair LLM inference orchestration on a single GPU. No Kubernetes."
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"
+authors = [{name = "Shrey Patel", email = "patelshrey77@gmail.com"}]
+keywords = ["llm", "inference", "vllm", "sglang", "multi-tenant", "gpu", "orchestration"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+
+[project.urls]
+Homepage = "https://github.com/coconut-labs/infergrid"
+Documentation = "https://github.com/coconut-labs/infergrid#readme"
+Repository = "https://github.com/coconut-labs/infergrid"
+Issues = "https://github.com/coconut-labs/infergrid/issues"
+
 dependencies = [
     "numpy>=1.24,<2.3",
     "pandas~=2.0",


### PR DESCRIPTION
## Summary
Pre-launch README + config cleanup. Three classes of fix:

**1. Stale PyPI placeholder references**
- \`README.md:54\`: \`pip install -e . # PyPI placeholder pending\` → \`pip install infergrid\` (0.1.0 is live).
- \`README.md:135\`: launch ship-gate cell no longer mentions "PyPI placeholder" (satisfied); only the waitlist backend Cloudflare Worker remains.

**2. PyPI metadata (pyproject.toml was null on 0.1.0's sidebar)**
- \`description\` aligned with README tagline ("Tenant-fair LLM inference orchestration on a single GPU. No Kubernetes.").
- Populates \`authors\`, \`project.urls\` (Homepage / Repository / Issues / Documentation), \`keywords\`, \`classifiers\`. Takes effect on next release.

**3. Credibility fixes flagged in pre-launch audit**
- \`README.md:97\` (architecture table, CacheManager row): prior wording "KV cache block tracking across GPU/CPU/SSD tiers, weighted eviction" implied per-request runtime tracking, but the hot path (\`router.py\`) only calls \`free_blocks_for_model()\` on unload and \`snapshot()\` for CLI status. The 487-LOC tiered-eviction tracker is scaffold reachable via direct API; per-request wiring lands with LMCache integration (Phase 3, post-launch per roadmap). New wording is honest about the state today.
- \`configs/quickstart_fairness.yaml:8-12\`: empirical anchor updated to v3 numbers (vLLM 0.19.1, 300 s steady state — 61.5 ms quiet p99, 1.14× solo) that match the README hero. Prior comment cited v2 (74 ms, 1.35× solo) from the original April-19 arm. v2 kept as historical context.

## Notes
\`pyproject\` metadata changes only affect PyPI sidebar on the **next release**. Existing 0.1.0 keeps its current sparse metadata until a version bump.

## Test plan
- [x] \`git diff\` reviewed — doc + comment changes only, zero behavior change
- [x] \`results/gate2_preprint_v3/\` referenced in yaml comment verified to exist
- [ ] (Optional) \`python -m build && twine check dist/*\` before next release to confirm metadata well-formed