### PR TITLE
feat(cli): interactive + help + man + doctor + 0.1.2 bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "infergrid"
-version = "0.1.1"
+version = "0.1.2"
 description = "Tenant-fair LLM inference orchestration on a single GPU. No Kubernetes."
 readme = "README.md"
 license = {text = "MIT"}
@@ -22,6 +22,7 @@ dependencies = [
     "prometheus-client~=0.19",
     "httpx~=0.25",
     "aiohttp~=3.9",
+    "rich>=13.0,<16.0",
 ]
 
 [project.urls]

--- a/src/infergrid/_manpages.py
+++ b/src/infergrid/_manpages.py
@@ -1,0 +1,290 @@
+"""Built-in help pages rendered by `infergrid man [topic]`.
+
+Each entry is a Markdown string. Keep them tight — this is terminal-rendered,
+not the LP. Content here is the canonical in-CLI explanation of what each
+command does + how to think about the tuning knobs.
+"""
+
+from __future__ import annotations
+
+PAGES: dict[str, str] = {}
+
+
+PAGES["overview"] = """
+# InferGrid
+
+**Tenant-fair LLM inference orchestration on a single GPU. No Kubernetes.**
+
+Middleware that sits on top of vLLM / SGLang and keeps a quiet user's TTFT
+predictable even when a noisy neighbor is hammering the same shared engine.
+
+## The flow
+
+```
+client → router → tenant-manager → admission → engine (vLLM / SGLang)
+                  (token bucket)    (queue)
+```
+
+Every request carries an `X-Tenant-ID` header. The tenant manager checks the
+tenant's token bucket before the request reaches the engine; over-budget
+requests get a 429, under-budget requests pass through. The quiet tenant
+stays near solo TTFT even with a flooder hitting the same engine.
+
+## Commands
+
+- `infergrid serve`  -- start the API server
+- `infergrid status` -- show loaded models, cache, tenant stats
+- `infergrid models` -- list available/loaded models
+- `infergrid doctor` -- environment + prerequisite check
+- `infergrid man`    -- open a help page in the terminal
+- `infergrid --version`
+
+Run `infergrid man <command>` for a detailed page on a specific command.
+
+## Further reading
+
+- Quickstart: `configs/quickstart_fairness.yaml`
+- Tuning: https://github.com/coconut-labs/infergrid/blob/main/docs/tuning_guide.md
+- Empirical results: https://github.com/coconut-labs/infergrid/tree/main/results
+- Bug reports: https://github.com/coconut-labs/infergrid/issues
+"""
+
+
+PAGES["serve"] = """
+# infergrid serve
+
+Start the InferGrid API server. Listens on port 8080 by default, serves an
+OpenAI-compatible HTTP surface, and spawns the configured engine
+subprocess(es) (vLLM or SGLang).
+
+## Two ways to configure
+
+**YAML (recommended for anything non-trivial):**
+
+```bash
+infergrid serve --config configs/quickstart_fairness.yaml
+```
+
+The YAML is where tenant budgets, multi-model lists, rate-limit knobs, and
+engine-specific flags live. A sample config is shipped with the package
+under `configs/`.
+
+**CLI flags (quick sanity check with one model, symmetric tenants):**
+
+```bash
+infergrid serve meta-llama/Llama-3.1-8B-Instruct --gpu-budget 80%
+```
+
+`--config` wins when both are supplied.
+
+## Flags
+
+- `MODELS...`         HuggingFace model IDs (repeatable). Ignored when `--config` is set.
+- `--config PATH`     YAML config file. Overrides all other flags.
+- `--gpu-budget PCT`  Fraction of GPU memory InferGrid may use. Default `80%`.
+- `--engine {vllm|sglang}`  Default engine backend. Default `vllm`.
+- `--port N`          HTTP port. Default `8080`.
+- `--max-concurrent N`  Engine-side concurrent-request cap. Default `128`.
+                        This is NOT the per-tenant fairness lever -- it's a
+                        coarse upper bound upstream of the engine's own
+                        scheduler. Per-tenant rate limits go in the YAML.
+- `--log-level LEVEL` DEBUG | INFO | WARNING | ERROR. Default `INFO`.
+
+## What happens on startup
+
+1. Parse config (YAML or CLI flags).
+2. Start the engine subprocess(es). First model takes ~30-90s on an 8B-class
+   model to load weights.
+3. `/health` returns 503 with `{"missing_models": [...]}` until all configured
+   engines finish loading. Poll `/health` before sending traffic:
+
+   ```bash
+   until curl -fs localhost:8080/health > /dev/null; do sleep 2; done
+   ```
+
+4. Serve requests. Send `X-Tenant-ID: your-tenant-id` on each call.
+
+## OpenAI-compatible routes
+
+- `POST /v1/chat/completions`
+- `POST /v1/completions`
+- `GET  /v1/models`
+
+## InferGrid-specific routes
+
+- `GET /health`              -- 200 when all engines are loaded, 503 otherwise
+- `GET /metrics`             -- Prometheus text exposition
+- `GET /infergrid/status`    -- JSON snapshot (what `infergrid status` reads)
+"""
+
+
+PAGES["status"] = """
+# infergrid status
+
+Print a JSON snapshot of the running server's internal state: loaded models,
+cache usage per tier, per-tenant budgets + current utilization, engine health,
+admission-queue depths.
+
+```bash
+infergrid status
+infergrid status --port 8080
+```
+
+Use this for debugging; use `/metrics` for continuous monitoring.
+
+## What's in the snapshot
+
+- `models[]`       -- each model, its engine, load state, last-used timestamp
+- `cache`          -- block counts per tier (GPU / CPU / SSD) + eviction stats
+- `tenants[]`      -- each tenant, budget, tokens-in-bucket, requests-in-flight
+- `admission`      -- queue depth per length bucket
+- `engines[]`      -- health, circuit-breaker state, recent failure count
+
+A non-200 response means the server isn't running on the port queried.
+"""
+
+
+PAGES["models"] = """
+# infergrid models
+
+Show a table of models currently known to the running server.
+
+```bash
+infergrid models
+infergrid models --port 8080
+```
+
+Column meaning:
+
+- `ID`      -- HuggingFace model ID (or local path)
+- `Engine`  -- which adapter serves it (`vllm`, `sglang`)
+- `Healthy` -- last health check result for this model's engine process
+"""
+
+
+PAGES["doctor"] = """
+# infergrid doctor
+
+Run a battery of local environment checks and print what needs fixing.
+
+```bash
+infergrid doctor
+```
+
+## What it checks
+
+- **Python version** (>= 3.11 required)
+- **InferGrid version** vs. the latest on PyPI
+- **Engine presence** -- is `vllm` importable? `sglang`?
+- **GPU visibility** -- does `nvidia-smi` report a CUDA device?
+- **Port availability** -- is the default 8080 free?
+- **Config files** -- are the shipped sample configs reachable from CWD?
+
+Doesn't mutate anything; flags issues and points at the fix.
+"""
+
+
+PAGES["tenants"] = """
+# Tenant fairness -- the mental model
+
+This is the mechanism that makes InferGrid different from running vLLM alone.
+
+## The problem
+
+Two tenants share one engine. Tenant A sends 32 requests/sec, Tenant B sends
+1. vLLM's continuous-batch scheduler is tenant-blind by design: it sees a
+stream of requests and tries to maximize throughput. Under contention,
+Tenant B's p99 TTFT collapses from 53.9 ms (solo) to 1,585 ms -- a 29x
+degradation. Tenant B experiences "noisy neighbor TTFT roulette."
+
+## The fix
+
+Per-tenant token-bucket rate limiting at the budget gate, **upstream** of
+the engine. Each tenant has:
+
+- `rate_limit_rpm`   sustained ceiling (refill rate * 60)
+- `rate_limit_burst` how many requests may spike before throttle kicks in
+
+Over-budget requests get 429'd at the gate before they reach the engine.
+The engine never saturates; Tenant B stays near solo TTFT.
+
+## The numbers
+
+Single A100-SXM4 80GB, Llama-3.1-8B, vLLM 0.19.1, 300s sustained:
+
+| Arm                              | Quiet p99 TTFT | vs. solo |
+|----------------------------------|---------------:|---------:|
+| Solo (no contention)             |       53.9 ms  |     1.0x |
+| InferGrid FIFO (no rate-limit)   |      1,585 ms  |      29x |
+| InferGrid + token bucket         |       61.5 ms  |    1.14x |
+
+## Tuning
+
+See the `tenants:` section of `configs/quickstart_fairness.yaml`. Start
+with symmetric quotas; widen once you have a tenant with a legit reason
+to burst.
+
+Rule of thumb: `rate_limit_burst = rate_limit_rpm / 60` gives one second
+of capacity. Smaller burst = faster throttle, longer burst = more grace.
+"""
+
+
+PAGES["quickstart"] = """
+# Quickstart
+
+## Install
+
+```bash
+pip install infergrid
+```
+
+Python 3.11+ required. On Linux with an NVIDIA GPU, also:
+
+```bash
+pip install 'infergrid[vllm]'   # or [sglang]
+```
+
+## Serve
+
+```bash
+infergrid serve --config configs/quickstart_fairness.yaml
+```
+
+Shipped configs live under `configs/` in the source distribution. Copy one
+and edit. `configs/quickstart_fairness.yaml` is heavily commented.
+
+## Talk to it
+
+```bash
+until curl -fs localhost:8080/health > /dev/null; do sleep 2; done
+
+curl localhost:8080/v1/completions \\
+  -H "X-Tenant-ID: noisy" \\
+  -d '{"model":"llama31-8b","prompt":"...","max_tokens":64,"stream":true}'
+
+curl localhost:8080/v1/completions \\
+  -H "X-Tenant-ID: quiet" \\
+  -d '{"model":"llama31-8b","prompt":"...","max_tokens":64,"stream":true}'
+```
+
+## Watch the rate limit fire
+
+```bash
+curl localhost:8080/metrics | grep -E "tenant_rejected|admission_queue_depth"
+```
+
+## Next
+
+Run `infergrid man tenants` for the fairness mental model, or open
+`docs/tuning_guide.md` in the repo for a deep treatment.
+"""
+
+
+def get_page(topic: str) -> str | None:
+    """Return the markdown text for a topic, or None if unknown."""
+    return PAGES.get(topic)
+
+
+def list_topics() -> list[str]:
+    """Return all available man topic names, sorted."""
+    return sorted(PAGES.keys())

