### PR TITLE
gate-ladder v0.2: configs + vLLM 0.19.1 bootstrap

### DIFF
--- a/configs/gate21_fairness_n8.yaml
+++ b/configs/gate21_fairness_n8.yaml
@@ -1,0 +1,43 @@
+# Gate 2.1 — N=8 tenants (1 flooder + 7 quiet) on 1×A100, Llama-3.1-8B.
+# Extension of configs/gate2_fairness_token_bucket_n6.yaml (N=6 CONFIRM).
+#
+# Hypothesis: token-bucket per-tenant fairness guarantee scales to N=8
+# without any quiet tenant degrading >1.25× of the N=6 aggregate p99.
+#
+# Pre-committed PASS:
+#   aggregate quiet_p99 (post-warmup, first 10s excluded) ≤ 75 ms
+#   AND worst-tenant p99 ≤ 80 ms
+#   (N=6 landed 61.0 ms agg / 65.0 ms worst; 75/80 ms = 1.23× slack.)
+# Pre-committed DISCONFIRM:
+#   aggregate quiet_p99 > 120 ms OR any quiet tenant p99 > 150 ms
+#   (signals queue pressure from additional tenants — re-examine
+#   rate_limit_burst.)
+#
+# Bench invocation (see scripts/gate_pod_bootstrap.sh):
+#   benchmarks/scripts/benchmark_n_tenant_single_model.py
+#     --flooder-rps 32 --quiet-rps 1 --num-quiet 7 --duration-s 300
+
+host: 0.0.0.0
+port: 8000
+gpu_budget_fraction: 0.92
+
+max_concurrent: 512       # 8 tenants × 64 ceiling
+admission_queue_size: 4096
+engine_start_timeout_s: 420
+log_level: INFO
+
+tenant_defaults:
+  max_concurrent_requests: 256
+  rate_limit_rpm: 600      # 10 RPS sustained per tenant (matches N=6)
+  rate_limit_burst: 10     # 1 second's burst (matches N=6)
+  priority: 1
+  scheduling: drr
+
+models:
+  - model_id: "meta-llama/Llama-3.1-8B-Instruct"
+    short_name: "llama31-8b"
+    engine: "vllm"
+    dtype: "bfloat16"
+    gpu_memory_utilization: 0.85
+    max_model_len: 4096
+    tensor_parallel_size: 1

--- a/configs/gate23_fairness_70b_tp4.yaml
+++ b/configs/gate23_fairness_70b_tp4.yaml
@@ -1,0 +1,48 @@
+# Gate 2.3 — Llama-3.1-70B across 4×A100-SXM4 TP=4, 1 flooder + 3 quiet.
+#
+# Hypothesis: token-bucket fairness transfers from 8B to 70B. The rate-limit
+# lever lives at the InferGrid budget gate, architecturally upstream of the
+# engine's TP-replicated scheduler, so bigger-model TTFT characteristics
+# should shift uniformly (quiet and flooder both get slower) without
+# breaking the per-tenant ratio.
+#
+# Pre-committed PASS:
+#   quiet_p99 (post-warmup) ≤ 2.5× solo_p99(70B)
+#   AND flooder 429 rate > 30% of offered (rate-limit firing correctly).
+#   Solo p99(70B) measured empirically in Arm 0 of the same pod.
+# Pre-committed DISCONFIRM:
+#   quiet_p99 > 4× solo OR flooder 429 rate < 15%
+#   (rate-limit not engaging at 70B scale — new research problem.)
+#
+# KV-cache headroom: 70B bf16 ≈ 140 GB / 4 GPUs = 35 GB/GPU weights.
+# gpu_memory_utilization=0.90 leaves ~37 GB/GPU for KV — max_model_len=2048
+# ensures per-seq KV << per-GPU budget even under 4 concurrent batches.
+#
+# Bench plan (two arms, same warm engine to amortize 70B load):
+#   Arm 0 — --flooder-rps 0 --num-quiet 3  → solo baseline
+#   Arm 1 — --flooder-rps 32 --num-quiet 3 → contended
+
+host: 0.0.0.0
+port: 8000
+gpu_budget_fraction: 0.92
+
+max_concurrent: 256
+admission_queue_size: 2048
+engine_start_timeout_s: 900     # 70B TP=4 load ~8 min on cold pod
+log_level: INFO
+
+tenant_defaults:
+  max_concurrent_requests: 64
+  rate_limit_rpm: 600            # 10 RPS sustained per tenant
+  rate_limit_burst: 10
+  priority: 1
+  scheduling: drr
+
+models:
+  - model_id: "meta-llama/Llama-3.1-70B-Instruct"
+    short_name: "llama31-70b"
+    engine: "vllm"
+    dtype: "bfloat16"
+    gpu_memory_utilization: 0.90
+    max_model_len: 2048          # tight to preserve KV headroom for 4 tenants
+    tensor_parallel_size: 4

