### PR TITLE
feat(bench): --prompt-length-dist flag for Gate 2.2 mixed-distribution fairness

### DIFF
--- a/benchmarks/scripts/benchmark_n_tenant_single_model.py
+++ b/benchmarks/scripts/benchmark_n_tenant_single_model.py
@@ -38,9 +38,15 @@ import sys
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import aiohttp
+
+# Make profiling utils importable for the mixed-length prompt sampler (Gate 2.2).
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_PROFILING_SCRIPTS = _SCRIPT_DIR.parent.parent / "profiling" / "scripts"
+if str(_PROFILING_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_PROFILING_SCRIPTS))
 
 logging.basicConfig(
     level=logging.INFO,
@@ -61,6 +67,110 @@ PROMPTS: list[str] = [
 ]
 
 
+# Gate 2.2: mixed-prompt-length distribution
+# ---------------------------------------------------------------------------
+# Parse and sample callable types: the sampler returns (prompt, requested_len)
+# where requested_len is the sampled input length in tokens (0 for the
+# legacy hardcoded-list path, so Gate 2.1 CSVs keep the same numeric column).
+PromptSampler = Callable[[random.Random], tuple[str, int]]
+
+
+def parse_prompt_length_dist(spec: str) -> list[tuple[int, float]]:
+    """Parse ``--prompt-length-dist`` spec into ``[(length, prob), ...]``.
+
+    Format: ``"64:0.4,512:0.3,2048:0.2,8192:0.1"``.
+
+    Fails fast on:
+      - non-numeric length or probability,
+      - non-positive lengths,
+      - probabilities not summing to ~1.0 (tolerance 0.001).
+    """
+    if not spec or not spec.strip():
+        raise ValueError("--prompt-length-dist is empty")
+    pairs: list[tuple[int, float]] = []
+    for chunk in spec.split(","):
+        piece = chunk.strip()
+        if not piece:
+            continue
+        if ":" not in piece:
+            raise ValueError(
+                f"--prompt-length-dist: bad entry {piece!r}, expected 'LEN:PROB'"
+            )
+        len_str, prob_str = piece.split(":", 1)
+        try:
+            length = int(len_str.strip())
+        except ValueError as exc:
+            raise ValueError(
+                f"--prompt-length-dist: non-numeric length {len_str!r}"
+            ) from exc
+        try:
+            prob = float(prob_str.strip())
+        except ValueError as exc:
+            raise ValueError(
+                f"--prompt-length-dist: non-numeric probability {prob_str!r}"
+            ) from exc
+        if length <= 0:
+            raise ValueError(
+                f"--prompt-length-dist: non-positive length {length}"
+            )
+        if prob < 0:
+            raise ValueError(
+                f"--prompt-length-dist: negative probability {prob} for length {length}"
+            )
+        pairs.append((length, prob))
+    if not pairs:
+        raise ValueError("--prompt-length-dist parsed to empty list")
+    total = sum(p for _, p in pairs)
+    if abs(total - 1.0) > 0.001:
+        raise ValueError(
+            f"--prompt-length-dist: probabilities sum to {total:.4f}, expected 1.0 (tol 0.001)"
+        )
+    return pairs
+
+
+def make_mixed_length_sampler(
+    pairs: list[tuple[int, float]], seed: int
+) -> PromptSampler:
+    """Build a seed-stable sampler that returns (prompt, sampled_length_tokens).
+
+    Reuses ``RequestGenerator.generate_fixed_length`` (from
+    ``profiling/scripts/profiling_utils.py``) to build prompt text. We sample
+    the length here rather than calling ``generate_mixed_length`` so the
+    per-request sampled length can be recorded in the CSV.
+    """
+    from profiling_utils import RequestGenerator
+
+    gen = RequestGenerator(seed=seed)
+    lengths = [length for length, _ in pairs]
+    weights = [prob for _, prob in pairs]
+    # Local rng for sampling the length itself — keeps prompt determinism
+    # independent of the tenant arrival rng stream.
+    length_rng = random.Random(seed)
+
+    def _sample(_unused_arrival_rng: random.Random) -> tuple[str, int]:
+        input_len = length_rng.choices(lengths, weights=weights, k=1)[0]
+        # Output length argument is required by generate_fixed_length but we
+        # do not use it — callers pass --max-tokens on the wire (Poisson model
+        # only changes arrival, --prompt-length-dist only changes content).
+        batch = gen.generate_fixed_length(1, input_len, output_len=64)
+        return batch[0]["prompt"], input_len
+
+    return _sample
+
+
+def make_legacy_sampler() -> PromptSampler:
+    """Gate 2.1 default: uniformly sample from the hardcoded PROMPTS list.
+
+    Uses the tenant's arrival rng directly, matching the pre-Gate-2.2
+    behavior byte-for-byte so existing invocations stay reproducible.
+    """
+
+    def _sample(arrival_rng: random.Random) -> tuple[str, int]:
+        return arrival_rng.choice(PROMPTS), 0
+
+    return _sample
+
+
 @dataclass
 class RequestResult:
     tenant: str
@@ -69,12 +179,17 @@ class RequestResult:
     ttft_ms: float
     total_latency_ms: float
     tokens_out: int
+    # Gate 2.2: sampled input length in tokens when --prompt-length-dist is
+    # used; 0 for the legacy hardcoded-PROMPTS path. Default keeps the
+    # dataclass backward-compatible with existing callers.
+    prompt_tokens: int = 0
     error: str = ""
 
 
 async def send_one(
     session: aiohttp.ClientSession, base_url: str, tenant_id: str,
     request_id: int, model: str, prompt: str, max_tokens: int, timeout_s: float,
+    prompt_tokens: int = 0,
 ) -> RequestResult:
     url = f"{base_url}/v1/completions"
     payload = {"model": model, "prompt": prompt, "max_tokens": max_tokens, "stream": True}
@@ -90,7 +205,8 @@ async def send_one(
                 return RequestResult(
                     tenant=tenant_id, request_id=request_id, submit_time=submit,
                     ttft_ms=0.0, total_latency_ms=(time.time() - submit) * 1000,
-                    tokens_out=0, error=f"HTTP {resp.status}: {body[:180]}",
+                    tokens_out=0, prompt_tokens=prompt_tokens,
+                    error=f"HTTP {resp.status}: {body[:180]}",
                 )
             async for line in resp.content:
                 decoded = line.decode("utf-8").strip()
@@ -119,13 +235,13 @@ async def send_one(
         return RequestResult(
             tenant=tenant_id, request_id=request_id, submit_time=submit,
             ttft_ms=0.0, total_latency_ms=(time.time() - submit) * 1000,
-            tokens_out=0, error="timeout",
+            tokens_out=0, prompt_tokens=prompt_tokens, error="timeout",
         )
     except Exception as exc:
         return RequestResult(
             tenant=tenant_id, request_id=request_id, submit_time=submit,
             ttft_ms=0.0, total_latency_ms=(time.time() - submit) * 1000,
-            tokens_out=0, error=str(exc),
+            tokens_out=0, prompt_tokens=prompt_tokens, error=str(exc),
         )
     end = time.time()
     total_ms = (end - submit) * 1000
@@ -133,6 +249,7 @@ async def send_one(
     return RequestResult(
         tenant=tenant_id, request_id=request_id, submit_time=submit,
         ttft_ms=ttft_ms, total_latency_ms=total_ms, tokens_out=tokens_out,
+        prompt_tokens=prompt_tokens,
     )
 
 
@@ -141,18 +258,20 @@ async def tenant_poisson_loop(
     session: aiohttp.ClientSession, base_url: str, model: str,
     max_tokens: int, timeout_s: float, rng: random.Random,
     results: list[RequestResult],
+    prompt_sampler: PromptSampler | None = None,
 ) -> None:
     if rps <= 0:
         return
+    sampler = prompt_sampler if prompt_sampler is not None else make_legacy_sampler()
     end_time = time.time() + duration_s
     request_id = 0
     in_flight: list[asyncio.Task[RequestResult]] = []
     mean_interarrival = 1.0 / rps
     while time.time() < end_time:
-        prompt = rng.choice(PROMPTS)
+        prompt, sampled_tokens = sampler(rng)
         task = asyncio.create_task(send_one(
             session, base_url, tenant_id, request_id, model, prompt,
-            max_tokens, timeout_s,
+            max_tokens, timeout_s, prompt_tokens=sampled_tokens,
         ))
         in_flight.append(task)
         request_id += 1
@@ -197,6 +316,13 @@ async def main_async(args: argparse.Namespace) -> int:
     outdir = Path(args.output_dir)
     outdir.mkdir(parents=True, exist_ok=True)
 
+    # Parse the optional prompt-length distribution (Gate 2.2). If unset, we
+    # fall through to the hardcoded PROMPTS list and Gate 2.1 behavior.
+    length_pairs: list[tuple[int, float]] | None = None
+    if args.prompt_length_dist:
+        length_pairs = parse_prompt_length_dist(args.prompt_length_dist)
+        logger.info("Mixed-prompt-length distribution: %s", length_pairs)
+
     # 1 flooder + N quiet tenants: budget for total offered concurrency.
     # Each quiet at quiet_rps × 5s avg + flooder at flooder_rps × 5s avg.
     expected_inflight = (args.flooder_rps + args.num_quiet * args.quiet_rps) * 5
@@ -212,6 +338,14 @@ async def main_async(args: argparse.Namespace) -> int:
     flooder_results: list[RequestResult] = []
     quiet_results: list[list[RequestResult]] = [[] for _ in range(args.num_quiet)]
 
+    # Per-tenant prompt samplers. Disjoint seed offset (+100) keeps the prompt
+    # rng stream independent of the arrival rng, so "same --seed → same
+    # prompts" stays stable even if arrival-loop rng usage changes later.
+    def sampler_for(tenant_offset: int) -> PromptSampler | None:
+        if length_pairs is None:
+            return None  # legacy path; tenant_poisson_loop uses make_legacy_sampler
+        return make_mixed_length_sampler(length_pairs, seed=args.seed + 100 + tenant_offset)
+
     start_wall = time.time()
     async with aiohttp.ClientSession(connector=connector) as session:
         coros = [
@@ -219,6 +353,7 @@ async def main_async(args: argparse.Namespace) -> int:
                 "flooder", args.flooder_rps, args.duration_s,
                 session, args.url, args.model, args.max_tokens, args.timeout_s,
                 random.Random(args.seed), flooder_results,
+                prompt_sampler=sampler_for(0),
             ),
         ]
         for i in range(args.num_quiet):
@@ -227,6 +362,7 @@ async def main_async(args: argparse.Namespace) -> int:
                     f"quiet_{i}", args.quiet_rps, args.duration_s,
                     session, args.url, args.model, args.max_tokens, args.timeout_s,
                     random.Random(args.seed + 1 + i), quiet_results[i],
+                    prompt_sampler=sampler_for(1 + i),
                 )
             )
         await asyncio.gather(*coros)
@@ -247,6 +383,32 @@ async def main_async(args: argparse.Namespace) -> int:
     quiet_summaries = {f"quiet_{i}": summarize(quiet_results[i]) for i in range(args.num_quiet)}
     # Aggregate quiet percentiles across all quiet samples (the launch claim).
     all_quiet = [r for sub in quiet_results for r in sub]
+
+    # Gate 2.2: record the actual sampled length distribution per tenant so
+    # a reviewer can verify it matched the requested dist within sampling noise.
+    def length_histogram(results: list[RequestResult]) -> dict[str, int]:
+        hist: dict[str, int] = {}
+        for r in results:
+            if r.prompt_tokens > 0:
+                key = str(r.prompt_tokens)
+                hist[key] = hist.get(key, 0) + 1
+        return hist
+
+    prompt_length_block: dict[str, Any] | None = None
+    if length_pairs is not None:
+        prompt_length_block = {
+            "requested": [
+                {"length": length, "prob": prob} for length, prob in length_pairs
+            ],
+            "sampled_histograms": {
+                "flooder": length_histogram(flooder_results),
+                **{
+                    f"quiet_{i}": length_histogram(quiet_results[i])
+                    for i in range(args.num_quiet)
+                },
+            },
+        }
+
     summary = {
         "wall_time_s": round(wall_s, 2),
         "flooder": summarize(flooder_results),
@@ -256,8 +418,11 @@ async def main_async(args: argparse.Namespace) -> int:
             "flooder_rps": args.flooder_rps, "quiet_rps": args.quiet_rps,
             "num_quiet": args.num_quiet, "duration_s": args.duration_s,
             "max_tokens": args.max_tokens, "model": args.model, "seed": args.seed,
+            "prompt_length_dist": args.prompt_length_dist or "",
         },
     }