--- a/src/infergrid/cli.py
+++ b/src/infergrid/cli.py
@@ -1,9 +1,16 @@
 """InferGrid CLI.
 
-Commands:
-    infergrid serve model1 model2 --gpu-budget 80 --port 8080
-    infergrid status
-    infergrid models
+The entry point for ``pip install infergrid``. Commands:
+
+* ``infergrid serve --config configs/quickstart_fairness.yaml``
+* ``infergrid status``
+* ``infergrid models``
+* ``infergrid doctor``
+* ``infergrid man [topic]``
+* ``infergrid --version``
+
+Run ``infergrid man`` with no topic for the overview; ``infergrid man
+<command>`` for a specific page.
 """
 
 from __future__ import annotations
@@ -12,12 +19,25 @@ import argparse
 import asyncio
 import json
 import logging
+import os
+import shutil
+import socket
+import subprocess
 import sys
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from typing import Sequence
 
 import aiohttp
 from aiohttp import web
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.prompt import Prompt
+from rich.table import Table
+from rich.text import Text
 
+from infergrid import __version__
+from infergrid._manpages import get_page, list_topics
 from infergrid.cache.manager import CacheManager
 from infergrid.common.config import InferGridConfig
 from infergrid.common.metrics import MetricsCollector
@@ -25,38 +45,58 @@ from infergrid.router.router import WorkloadRouter
 from infergrid.tenant.manager import TenantManager
 
 logger = logging.getLogger("infergrid")
