### PR TITLE
release: 0.1.1 — fix TOML structure bug + bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infergrid"
-version = "0.1.0"
+version = "0.1.1"
 description = "Tenant-fair LLM inference orchestration on a single GPU. No Kubernetes."
 readme = "README.md"
 license = {text = "MIT"}
@@ -15,13 +15,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
-
-[project.urls]
-Homepage = "https://github.com/coconut-labs/infergrid"
-Documentation = "https://github.com/coconut-labs/infergrid#readme"
-Repository = "https://github.com/coconut-labs/infergrid"
-Issues = "https://github.com/coconut-labs/infergrid/issues"
-
 dependencies = [
     "numpy>=1.24,<2.3",
     "pandas~=2.0",
@@ -30,6 +23,12 @@ dependencies = [
     "httpx~=0.25",
     "aiohttp~=3.9",
 ]
+
+[project.urls]
+Homepage = "https://github.com/coconut-labs/infergrid"
+Documentation = "https://github.com/coconut-labs/infergrid#readme"
+Repository = "https://github.com/coconut-labs/infergrid"
+Issues = "https://github.com/coconut-labs/infergrid/issues"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary
Ships 0.1.1 to PyPI with the README/metadata fixes from PR #67, and fixes a TOML-scope bug introduced in that same PR that broke \`python -m build\` on main.

## The TOML bug
PR #67 added a \`[project.urls]\` sub-table to pyproject.toml. In TOML, a sub-table claims all subsequent keys until the next \`[section]\` header. Because the new \`[project.urls]\` block was placed **before** the existing \`dependencies = [...]\` list under \`[project]\`, \`dependencies\` got rebound as \`project.urls.dependencies\` — which setuptools rightly rejects (\`project.urls.*\` must be strings):

\`\`\`
ValueError: invalid pyproject.toml config: \`project.urls.dependencies\`.
configuration error: \`project.urls.dependencies\` must be string
\`\`\`

Fix: moved \`dependencies = [...]\` back under \`[project]\` *ahead* of the sub-table. Net change is 1 section reordered, no semantic change. 0.1.0 on PyPI was built before PR #67 reordered things and is unaffected.

## 0.1.1 payload (vs. 0.1.0)
- README destaled (PR #67): pip install instruction, ship-gate row, CacheManager wording, quickstart_fairness.yaml v3 empirical anchor.
- pyproject metadata populated (PR #67): description aligned to README tagline; authors / project.urls / keywords / classifiers (all were null on 0.1.0).
- **No source code change.** Same 144 unit tests.

## Test plan
- [x] \`python -m build\` succeeds (infergrid-0.1.1.whl + .tar.gz in dist/, 45 KB + 43 KB)
- [x] \`twine check dist/*\` both PASS
- [ ] Post-merge: \`twine upload dist/*\` → live on https://pypi.org/project/infergrid/0.1.1/
- [ ] Verify \`pip install infergrid==0.1.1\` works from a clean venv

Needs admin merge (branch protection requires 1 review; Jay is on deck but launch cadence).