+    if prompt_length_block is not None:
+        summary["prompt_length"] = prompt_length_block
     summary_path = outdir / "summary.json"
     with open(summary_path, "w") as fh:
         json.dump(summary, fh, indent=2)
@@ -299,6 +464,16 @@ def main() -> int:
     p.add_argument("--timeout-s", type=float, default=60.0)
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--output-dir", required=True)
+    p.add_argument(
+        "--prompt-length-dist",
+        default="",
+        help=(
+            "Optional mixed input-length distribution (Gate 2.2), e.g. "
+            "'64:0.4,512:0.3,2048:0.2,8192:0.1'. Probabilities must sum to "
+            "~1.0 (tolerance 0.001). When unset, the hardcoded short-prompt "
+            "list (Gate 2.1 behavior) is used."
+        ),
+    )
     args = p.parse_args()
     return asyncio.run(main_async(args))
 

--- a/tests/unit/test_prompt_length_dist.py
+++ b/tests/unit/test_prompt_length_dist.py
@@ -1,0 +1,211 @@
+"""Unit tests for Gate 2.2 --prompt-length-dist flag and sampler.
+
+Covers the parse validator (shape + three fail-fast rules), the seed-stable
+mixed-length sampler, the legacy (no-flag) path's backward compatibility,
+and an end-to-end parse + sample smoke test that never fires HTTP.
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add the benchmark script dir so we can import the module under test.
+_BENCH_SCRIPTS = (
+    Path(__file__).resolve().parent.parent.parent / "benchmarks" / "scripts"
+)
+sys.path.insert(0, str(_BENCH_SCRIPTS))
+
+from benchmark_n_tenant_single_model import (  # noqa: E402
+    PROMPTS,
+    make_legacy_sampler,
+    make_mixed_length_sampler,
+    parse_prompt_length_dist,
+)
+
+# ---------------------------------------------------------------------------
+# parse_prompt_length_dist — happy path + three fail-fast rules
+# ---------------------------------------------------------------------------
+
+
+class TestParsePromptLengthDist:
+    def test_parses_valid_spec(self) -> None:
+        spec = "64:0.4,512:0.3,2048:0.2,8192:0.1"
+        result = parse_prompt_length_dist(spec)
+        assert result == [(64, 0.4), (512, 0.3), (2048, 0.2), (8192, 0.1)]
+
+    def test_parses_single_bucket(self) -> None:
+        # Edge case: one length with p=1.0 is legal.
+        assert parse_prompt_length_dist("128:1.0") == [(128, 1.0)]
+
+    def test_tolerates_whitespace(self) -> None:
+        spec = " 64 : 0.5 , 512 : 0.5 "
+        assert parse_prompt_length_dist(spec) == [(64, 0.5), (512, 0.5)]
+
+    def test_rejects_probabilities_summing_to_0_8(self) -> None:
+        # Clearly wrong: 0.4 + 0.3 + 0.1 = 0.8, > 0.001 off from 1.0.
+        with pytest.raises(ValueError, match="sum"):
+            parse_prompt_length_dist("64:0.4,512:0.3,2048:0.1")
+
+    def test_rejects_probabilities_slightly_over_tolerance(self) -> None:
+        # 0.5 + 0.499 = 0.999, within tol. 0.5 + 0.495 = 0.995, NOT within tol.
+        with pytest.raises(ValueError, match="sum"):
+            parse_prompt_length_dist("64:0.5,512:0.495")
+
+    def test_accepts_probabilities_at_tolerance_edge(self) -> None:
+        # 0.5 + 0.4995 = 0.9995, within 0.001 tolerance.
+        result = parse_prompt_length_dist("64:0.5,512:0.4995")
+        assert len(result) == 2
+
+    def test_rejects_non_numeric_length(self) -> None:
+        with pytest.raises(ValueError, match="non-numeric length"):
+            parse_prompt_length_dist("abc:0.5,512:0.5")
+
+    def test_rejects_non_numeric_probability(self) -> None:
+        with pytest.raises(ValueError, match="non-numeric probability"):
+            parse_prompt_length_dist("64:xyz,512:0.5")
+
+    def test_rejects_non_positive_length(self) -> None:
+        with pytest.raises(ValueError, match="non-positive length"):
+            parse_prompt_length_dist("0:0.5,512:0.5")
+
+    def test_rejects_negative_length(self) -> None:
+        with pytest.raises(ValueError, match="non-positive length"):
+            parse_prompt_length_dist("-64:0.5,512:0.5")
+
+    def test_rejects_empty_spec(self) -> None:
+        with pytest.raises(ValueError):
+            parse_prompt_length_dist("")
+
+    def test_rejects_malformed_entry(self) -> None:
+        with pytest.raises(ValueError, match="LEN:PROB"):
+            parse_prompt_length_dist("64,512:0.5")
+
+
+# ---------------------------------------------------------------------------
+# make_mixed_length_sampler — seed stability + distribution correctness
+# ---------------------------------------------------------------------------
+
+
+class TestMixedLengthSampler:
+    def test_seed_produces_stable_sequence(self) -> None:
+        """Same seed → identical (prompt, length) sequence for bisection."""
+        pairs = [(64, 0.4), (512, 0.3), (2048, 0.2), (8192, 0.1)]
+        s1 = make_mixed_length_sampler(pairs, seed=42)
+        s2 = make_mixed_length_sampler(pairs, seed=42)
+        # The arrival rng passed in is ignored by the mixed-length sampler
+        # (it has its own length_rng), so we can pass any rng.
+        dummy = random.Random(0)
+        seq1 = [s1(dummy) for _ in range(50)]
+        seq2 = [s2(dummy) for _ in range(50)]
+        assert seq1 == seq2, "same seed must produce same prompts + lengths"
+
+    def test_different_seeds_diverge(self) -> None:
+        pairs = [(64, 0.5), (512, 0.5)]
+        s1 = make_mixed_length_sampler(pairs, seed=42)
+        s2 = make_mixed_length_sampler(pairs, seed=43)
+        dummy = random.Random(0)
+        seq1 = [s1(dummy)[1] for _ in range(100)]
+        seq2 = [s2(dummy)[1] for _ in range(100)]
+        assert seq1 != seq2, "different seeds must produce different length sequences"
+
+    def test_distribution_matches_requested_within_chi_squared(self) -> None:
+        """1000 samples with 40/30/20/10 split; 64-token prompts should be ~40%.
+
+        Chi-squared test at df=3, alpha=0.01 → critical ≈ 11.34.
+        Under the null hypothesis (sampler is correct), the test stat is
+        very unlikely to exceed this. Fail the test only on a truly skewed
+        outcome.
+        """
+        pairs = [(64, 0.4), (512, 0.3), (2048, 0.2), (8192, 0.1)]
+        sampler = make_mixed_length_sampler(pairs, seed=42)
+        dummy = random.Random(0)
+        n = 1000
+        counts = {64: 0, 512: 0, 2048: 0, 8192: 0}
+        for _ in range(n):
+            _, sampled_len = sampler(dummy)
+            counts[sampled_len] = counts.get(sampled_len, 0) + 1
+
+        # Sanity: 64 should be within a reasonable window of 40%.
+        frac_64 = counts[64] / n
+        assert 0.35 <= frac_64 <= 0.45, (
+            f"64-token fraction {frac_64:.3f} outside 35-45% for n=1000"
+        )
+
+        # Chi-squared goodness-of-fit
+        expected = {64: 400.0, 512: 300.0, 2048: 200.0, 8192: 100.0}
+        chi2 = sum(
+            (counts[length] - expected[length]) ** 2 / expected[length]
+            for length in expected
+        )
+        # df=3, alpha=0.01 critical value ≈ 11.345. Well above typical draws
+        # from a correct sampler — this guards against a broken implementation.
+        assert chi2 < 11.345, (
+            f"chi-squared {chi2:.2f} exceeds df=3 alpha=0.01 critical (11.345); "
+            f"counts={counts}"
+        )
+
+    def test_sampler_returns_positive_prompt_and_length(self) -> None:
+        pairs = [(64, 0.5), (512, 0.5)]
+        sampler = make_mixed_length_sampler(pairs, seed=7)
+        dummy = random.Random(0)
+        for _ in range(20):
+            prompt, length = sampler(dummy)
+            assert isinstance(prompt, str)
+            assert len(prompt) > 0
+            assert length in (64, 512)
+
+
+# ---------------------------------------------------------------------------
+# Legacy-path backward compat — unset flag must match pre-Gate-2.2 behavior
+# ---------------------------------------------------------------------------
+
+
+class TestLegacySampler:
+    def test_legacy_matches_direct_rng_choice(self) -> None:
+        """make_legacy_sampler(rng) must equal rng.choice(PROMPTS) exactly.
+
+        This is the Gate 2.1 backward-compat guarantee: the same --seed
+        produces the same prompt sequence as before the Gate 2.2 flag existed.
+        """
+        sampler = make_legacy_sampler()
+        rng_a = random.Random(42)
+        rng_b = random.Random(42)
+        for _ in range(30):
+            via_sampler, sampled_tokens = sampler(rng_a)
+            via_direct = rng_b.choice(PROMPTS)
+            assert via_sampler == via_direct
+            assert sampled_tokens == 0  # legacy path records 0 tokens in CSV
+
+
+# ---------------------------------------------------------------------------
+# Integration smoke: end-to-end parse + sample without firing HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestIntegrationSmoke:
+    def test_parse_then_sample_end_to_end(self) -> None:
+        """Parse a CLI-style flag and drive the sampler for a few iterations.
+
+        Covers the full code path the harness exercises in ``main_async``
+        before any network activity happens, minus argparse itself.
+        """
+        spec = "64:0.4,512:0.3,2048:0.2,8192:0.1"
+        pairs = parse_prompt_length_dist(spec)
+        assert pairs == [(64, 0.4), (512, 0.3), (2048, 0.2), (8192, 0.1)]
+
+        sampler = make_mixed_length_sampler(pairs, seed=142)
+        arrival_rng = random.Random(42)
+        collected: list[tuple[str, int]] = []
+        for _ in range(10):
+            prompt, length = sampler(arrival_rng)
+            collected.append((prompt, length))
+
+        # Every draw produces a usable prompt and a length from the distribution
+        valid_lengths = {64, 512, 2048, 8192}
+        for prompt, length in collected:
+            assert length in valid_lengths
+            assert isinstance(prompt, str) and len(prompt) > 0


### PR DESCRIPTION
## Why this unblocks

Gate 2.2 in the $72 RunPod ladder (mixed-prompt-length fairness) cannot
run today — `benchmark_n_tenant_single_model.py` only draws from an
8-element hardcoded PROMPTS list (short tasks only), so the N-tenant
fairness chart under Gate 2.2 would be scored against an unrealistic
input-length profile. This PR adds an opt-in flag that lets the harness
sample input lengths from a configurable distribution (64/512/2048/8192
tokens, weighted) so Gate 2.2 can reuse the same Gate 2.1 script
instead of forking a second benchmark.

## Flag syntax + example invocation

```bash
python benchmarks/scripts/benchmark_n_tenant_single_model.py \
  --url http://localhost:8000 \
  --model meta-llama/Llama-3.1-8B-Instruct \
  --flooder-rps 32 --quiet-rps 1 --num-quiet 5 \
  --duration-s 300 --max-tokens 64 \
  --prompt-length-dist "64:0.4,512:0.3,2048:0.2,8192:0.1" \
  --output-dir /workspace/results/gate2_2_mixed
```

Parser is strict: fails fast on non-numeric length/probability,
probabilities outside `1.0 ± 0.001`, or non-positive lengths.

## How the sampler works (reuse + why)

- Prompt text: reuses `RequestGenerator.generate_fixed_length` from
  `profiling/scripts/profiling_utils.py` (the same builder used by
  `run_baseline_comparison.py`). Does not reinvent a RequestGenerator.
- Length draw: sampled inline with `random.choices(lengths, weights)`
  rather than calling the existing `generate_mixed_length` method.
  Reason: `generate_mixed_length` returns `{prompt, max_tokens}` and
  throws away the sampled `input_len`, which we need to record in the
  CSV. The inline sample + fixed-length-text path is the cleanest
  seed-stable way to surface the per-request length.
- The dict's `max_tokens` field (scaled by `generate_mixed_length` /
  `generate_fixed_length`) is deliberately discarded. Wire traffic
  uses `--max-tokens` as before; only prompt content changes. Poisson
  arrival model is untouched.
- Per-tenant seed offset: prompt rng = `seed + 100 + tenant_offset`,
  disjoint from arrival rng = `seed + i` — so `--seed` stays stable for
  bisection even if arrival-loop rng usage changes later.

## Backward compatibility (Gate 2.1 untouched)

When `--prompt-length-dist` is not set:
- `make_legacy_sampler()` does `arrival_rng.choice(PROMPTS)` — the same
  call on the same rng in the same order as before, so existing
  invocations produce byte-identical prompt sequences.
- `prompt_tokens` CSV column = 0 (default), signaling "legacy path".
- `summary.json` does not get the `prompt_length` block.

**Schema note for reviewers:** `RequestResult` gained a new
`prompt_tokens: int = 0` field, so Gate 2.1 CSVs also get this extra
column (value = 0 for every row). `pd.read_csv` tolerates that
transparently; any downstream consumer that uses raw `csv.reader`
positional indexing should be updated.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `pytest tests/unit/` — 171 passed (153 baseline + 18 new)
- [x] Stable-seed test: same `--seed` → identical (prompt, length)
      sequence across two runs (50 samples)
- [x] Chi-squared goodness-of-fit on 1000 samples, df=3, alpha=0.01
      critical 11.345 — sampler draws match requested 40/30/20/10 split
- [x] Parser fails fast on probabilities summing to 0.8, non-numeric
      length `"abc:0.5"`, non-positive length (`0:` and `-64:`), and
      malformed entry (missing `:`)
- [x] Legacy path byte-for-byte equivalence: `make_legacy_sampler`
      output equals `rng.choice(PROMPTS)` with the same seed, 30 draws
- [x] `main_async` end-to-end fails fast with a clear `ValueError`
      when the flag is malformed (smoke-tested locally against a bad
      `0.8`-sum spec)
- [ ] To-do after merge (RunPod): run a short 30s bench with the flag
      set and eyeball `summary.json.prompt_length.sampled_histograms`
      — counts should be within sampling noise of the requested 40/30/20/10