+_console = Console()
+_err_console = Console(stderr=True)
+
+
+# ─────────────────────────────── arg parser ───────────────────────────────
 
 
 def build_parser() -> argparse.ArgumentParser:
-    """Build the argument parser for the InferGrid CLI.
-
-    Returns:
-        Configured ArgumentParser.
-    """
+    """Build the argument parser for the InferGrid CLI."""
     parser = argparse.ArgumentParser(
         prog="infergrid",
-        description="InferGrid -- adaptive inference orchestration for LLM serving",
+        description=(
+            "Tenant-fair LLM inference orchestration on a single GPU. "
+            "No Kubernetes. Middleware on top of vLLM / SGLang."
+        ),
+        epilog=(
+            "Run `infergrid man` for expanded help. "
+            "Issues: https://github.com/coconut-labs/infergrid/issues"
+        ),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"infergrid {__version__}",
     )
     sub = parser.add_subparsers(dest="command", help="Available commands")
 
     # ── serve ──
-    serve_parser = sub.add_parser("serve", help="Start the InferGrid API server")
+    serve_parser = sub.add_parser(
+        "serve",
+        help="Start the InferGrid API server",
+        description=(
+            "Start the API server. Prefer `--config PATH` for anything "
+            "non-trivial; CLI flags are fine for a quick sanity check."
+        ),
+    )
     serve_parser.add_argument(
         "models",
         nargs="*",
-        help="HuggingFace model IDs to serve (optional when --config provides models)",
+        help="HuggingFace model IDs (ignored when --config is given)",
     )
     serve_parser.add_argument(
         "--gpu-budget",
         type=str,
         default="80%",
-        help="GPU memory budget as a percentage (e.g. '80%%') or fraction (e.g. '0.8')",
+        help="Fraction of GPU memory InferGrid may use (e.g. '80%%' or '0.8')",
     )
     serve_parser.add_argument(
         "--port",
         type=int,
         default=8080,
-        help="API server port (default: 8080)",
+        help="HTTP port (default: 8080)",
     )
     serve_parser.add_argument(
         "--engine",
@@ -69,17 +109,15 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=128,
         help=(
-            "Maximum concurrent requests forwarded to the engine. "
-            "Requests beyond this limit are queued with priority ordering. "
-            "Set based on engine profiling -- above the cliff point, TTFT "
-            "degrades dramatically with minimal throughput gain. (default: 128)"
+            "Coarse engine-side concurrent-request cap. NOT the per-tenant "
+            "fairness lever -- those live in the YAML. (default: 128)"
         ),
     )
     serve_parser.add_argument(
         "--config",
         type=str,
         default=None,
-        help="Path to a YAML configuration file (overrides other flags)",
+        help="YAML config file (overrides other flags)",
     )
     serve_parser.add_argument(
         "--log-level",
@@ -87,16 +125,27 @@ def build_parser() -> argparse.ArgumentParser:
         default="INFO",
         help="Log level (default: INFO)",
     )