--- a/configs/gate24_fairness_mixtral_tp2.yaml
+++ b/configs/gate24_fairness_mixtral_tp2.yaml
@@ -1,0 +1,41 @@
+# Gate 2.4 — Mixtral-8x7B (MoE) on 2×A100-SXM4 TP=2, 1 flooder + 3 quiet.
+#
+# Hypothesis: MoE routing overhead (per-token expert selection, 2-of-8)
+# does not destabilize token-bucket fairness. Unlike dense 70B, Mixtral's
+# TTFT has shape-dependent expert-load variance; the open question is
+# whether flooder + quiet tenants compete differently at the expert-
+# capacity layer than at the admission gate.
+#
+# Pre-committed PASS:
+#   quiet_p99 (post-warmup) ≤ 2× solo_p99(Mixtral)
+#   AND per-tenant p99 spread across the 3 quiets < 1.5×
+#   (no quiet tenant structurally disadvantaged by expert-slot contention.)
+# Pre-committed DISCONFIRM:
+#   quiet_p99 > 3× solo OR per-tenant spread > 2×
+#   (MoE expert contention leaks past the admission gate — real finding;
+#   document the limitation rather than paper over it.)
+
+host: 0.0.0.0
+port: 8000
+gpu_budget_fraction: 0.92
+
+max_concurrent: 256
+admission_queue_size: 2048
+engine_start_timeout_s: 600
+log_level: INFO
+
+tenant_defaults:
+  max_concurrent_requests: 128
+  rate_limit_rpm: 600
+  rate_limit_burst: 10
+  priority: 1
+  scheduling: drr
+
+models:
+  - model_id: "mistralai/Mixtral-8x7B-Instruct-v0.1"
+    short_name: "mixtral-8x7b"
+    engine: "vllm"
+    dtype: "bfloat16"
+    gpu_memory_utilization: 0.88
+    max_model_len: 4096
+    tensor_parallel_size: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ profiling = [
     "ipykernel~=6.25",
     "transformers>=4.51.1,<5.0",
 ]
-vllm = ["vllm==0.8.5", "numba>=0.60,<0.62", "numpy>=1.24,<2.3"]
+vllm = ["vllm==0.19.1", "numpy>=1.24"]
 sglang = ["sglang~=0.3.0"]
 
 [project.scripts]

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -3,19 +3,18 @@
 # Tested on: NVIDIA A100-SXM4-80GB, CUDA 12.4, Python 3.11
 
 # === Inference engine ===
-vllm==0.8.5
+# Bumped from 0.8.5 (Gate 0/1 era) to 0.19.1 — the version the Gate
+# 2-FAIRNESS v3 launch numbers are keyed to (see results/CORRECTIONS.md
+# C7). Prior 0.8.5-specific compat pins (transformers<5, numpy<2.3) are
+# lifted; let vLLM 0.19.1's transitive requirements drive the tree.
+vllm==0.19.1
 
 # === Core ML (let vllm pull these — DO NOT pin torch separately) ===
-# torch, torchvision, torchaudio are pulled by vllm as transitive deps
-# Pinning them separately causes conflicts
+# torch, torchvision, torchaudio are pulled by vllm as transitive deps.
+# Pinning them separately causes conflicts.
 
-# === vLLM 0.8.5 compat pins (Gate 0 regression fences) ===
-# transformers>=5.0 removes PreTrainedTokenizerBase.all_special_tokens_extended,
-#   which vllm 0.8.5's tokenizer_group relies on. Pin to the 4.51+ series.
-# numpy>=2.3 breaks numba (numba needs numpy<=2.2 at the time of vllm 0.8.5),
-#   and vllm 0.8.5's spec_decode.ngram_proposer imports numba on import.
-transformers>=4.51.1,<5.0
-numpy>=1.24,<2.3
+transformers>=4.51.1,<6.0
+numpy>=1.24
 
 # === Profiling dependencies ===
 aiohttp>=3.9,<4.0

--- a/scripts/gate_pod_bootstrap.sh
+++ b/scripts/gate_pod_bootstrap.sh
@@ -151,18 +151,20 @@ abort_check
 phase_ts 2
 echo "--- Phase 2: python deps ---"
 python3 -m pip install --quiet --upgrade pip || fail "pip upgrade"
-python3 -m pip install --quiet 'vllm==0.8.5' || fail "vllm install"
+python3 -m pip install --quiet 'vllm==0.19.1' || fail "vllm install"
 python3 -m pip install --quiet -r requirements-gpu.txt || fail "requirements-gpu"
 python3 -m pip install --quiet -e . || fail "infergrid editable"
 python3 -m pip install --quiet 'huggingface_hub[cli]' || fail "hf cli"
 