+    serve_parser.add_argument(
+        "--no-interactive",
+        action="store_true",
+        help="Fail fast instead of prompting when neither MODELS nor --config is given",
+    )
 
     # ── status ──
     status_parser = sub.add_parser(
-        "status", help="Show loaded models, cache usage, tenant stats"
+        "status",
+        help="Snapshot loaded models + cache + tenant budgets",
     )
     status_parser.add_argument(
         "--port",
         type=int,
         default=8080,
         help="API server port to query (default: 8080)",
+    )
+    status_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit raw JSON instead of a rendered table",
     )
 
     # ── models ──
@@ -107,19 +156,43 @@ def build_parser() -> argparse.ArgumentParser:
         default=8080,
         help="API server port to query (default: 8080)",
     )
+    models_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit raw JSON instead of a rendered table",
+    )
+
+    # ── doctor ──
+    sub.add_parser(
+        "doctor",
+        help="Local environment + prerequisite check",
+        description=(
+            "Verify Python version, GPU visibility, engine availability, "
+            "port availability, and whether a newer InferGrid is on PyPI."
+        ),
+    )
+
+    # ── man ──
+    man_parser = sub.add_parser(
+        "man",
+        help="Open a built-in help page in the terminal",
+        description=(
+            "Render one of the bundled help topics. Run with no topic "
+            "for the overview; 'infergrid man topics' lists all pages."
+        ),
+    )
+    man_parser.add_argument(
+        "topic",
+        nargs="?",
+        default="overview",
+        help="Help topic (default: overview). Use 'topics' to list all.",
+    )
 
     return parser
 
 
 def _parse_gpu_budget(raw: str) -> float:
-    """Parse a GPU budget string to a float fraction.
-
-    Args:
-        raw: Budget string like "80%" or "0.8".
-
-    Returns:
-        Float between 0.0 and 1.0.
-    """
+    """Parse a GPU budget string to a float fraction in [0, 1]."""
     raw = raw.strip()
     if raw.endswith("%"):
         return float(raw[:-1]) / 100.0
@@ -129,18 +202,17 @@ def _parse_gpu_budget(raw: str) -> float:
     return val
 
 
-async def _run_server(config: InferGridConfig) -> None:
-    """Start the aiohttp server with the WorkloadRouter.
+# ─────────────────────────────── serve ───────────────────────────────
 
-    Args:
-        config: InferGrid configuration.
-    """
+
+async def _run_server(config: InferGridConfig) -> None:
+    """Start the aiohttp server with the WorkloadRouter."""
     metrics = MetricsCollector()
     cache_manager = CacheManager()
     # Wire config.tenant_defaults → TenantManager.default_budget. Without
     # this, the manager always falls back to its internal 64-concurrent
     # default and rejects high-concurrency traffic with 429 even when the
-    # config lifts the cap. That blocks Gate 1 (c=256 vs default=64).
+    # config lifts the cap.
     from infergrid.tenant.manager import TenantBudget
 
     td = config.tenant_defaults
@@ -163,14 +235,11 @@ async def _run_server(config: InferGridConfig) -> None:
     await router.start()
 
     app = web.Application()
-
-    # OpenAI-compatible endpoints
     app.router.add_post("/v1/chat/completions", router.handle_request)
     app.router.add_post("/v1/completions", router.handle_request)
     app.router.add_get("/v1/models", router.handle_models)
     app.router.add_get("/health", router.handle_health)
 
-    # InferGrid status endpoints
     async def handle_status(request: web.Request) -> web.Response:
         return web.json_response(router.snapshot())
 
@@ -188,16 +257,19 @@ async def _run_server(config: InferGridConfig) -> None:
     site = web.TCPSite(runner, config.host, config.port)
     await site.start()
 
-    logger.info(
-        "InferGrid serving on http://%s:%d with %d model(s)",
-        config.host,
-        config.port,
-        len(config.models),
+    _console.print(
+        f"[bold green]✓[/bold green] InferGrid serving on "
+        f"[cyan]http://{config.host}:{config.port}[/cyan] "
+        f"with [bold]{len(config.models)}[/bold] model(s)"
     )
-    logger.info("  Models: %s", [m.model_id for m in config.models])
-    logger.info("  GPU budget: %.0f%%", config.gpu_budget_fraction * 100)
+    _console.print(
+        f"  [dim]Models:[/dim] {', '.join(m.model_id for m in config.models)}"
+    )
+    _console.print(f"  [dim]GPU budget:[/dim] {config.gpu_budget_fraction * 100:.0f}%")
+    _console.print(
+        f"  [dim]/health ready check:[/dim] curl -fs localhost:{config.port}/health"
+    )
 
-    # Run until interrupted
     try:
         await asyncio.Event().wait()
     except (KeyboardInterrupt, asyncio.CancelledError):
@@ -207,16 +279,56 @@ async def _run_server(config: InferGridConfig) -> None:
         await runner.cleanup()
 
 
+def _interactive_serve_wizard() -> argparse.Namespace:
+    """Prompt the user for the minimum inputs to start `serve`.
+
+    Returns a Namespace compatible with what argparse would produce.
+    """
+    _console.print(
+        "[bold]No config or model given.[/bold] Quick wizard "
+        "(Ctrl-C to abort; pass --config to skip this).\n"
+    )
+    model = Prompt.ask(
+        "HuggingFace [cyan]model ID[/cyan]",
+        default="meta-llama/Llama-3.1-8B-Instruct",
+    )
+    engine = Prompt.ask(
+        "Engine",
+        choices=["vllm", "sglang"],
+        default="vllm",
+    )
+    gpu_budget = Prompt.ask(
+        "GPU memory budget (e.g. '80%%' or '0.8')",
+        default="80%",
+    )
+    port = Prompt.ask("HTTP port", default="8080")
+
+    return argparse.Namespace(
+        command="serve",
+        models=[model],
+        gpu_budget=gpu_budget,
+        port=int(port),
+        engine=engine,
+        max_concurrent=128,
+        config=None,
+        log_level="INFO",
+        no_interactive=False,
+    )
+
+
 def _cmd_serve(args: argparse.Namespace) -> None:
     """Handle the 'serve' command."""
+    if not args.config and not args.models:
+        if args.no_interactive or not sys.stdin.isatty():
+            raise SystemExit(
+                "infergrid serve: at least one MODEL or --config is required "
+                "(--no-interactive set and stdin is not a tty)"
+            )
+        args = _interactive_serve_wizard()
+
     if args.config:
         config = InferGridConfig.from_yaml(args.config)
     else:
-        if not args.models:
-            raise SystemExit(
-                "infergrid serve: at least one positional MODEL is required "
-                "when --config is not provided"
-            )
         gpu_budget = _parse_gpu_budget(args.gpu_budget)
         config = InferGridConfig.from_cli_args(
             model_ids=args.models,
@@ -235,15 +347,11 @@ def _cmd_serve(args: argparse.Namespace) -> None:
     asyncio.run(_run_server(config))
 
 
+# ─────────────────────────────── status / models ───────────────────────────────
+
+
 async def _fetch_json(url: str) -> dict:
-    """Fetch JSON from a URL.
-
-    Args:
-        url: HTTP URL.
-
-    Returns:
-        Parsed JSON as a dict.
-    """
+    """Fetch JSON from a URL."""
     timeout = aiohttp.ClientTimeout(total=5)
     async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.get(url) as resp:
@@ -255,15 +363,77 @@ def _cmd_status(args: argparse.Namespace) -> None:
     url = f"http://localhost:{args.port}/infergrid/status"
     try:
         data = asyncio.run(_fetch_json(url))
-    except Exception:
-        logger.error(
-            "Error connecting to InferGrid at port %d",
-            args.port,
-            exc_info=True,
+    except Exception as e:
+        _err_console.print(
+            f"[red]✗[/red] Could not reach InferGrid on port {args.port}: {e}"
+        )
+        _err_console.print(
+            f"  Start the server with [cyan]infergrid serve --port {args.port}[/cyan]"
         )
         sys.exit(1)
 
-    print(json.dumps(data, indent=2))
+    if args.json:
+        print(json.dumps(data, indent=2))
+        return
+
+    _render_status(data)
+
+
+def _render_status(data: dict) -> None:
+    """Render a status snapshot as a rich table."""
+    models = data.get("models", [])
+    tenants = data.get("tenants", [])
+    cache = data.get("cache", {})
+
+    _console.print(
+        f"[bold]InferGrid status[/bold]  "
+        f"[dim]({len(models)} models · {len(tenants)} tenants)[/dim]"
+    )
+
+    if models:
+        t = Table(title="Models", header_style="bold", box=None, padding=(0, 1))
+        t.add_column("ID", style="cyan")
+        t.add_column("Engine")
+        t.add_column("State", style="green")
+        t.add_column("Last used", style="dim")
+        for m in models:
+            state = m.get("state", "?")
+            t.add_row(
+                m.get("id") or m.get("model_id", "?"),
+                m.get("engine", "?"),
+                state,
+                str(m.get("last_used_at", "—")),
+            )
+        _console.print(t)
+
+    if tenants:
+        t = Table(title="Tenants", header_style="bold", box=None, padding=(0, 1))
+        t.add_column("ID", style="cyan")
+        t.add_column("In-flight", justify="right")
+        t.add_column("Bucket tokens", justify="right")
+        t.add_column("Rate limit (RPM)", justify="right")
+        for tt in tenants:
+            t.add_row(
+                tt.get("id", "?"),
+                str(tt.get("in_flight", 0)),
+                f"{tt.get('tokens', 0):.1f}",
+                str(tt.get("rate_limit_rpm", "—")),
+            )
+        _console.print(t)
+
+    if cache:
+        t = Table(title="Cache", header_style="bold", box=None, padding=(0, 1))
+        t.add_column("Tier", style="cyan")
+        t.add_column("Blocks", justify="right")
+        t.add_column("Evictions", justify="right")
+        for tier, stats in cache.items():
+            if isinstance(stats, dict):
+                t.add_row(
+                    tier,
+                    str(stats.get("blocks", 0)),
+                    str(stats.get("evictions", 0)),
+                )
+        _console.print(t)
 
 
 def _cmd_models(args: argparse.Namespace) -> None:
@@ -271,33 +441,224 @@ def _cmd_models(args: argparse.Namespace) -> None:
     url = f"http://localhost:{args.port}/v1/models"
     try:
         data = asyncio.run(_fetch_json(url))
-    except Exception:
-        logger.error(
-            "Error connecting to InferGrid at port %d",
-            args.port,
-            exc_info=True,
+    except Exception as e:
+        _err_console.print(
+            f"[red]✗[/red] Could not reach InferGrid on port {args.port}: {e}"
         )
         sys.exit(1)
 
     models = data.get("data", [])
-    if not models:
-        print("No models loaded.")
+
+    if args.json:
+        print(json.dumps(data, indent=2))
         return
 
-    print(f"{'Model ID':<50} {'Engine':<10} {'Healthy':<10}")
-    print("-" * 70)
+    if not models:
+        _console.print("[yellow]No models loaded.[/yellow]")
+        return
+
+    t = Table(header_style="bold", box=None, padding=(0, 1))
+    t.add_column("Model ID", style="cyan")
+    t.add_column("Engine")
+    t.add_column("Healthy")
     for m in models:
-        print(f"{m['id']:<50} {m.get('engine', '?'):<10} {m.get('healthy', '?'):<10}")
+        healthy = m.get("healthy", None)
+        mark = Text("✓", style="green") if healthy else Text("✗", style="red")
+        if healthy is None:
+            mark = Text("?", style="dim")
+        t.add_row(str(m.get("id", "?")), str(m.get("engine", "?")), mark)
+    _console.print(t)
+
+
+# ─────────────────────────────── doctor ───────────────────────────────
+
+
+def _pypi_latest_version() -> str | None:
+    """Best-effort fetch of the latest infergrid version from PyPI."""
+    try:
+        import urllib.request
+
+        req = urllib.request.Request(
+            "https://pypi.org/pypi/infergrid/json",
+            headers={"User-Agent": f"infergrid-doctor/{__version__}"},
+        )
+        with urllib.request.urlopen(req, timeout=3) as resp:  # noqa: S310
+            payload = json.loads(resp.read().decode())
+            return payload["info"]["version"]
+    except Exception:
+        return None
+
+
+def _port_free(port: int) -> bool:
+    """True if TCP ``port`` on localhost is bindable right now."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", port))
+        return True
+    except OSError:
+        return False
+
+
+def _nvidia_smi_summary() -> str | None:
+    """Return a one-line device summary, or None if nvidia-smi is missing."""
+    if not shutil.which("nvidia-smi"):
+        return None
+    try:
+        out = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,driver_version",
+                "--format=csv,noheader",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+        line = (out.stdout or "").strip().splitlines()
+        return line[0] if line else None
+    except Exception:
+        return None
+
+
+def _engine_importable(module_name: str) -> bool:
+    """True if ``import module_name`` would succeed."""
+    try:
+        __import__(module_name)
+        return True
+    except Exception:
+        return False
+
+
+def _cmd_doctor(_args: argparse.Namespace) -> None:
+    """Handle the 'doctor' command."""
+    checks: list[tuple[str, str, str | None]] = []
+
+    # Python version
+    py = sys.version_info
+    py_ok = (py.major, py.minor) >= (3, 11)
+    checks.append(
+        (
+            "ok" if py_ok else "fail",
+            "Python",
+            f"{py.major}.{py.minor}.{py.micro}" + ("" if py_ok else "  ✗ need >= 3.11"),
+        )
+    )
+
+    # InferGrid version vs PyPI
+    latest = _pypi_latest_version()
+    if latest is None:
+        checks.append(("warn", "InferGrid", f"{__version__} (PyPI unreachable)"))
+    elif latest == __version__:
+        checks.append(("ok", "InferGrid", f"{__version__} (latest)"))
+    else:
+        checks.append(
+            (
+                "warn",
+                "InferGrid",
+                f"{__version__} installed · {latest} available  "
+                "[dim]pip install --upgrade infergrid[/dim]",
+            )
+        )
+
+    # Engines
+    for eng in ("vllm", "sglang"):
+        present = _engine_importable(eng)
+        status = "ok" if present else "warn"
+        note = "importable" if present else f"missing  [dim]pip install {eng}[/dim]"
+        checks.append((status, f"engine:{eng}", note))
+
+    # GPU
+    gpu = _nvidia_smi_summary()
+    if gpu is None:
+        checks.append(("warn", "GPU", "nvidia-smi not found (CPU-only host?)"))
+    else:
+        checks.append(("ok", "GPU", gpu))
+
+    # Default port
+    port = 8080
+    if _port_free(port):
+        checks.append(("ok", f"port:{port}", "free"))
+    else:
+        checks.append(
+            (
+                "warn",
+                f"port:{port}",
+                "in use  [dim](pick another via --port)[/dim]",
+            )
+        )
+
+    # Shipped configs reachable
+    cfg_path = os.path.join("configs", "quickstart_fairness.yaml")
+    if os.path.exists(cfg_path):
+        checks.append(("ok", "configs/quickstart_fairness.yaml", "present in CWD"))
+    else:
+        checks.append(
+            (
+                "warn",
+                "configs/quickstart_fairness.yaml",
+                "not in CWD  [dim](run from a clone of the repo, or pass "
+                "--config /abs/path.yaml)[/dim]",
+            )
+        )
+
+    t = Table(header_style="bold", box=None, padding=(0, 1))
+    t.add_column("", width=2)
+    t.add_column("Check", style="cyan")
+    t.add_column("Result")
+    for status, name, note in checks:
+        icon = {
+            "ok": "[green]✓[/green]",
+            "warn": "[yellow]![/yellow]",
+            "fail": "[red]✗[/red]",
+        }[status]
+        t.add_row(icon, name, note or "")
+    _console.print("[bold]infergrid doctor[/bold]")
+    _console.print(t)
+
+    if any(s == "fail" for s, _, _ in checks):
+        sys.exit(1)
+
+
+# ─────────────────────────────── man ───────────────────────────────
+
+
+def _cmd_man(args: argparse.Namespace) -> None:
+    """Handle the 'man' command."""
+    topic = args.topic
+    if topic == "topics":
+        _console.print("[bold]Available help topics[/bold]")
+        for t in list_topics():
+            _console.print(f"  [cyan]{t}[/cyan]")
+        _console.print("\nUsage: [cyan]infergrid man <topic>[/cyan]")
+        return
+
+    page = get_page(topic)
+    if page is None:
+        _err_console.print(f"[red]✗[/red] Unknown topic: [cyan]{topic}[/cyan]")
+        _err_console.print(
+            "Run [cyan]infergrid man topics[/cyan] to list available pages."
+        )
+        sys.exit(1)
+
+    _console.print(Markdown(page))
+
+
+# ─────────────────────────────── main ───────────────────────────────
 
 
 def main(argv: Sequence[str] | None = None) -> None:
-    """CLI entry point.
-
-    Args:
-        argv: Command-line arguments (defaults to sys.argv).
-    """
+    """CLI entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    # Pre-check that infergrid is actually installed as a package when we
+    # fetch __version__ via importlib.metadata — this is a belt-and-suspenders
+    # check for editable installs where metadata can be absent.
+    try:
+        _pkg_version("infergrid")
+    except PackageNotFoundError:
+        pass  # non-fatal; __init__.py falls back to "0.0.0+unknown"
 
     if args.command == "serve":
         _cmd_serve(args)
@@ -305,6 +666,10 @@ def main(argv: Sequence[str] | None = None) -> None:
         _cmd_status(args)
     elif args.command == "models":
         _cmd_models(args)
+    elif args.command == "doctor":
+        _cmd_doctor(args)
+    elif args.command == "man":
+        _cmd_man(args)
     else:
         parser.print_help()
         sys.exit(1)


### PR DESCRIPTION
## Summary
Ship 0.1.2 with a substantially expanded CLI. Fixes two credibility drifts from the pre-launch audit, adds three new subcommands, moves the whole CLI to rich-rendered output.

## Credibility drifts fixed
- \`argparse.description\`: *"adaptive inference orchestration for LLM serving"* (stale Phase-1 framing) → *"Tenant-fair LLM inference orchestration on a single GPU. No Kubernetes."* Matches README v3 hero.
- \`--max-concurrent\` help text no longer references the Gate-1.5 DISCONFIRMED "scheduling cliff". Rewrites to call out that it's a coarse upstream cap, **not** the per-tenant fairness lever.
- **\`--version\` flag added.** Was genuinely missing — \`pip install infergrid && infergrid --version\` failed pre-this-PR. Pulled from \`importlib.metadata\` via \`src/infergrid/__init__.py\`.

## New subcommands
- **\`infergrid doctor\`** — environment check. Python ≥ 3.11, InferGrid-vs-PyPI version compare, \`vllm\`/\`sglang\` importability, \`nvidia-smi\` visibility, port 8080 free?, sample configs reachable from CWD. Rich table, non-mutating. Non-zero exit only on \`fail\` (Python too old).
- **\`infergrid man [topic]\`** — renders one of 7 bundled Markdown help pages via \`rich.markdown\`. Topics: \`overview\`, \`serve\`, \`status\`, \`models\`, \`doctor\`, \`tenants\` (the fairness mental model + v3 numbers), \`quickstart\`. \`infergrid man topics\` lists them.

## Interactive \`serve\`
\`infergrid serve\` with no positional args and no \`--config\` now prompts for model / engine / GPU budget / port via \`rich.prompt\`. Non-tty or \`--no-interactive\` falls back to the previous hard-fail so CI + scripts are unaffected.

## Output polish
\`status\` and \`models\` render \`rich.table.Table\` instead of bare text; both take \`--json\` to stay pipeable. Error paths (worker unreachable) write to stderr with a suggested fix.

## New file: \`src/infergrid/_manpages.py\` (~230 LOC)
Pure data — Markdown strings keyed by topic. Kept as Python so the sdist ships them without \`package-data\` config.

## Dependency added
\`rich>=13.0,<16.0\` to core deps. ~1.5 MB installed; standard Python CLI vocabulary.

## Version bump 0.1.1 → 0.1.2
**Fixes the red-flag from the pre-launch audit:** 0.1.1 shipped with \`__version__ = "0.1.0"\` hard-coded because its sdist predated PR #70's durable \`importlib.metadata\` fix. 0.1.2 is the first release where \`pip install infergrid && python -c "import infergrid; print(infergrid.__version__)"\` prints the right number.

## Test plan
- [x] \`pytest tests/unit/\` — 153/153 green locally
- [x] \`ruff check src/ tests/\` → clean
- [x] \`ruff format --check\` → all 34 files clean
- [x] CLI smoke: \`--version\`, \`--help\`, \`man topics\`, \`doctor\` all work
- [ ] CI matrix (3.11 + 3.12) green on this PR
- [ ] Post-merge: \`python -m build\` + \`twine upload dist/*\` → 0.1.2 live on PyPI