-# ---- Dep verification (Gate-0 lessons 3+4) ----
+# ---- Dep verification ----
+# Gate-0 era pinned transformers<5 and numpy<2.3 for vLLM 0.8.5 compat.
+# Those assertions are removed along with the pin bump to 0.19.1.
+# We still print versions so the bench log captures the resolved tree.
 python3 -c "
 import transformers, numpy, vllm, torch
 print(f'vllm={vllm.__version__} transformers={transformers.__version__} numpy={numpy.__version__} torch={torch.__version__}')
-assert int(transformers.__version__.split('.')[0]) < 5, 'transformers must be < 5'
-assert tuple(int(x) for x in numpy.__version__.split('.')[:2]) < (2, 3), 'numpy must be < 2.3'
-print('PINS OK')" || fail "dep version check"
+assert vllm.__version__.startswith('0.19.'), f'expected vllm 0.19.x, got {vllm.__version__}'
+print('VERSIONS OK')" || fail "dep version check"
 
 # ---- Phase 3: HF login ----
 phase_ts 3


### PR DESCRIPTION
## Summary
Prereq PR for the post-launch \$72 gate ladder (Gates 2.1 / 2.4 / 2.3). Everything needed for pod spin goes here because \`scripts/gate_pod_bootstrap.sh\` clones \`--branch main --depth 1\` and can't see feature branches.

### 3 new YAML configs
| Config | Gate | Setup | Pre-committed PASS |
|---|---|---|---|
| \`gate21_fairness_n8.yaml\` | 2.1 | 1×A100, Llama-3.1-8B, N=8 (1 flooder + 7 quiet) | agg quiet p99 ≤ 75 ms, worst tenant ≤ 80 ms |
| \`gate24_fairness_mixtral_tp2.yaml\` | 2.4 | 2×A100 TP=2, Mixtral-8×7B MoE, 1 flooder + 3 quiet | quiet p99 ≤ 2× solo, per-tenant spread < 1.5× |
| \`gate23_fairness_70b_tp4.yaml\` | 2.3 | 4×A100 TP=4, Llama-3.1-70B, 1 flooder + 3 quiet | quiet p99 ≤ 2.5× solo, flooder 429 rate > 30% |

All three parse against \`InferGridConfig.from_yaml\` (verified in the branch).

### vLLM 0.8.5 → 0.19.1

Three locations still pinned 0.8.5, contradicting the Gate 2-FAIRNESS v3 launch numbers that are keyed to 0.19.1 (CORRECTIONS C7):
- \`requirements-gpu.txt:6\`
- \`scripts/gate_pod_bootstrap.sh:154\` (install) + \`:163-164\` (hard-coded asserts for \`transformers<5\` and \`numpy<2.3\`)
- \`pyproject.toml\` \`[project.optional-dependencies].vllm\`

Dropping the 0.8.5-specific compat fences (transformers<5, numpy<2.3, numba==0.60.x) in favor of vLLM 0.19.1's transitive tree. Keep the version-print for post-hoc diff and replace the numeric asserts with a \`vllm.__version__.startswith('0.19.')\` smoke check.

### Gate 2.2 is NOT in this PR

\`benchmark_n_tenant_single_model.py\` has a hardcoded short-prompt list (lines 52-61); \`RequestGenerator.generate_mixed_length\` exists but isn't wired into the N-tenant harness. Executing Gate 2.2 without that harness wiring would mean fabricating a mixed-length distribution in place — not acceptable. Follow-up PR adds a \`--prompt-length-dist\` flag to the harness; Gate 2.2 runs against it after that lands.

## Test plan
- [x] \`ruff check src/ tests/\` clean
- [x] \`pytest tests/unit/\` 153/153 green
- [x] All 3 YAMLs parse against \`InferGridConfig.from_yaml\` with correct TP values (1, 4, 2)
- [ ] CI matrix 3.11 + 3.12 green on this PR
- [ ] **On-pod validation:** first bootstrap run after merge will exercise the new vLLM 0.19.1 install path; any transitive-dep issue surfaces immediately and is fixed on the spot (cheap — Gate 2.1 is \$9).

## After merge
User runs, in order:
1. **Gate 2.1** — 1×A100 spot, \`gate21_fairness_n8.yaml\` (\$9, ~45 min)
2. **Gate 2.4** — 2×A100 spot, \`gate24_fairness_mixtral_tp2.yaml\` (\$18, ~75 min)
3. **Gate 2.3** — 4×A100 **SECURE on-demand** (not spot — preemption on 70B eats \$8), \`gate23_fairness_70b_tp4.yaml\`, Arm 0 then Arm 1 on the same warm engine (\$36, ~5h wall)

Persistent RunPod network volume at \`/workspace/hf_cache\` shared across all three — Llama-8B / Mixtral-8×7B / Llama-70B each download exactly once.