### PR TITLE
results: gate-ladder v0.2 OUTCOME templates (numbers pending)

### DIFF
--- a/results/gate21_n8_TBD/GATE21_N8_OUTCOME.md
+++ b/results/gate21_n8_TBD/GATE21_N8_OUTCOME.md
@@ -1,0 +1,124 @@
+# Gate 2.1 (N=8) — Per-Tenant Fairness at N=8 on a Shared vLLM Engine
+
+**Date:** <TBD_DATE>
+**Hardware:** 1× <TBD_GPU_MODEL> on RunPod (SECURE on-demand, ~$<TBD_HOURLY>/hr) — see Caveats re: GPU substitution from A100-SXM4 80GB.
+**Total cost:** ~$<TBD_COST_ACTUAL> actual (ceiling $<TBD_COST_CEILING>)
+**main tip at start:** `<TBD_SHA>` (<TBD_PR_POINTER>).
+**Model:** `meta-llama/Llama-3.1-8B-Instruct`, bfloat16, max_model_len=4096, gpu_memory_utilization=0.85
+**Workload:** 1 flooder + 7 quiet tenants, 300s sustained, 128-token outputs. Extends the N=6 CONFIRM (Gate 2-FAIRNESS) to N=8 on a single GPU serving a single engine.
+**Status:** **<TBD_STATUS>.** <TBD_STATUS_ONELINER>
+
+**Hypothesis going in:** the fairness property observed at N=2 and N=6 holds at N=8 — that is, per-tenant budget-layer rate-limiting keeps the 7 quiet tenants' TTFT near solo baseline even when a single flooder saturates the shared engine. Null: fairness degrades with N (per-tenant baseline quota shrinks, contention for flooder's own capacity grows, warmup transients stack).
+
+---
+
+## Headline numbers
+
+| | Arm 0 solo baseline | Arm 1 FIFO contended | Arm 5 DRR + rate_limit |
+|---|---:|---:|---:|
+| `quiet_user.ttft_p50` (median across 7 quiets) | **<TBD> ms** | <TBD> ms | **<TBD> ms** |
+| `quiet_user.ttft_p99` (worst of 7 quiets, p99) | <TBD> ms | <TBD> ms | <TBD> ms |
+| `quiet_user.count_ok` (sum across 7 quiets) | <TBD> / 300s | <TBD> / 300s | <TBD> / 300s |
+| `flooder.count_ok` | (n/a) | <TBD> | <TBD> |
+| `flooder.count_err` (429) | (n/a) | <TBD> | **<TBD>** |
+
+**p50 starvation reduction (Arm 1 → Arm 5): <TBD>× improvement.**
+**Per-quiet-tenant steady-state p50 spread (max − min across 7 quiets): <TBD> ms.**
+
+---
+
+## Pre-committed criteria (from advisor + runbook)
+
+| Criterion | Value | Result |
+|---|---|---|
+| Arm 5 quiet_p99 (worst of 7) ≤ 110ms (2× solo baseline) | <TBD> ms | **<TBD>** |
+| Arm 5 flooder gets 429'd (rate-limit fires) | tenant_rejected=<TBD>; flooder count_err=<TBD> | **<TBD>** |
+| Arm 5 no quiet tenant gets 429'd (plumbing check) | quiet count_err sum=<TBD> | **<TBD>** |
+| Arm 5 per-quiet-tenant spread ≤ 1.5× | max/min=<TBD> | **<TBD>** |
+
+The fourth criterion is new at N=8: with 7 quiets, "fairness" isn't just flooder-vs-quiet, it's also quiet-vs-quiet. If DRR is working, the 7 quiets should be within ~1.5× of each other on p50 TTFT.
+
+---
+
+## All arms — full data table
+
+| Arm | Config | quiet_p50 (median/worst) | quiet_p99 (worst) | flood_p50 | flood_p99 | flood_err | Notes |
+|---|---|---:|---:|---:|---:|---:|---|
+| **0** | gate2_fairness_fifo + flooder_rps=0 (solo baseline) | **<TBD> / <TBD>** | **<TBD>** | n/a | n/a | n/a | 7 quiets alone, <TBD> req each |
+| **1** | gate2_fairness_fifo + flooder_rps=32 (no fairness) | **<TBD> / <TBD>** | **<TBD>** | <TBD> | <TBD> | <TBD> | expected: starvation on all 7 |
+| **5** | gate2_fairness_drr_ratelimit (rate_limit=600 RPM) | **<TBD> / <TBD>** | **<TBD>** | <TBD> | <TBD> | **<TBD>** | expected: all 7 quiets near baseline |
+
+---
+
+## What the data falsifies and confirms
+
+### Confirmed
+- <TBD>
+
+### Falsified
+- <TBD>
+
+### Diagnosed
+- <TBD>
+
+---
+
+## Per-quiet-tenant breakdown (Arm 5)
+
+| Tenant | count_ok | ttft_p50 (ms) | ttft_p99 (ms) | count_err |
+|---|---:|---:|---:|---:|
+| quiet_1 | <TBD> | <TBD> | <TBD> | <TBD> |
+| quiet_2 | <TBD> | <TBD> | <TBD> | <TBD> |
+| quiet_3 | <TBD> | <TBD> | <TBD> | <TBD> |
+| quiet_4 | <TBD> | <TBD> | <TBD> | <TBD> |
+| quiet_5 | <TBD> | <TBD> | <TBD> | <TBD> |
+| quiet_6 | <TBD> | <TBD> | <TBD> | <TBD> |
+| quiet_7 | <TBD> | <TBD> | <TBD> | <TBD> |
+| **spread** | — | **<TBD>** | **<TBD>** | — |
+
+If the spread column shows the 7 quiets within ~1.5× on p50, DRR is genuinely distributing across tenants. If it shows 3-5× spread, DRR is no-op and quiet-vs-quiet fairness is arrival-order-dependent.
+
+---
+
+## Operational notes
+
+- <TBD: pod spin count / any resume vs terminate lessons>
+- <TBD: config availability on main — bootstrap limitation reminder if relevant>
+- <TBD: cost actual vs ceiling>
+
+---
+
+## Implications for the launch post
+
+<TBD: 1-4 bullets on what the N=8 result adds to the N=6 CONFIRM story. If CONFIRM, the claim "fairness scales with N" is now defensible to at least N=8 on a single engine. If FAIL, note the mechanism (warmup stacking? DRR quantum exhaustion? flooder share erosion?) and whether it's a launch-blocker or a "known limit" footnote.>
+
+**Hero number for launch post:** <TBD>
+
+---
+
+## Rsync'd artifacts
+
+- `<TBD_arm0_dir>/` — 300s solo baseline (FIFO config, flooder_rps=0, 7 quiets only)
+- `<TBD_arm1_dir>/` — FIFO contended (no fairness, 1 flooder + 7 quiets)
+- `<TBD_arm5_dir>/` — **DRR + rate_limit_rpm=600 (the fix, 1 flooder + 7 quiets)**
+
+Each contains tarball + extracted: `benchmarks/{tenant_flooder.csv, tenant_quiet_{1..7}.csv, summary.json}`, `engine_logs/`, `prometheus_dump.txt`, `gpu_trace.csv`, `server.log`, `phase_*.ts`, `status_{before,after}.json`, `pip_freeze.txt`, `metadata.json` (records actual GPU model — see Caveats).
+
+---
+
+## Caveats not yet investigated
+
+1. **GPU substitution.** A100-SXM4 80GB availability collapsed during scheduling; Gate 2.1 pivoted to **H100 SXM 80GB HBM3**. Actual pod GPU recorded in the `metadata.json` tarball; absolute numbers (latencies, throughputs) may differ from the A100 spec but the per-tenant fairness ratio should preserve since fairness is a property of the admission+scheduling layer, not the compute substrate.
+2. <TBD: any warmup-transient observations specific to N=8>
+3. <TBD: whether the 7 quiets share a single TenantBudget RPM allocation or individual ones, and what that implies>
+4. <TBD: DRR quantum interaction with 8 tenants on a single engine>
+
+These are enhancements to consider post-launch, not blockers for the launch story.
+
+---
+
+## Decision tree from here
+
+<TBD: conditional on outcome. If CONFIRM → proceed to Gate 2.2 mixed-prompt-length on the same pod. If FAIL → diagnose and decide whether N=6 stands as the cap on the scaling claim in the launch post.>
+
+This OUTCOME is interpretation-friendly per the runbook contract: raw numbers + diagnostic decomposition + the user calls the shot on framing.

--- a/results/gate22_mixed_TBD/GATE22_MIXED_OUTCOME.md
+++ b/results/gate22_mixed_TBD/GATE22_MIXED_OUTCOME.md
@@ -1,0 +1,131 @@
+# Gate 2.2 (Mixed Prompt-Length) — Fairness Under Realistic Long-Tail Prompts
+
+**Date:** <TBD_DATE>
+**Hardware:** 1× <TBD_GPU_MODEL> on RunPod (SECURE on-demand, ~$<TBD_HOURLY>/hr) — same pod as Gate 2.1 post-completion — see Caveats re: GPU substitution from A100-SXM4 80GB.
+**Total cost:** ~$<TBD_COST_ACTUAL> actual (ceiling $<TBD_COST_CEILING>)
+**main tip at start:** `<TBD_SHA>` (PR #78 `--prompt-length-dist` landed cbee679).
+**Model:** `meta-llama/Llama-3.1-8B-Instruct`, bfloat16, max_model_len=8192, gpu_memory_utilization=0.85
+**Workload:** 1 flooder + 7 quiet tenants, 300s sustained, 128-token outputs, `--prompt-length-dist "64:0.4,512:0.3,2048:0.2,8192:0.1"`. Drawn from the same distribution for all 8 tenants.
+**Status:** **<TBD_STATUS>.** <TBD_STATUS_ONELINER>
+
+**Hypothesis going in:** the per-tenant bucket fairness observed under uniform 128-token prompts (Gate 2-FAIRNESS, Gate 2.1 N=8) survives a realistic long-tail prompt distribution — specifically, that the DRR quantum accounting tracks tokens (or at least accounts for prefill-time variance proportionally), so an 8192-token quiet prompt doesn't get starved by a flood of 64-token flooder prompts, and a flooder spamming 8192-token prompts doesn't exhaust its quota more slowly than expected.
+
+Null: fairness is prompt-length-dependent. Long prompts either (a) exhaust DRR quantum faster than RPM rate-limit accounts for, starving same-tenant follow-up requests, or (b) cluster at the vLLM prefill batcher in a way that the admission layer can't see, reintroducing quiet-tenant tail latency that N=8 uniform hid.
+
+---
+
+## Headline numbers
+
+| | Arm 0 solo baseline (mixed) | Arm 1 FIFO contended (mixed) | Arm 5 DRR + rate_limit (mixed) |
+|---|---:|---:|---:|
+| `quiet_user.ttft_p50` (median across 7 quiets) | **<TBD> ms** | <TBD> ms | **<TBD> ms** |
+| `quiet_user.ttft_p99` (worst of 7 quiets, p99) | <TBD> ms | <TBD> ms | <TBD> ms |
+| `quiet_user.ttft_p50`, **8192-token bucket only** | **<TBD> ms** | <TBD> ms | **<TBD> ms** |
+| `quiet_user.ttft_p99`, **8192-token bucket only** | <TBD> ms | <TBD> ms | <TBD> ms |
+| `flooder.count_ok` | (n/a) | <TBD> | <TBD> |
+| `flooder.count_err` (429) | (n/a) | <TBD> | **<TBD>** |
+
+**Per-bucket fairness ratio (Arm 5 quiet_p50 / Arm 0 quiet_p50), by prompt length:**
+
+| Prompt length | N | Arm 0 p50 | Arm 5 p50 | Ratio |
+|---|---:|---:|---:|---:|
+| 64 tok (40%) | <TBD> | <TBD> ms | <TBD> ms | **<TBD>×** |
+| 512 tok (30%) | <TBD> | <TBD> ms | <TBD> ms | **<TBD>×** |
+| 2048 tok (20%) | <TBD> | <TBD> ms | <TBD> ms | **<TBD>×** |
+| 8192 tok (10%) | <TBD> | <TBD> ms | <TBD> ms | **<TBD>×** |
+
+If all 4 buckets stay within ~1.5× of solo baseline, per-bucket fairness holds. If the 8192-tok bucket blows up to 5-10× while the 64-tok bucket is near baseline, we've learned that DRR quantum accounts for request count but not token-weighted cost — a known limitation to footnote, not a launch-blocker.
+
+---
+
+## Pre-committed criteria (from advisor + runbook)
+
+| Criterion | Value | Result |
+|---|---|---|
+| Arm 5 overall quiet_p99 ≤ 2× Arm 0 overall quiet_p99 | <TBD> ms vs <TBD> ms | **<TBD>** |
+| Arm 5 per-bucket quiet_p50 ≤ 1.5× Arm 0 per-bucket p50 (all 4 buckets) | see table | **<TBD>** |
+| Arm 5 flooder gets 429'd (rate-limit fires under mixed load) | tenant_rejected=<TBD> | **<TBD>** |
+| Arm 5 no quiet tenant starved on any specific bucket | worst-bucket quiet count_ok > 0 for all tenants | **<TBD>** |
+
+The "per-bucket" criterion is the real novel test here. Uniform-prompt fairness is straightforward; the question is whether mixed traffic breaks the abstraction.
+
+---
+
+## All arms — full data table
+
+| Arm | Config | quiet_p50 (median) | quiet_p99 (worst) | flood_p50 | flood_p99 | flood_err | Notes |
+|---|---|---:|---:|---:|---:|---:|---|
+| **0** | gate2_fairness_fifo + flooder_rps=0 (mixed, solo) | **<TBD>** | **<TBD>** | n/a | n/a | n/a | 7 quiets on mixed dist |
+| **1** | gate2_fairness_fifo + flooder_rps=32 (mixed, no fairness) | **<TBD>** | **<TBD>** | <TBD> | <TBD> | <TBD> | expected: bucket-dependent starvation |
+| **5** | gate2_fairness_drr_ratelimit (mixed, rate_limit=600) | **<TBD>** | **<TBD>** | <TBD> | <TBD> | **<TBD>** | expected: per-bucket near baseline |
+
+---
+
+## What the data falsifies and confirms
+
+### Confirmed
+- <TBD>
+
+### Falsified
+- <TBD>
+
+### Diagnosed
+- <TBD>
+
+---
+
+## Token-weighted cost breakdown (Arm 5)
+
+| Bucket | total prefill tokens (all tenants) | total prefill tokens (flooder) | total prefill tokens (quiets sum) | flooder share | quiet share per-quiet |
+|---|---:|---:|---:|---:|---:|
+| 64 tok | <TBD> | <TBD> | <TBD> | <TBD>% | <TBD>% |
+| 512 tok | <TBD> | <TBD> | <TBD> | <TBD>% | <TBD>% |
+| 2048 tok | <TBD> | <TBD> | <TBD> | <TBD>% | <TBD>% |
+| 8192 tok | <TBD> | <TBD> | <TBD> | <TBD>% | <TBD>% |
+
+If flooder's aggregate prefill-token share exceeds its RPM-implied fair share (1/8 = 12.5% per-tenant), the rate-limit is not token-weighted and long prompts break fairness by volume. If flooder's aggregate share tracks its RPM budget, fairness holds even on total-compute terms.
+
+---
+
+## Operational notes
+
+- <TBD: resumed same pod as Gate 2.1 / fresh spin — whichever the runbook executed>
+- <TBD: any OOM or prefill-memory incidents at 8192 max_model_len>
+- <TBD: cost actual vs ceiling>
+
+---
+
+## Implications for the launch post
+
+<TBD: 1-4 bullets. If CONFIRM → the mixed-prompt fairness story is the strongest version of the hero: "works on realistic traffic, not just synthetic uniform prompts." If per-bucket FAIL on 8192 → honest footnote: "DRR quantum is count-based; token-weighted scheduling is roadmap." If overall FAIL → diagnose and escalate.>
+
+**Hero number for launch post:** <TBD>
+
+---
+
+## Rsync'd artifacts
+
+- `<TBD_arm0_mixed_dir>/` — 300s solo baseline (FIFO config, flooder_rps=0, mixed dist, 7 quiets)
+- `<TBD_arm1_mixed_dir>/` — FIFO contended (no fairness, mixed dist, 1 flooder + 7 quiets)
+- `<TBD_arm5_mixed_dir>/` — **DRR + rate_limit_rpm=600 (the fix, mixed dist, 1 flooder + 7 quiets)**
+
+Each contains tarball + extracted: `benchmarks/{tenant_flooder.csv, tenant_quiet_{1..7}.csv, summary.json, prompt_length_histogram.csv}`, `engine_logs/`, `prometheus_dump.txt`, `gpu_trace.csv`, `server.log`, `phase_*.ts`, `status_{before,after}.json`, `pip_freeze.txt`, `metadata.json` (records actual GPU model — see Caveats).
+
+---
+
+## Caveats not yet investigated
+
+1. **GPU substitution.** A100-SXM4 80GB availability collapsed during scheduling; Gate 2.1 pivoted to **H100 SXM 80GB HBM3** and Gate 2.2 may follow. Actual pod GPU recorded in the `metadata.json` tarball; absolute numbers may differ from the A100 spec but the per-tenant fairness ratio should preserve since fairness is a property of the admission+scheduling layer, not the compute substrate.
+2. Distribution is drawn iid for all 8 tenants — a realistic "enterprise vs hobbyist" scenario would assign different distributions per tenant (e.g., flooder = all 64-tok, quiet_7 = all 8192-tok). Deferred.
+3. Output length is still fixed at 128 tokens. Variable output lengths would interact with DRR quantum differently (decode dominates compute at long outputs).
+4. The 8192-tok bucket is only 10% of traffic by count but dominates compute by volume (8192/64 = 128× cheaper per prefill token means the 10% bucket is ~73% of total prefill cost). Whether DRR should be token-weighted or count-weighted is a design question this bench surfaces.
+
+These are enhancements to consider post-launch, not blockers for the launch story.
+
+---
+
+## Decision tree from here
+
+<TBD: conditional on outcome. If CONFIRM overall + per-bucket → launch post can carry the "works on realistic traffic" claim at full strength. If per-bucket FAIL on 8192 → footnote + defer token-weighted DRR to post-launch roadmap. If overall FAIL → falls back to N=8 uniform as the scaling-claim ceiling.>
+
+This OUTCOME is interpretation-friendly per the runbook contract: raw numbers + diagnostic decomposition + the user calls the shot on framing.

--- a/results/gate23_70b_tp4_TBD/GATE23_70B_TP4_OUTCOME.md
+++ b/results/gate23_70b_tp4_TBD/GATE23_70B_TP4_OUTCOME.md
@@ -1,0 +1,141 @@
+# Gate 2.3 (Llama-3.1-70B, TP=4) — Fairness at Frontier Model Scale
+
+**Date:** <TBD_DATE>
+**Hardware:** 4× <TBD_GPU_MODEL> on RunPod (SECURE on-demand, ~$<TBD_HOURLY>/hr, TP=4) — see Caveats re: GPU substitution from A100-SXM4 80GB.
+**Total cost:** ~$<TBD_COST_ACTUAL> actual (ceiling $<TBD_COST_CEILING>)
+**main tip at start:** `<TBD_SHA>` (<TBD_PR_POINTER>).
+**Model:** `meta-llama/Llama-3.1-70B-Instruct`, bfloat16, tensor_parallel_size=4, max_model_len=4096, gpu_memory_utilization=0.90
+**Workload:** Two arms — **Arm 0 solo baseline** (1 quiet alone, 300s) + **Arm 5 contended** (1 flooder + 1 quiet, DRR + rate_limit, 300s), 128-token outputs. Frontier-credibility gate — the single experiment that determines whether the launch post can claim "works at 70B" or caps at "demonstrated at 8B."
+**Status:** **<TBD_STATUS>.** <TBD_STATUS_ONELINER>
+
+**Hypothesis going in:** the per-tenant fairness property transfers from Llama-3.1-8B on a single GPU to Llama-3.1-70B on 4× GPUs via TP=4. Fairness is a property of the admission + budget layer — it doesn't know and shouldn't care about tensor-parallelism, model size, or attention head count. Null: 70B at TP=4 exposes a new failure mode (NCCL stall propagating head-of-line blocking across tenants; larger per-request compute collapsing batching efficiency; VRAM pressure on 4× 80GB forcing gpu_memory_utilization down and narrowing the batch window enough that fairness degrades).
+
+Two arms instead of three because: (a) 70B at TP=4 is expensive (~$<TBD>/hr vs ~$<TBD>/hr for single-GPU 8B), (b) the FIFO-contended arm was already demonstrated at 8B — the 70B question is specifically "does the fix still work at scale," not "do we re-prove starvation at scale." If Arm 5 holds, the launch post can reference the 8B Arm 1 for the "starvation exists" baseline and this gate for "fix works at frontier scale."
+
+---
+
+## Headline numbers
+
+| | Arm 0 solo baseline (70B) | Arm 5 DRR + rate_limit (70B) |
+|---|---:|---:|
+| `quiet_user.ttft_p50` | **<TBD> ms** | **<TBD> ms** |
+| `quiet_user.ttft_p99` | <TBD> ms | <TBD> ms |
+| `quiet_user.count_ok` | <TBD> / 300s | <TBD> / 300s |
+| `flooder.count_ok` | (n/a) | <TBD> |
+| `flooder.count_err` (429) | (n/a) | **<TBD>** |
+
+**Fairness ratio (Arm 5 quiet_p50 / Arm 0 quiet_p50): <TBD>×**
+
+**Cross-scale fairness-ratio comparison:**
+
+| Model / scale | Arm 0 p50 | Arm 5 p50 | Ratio | Notes |
+|---|---:|---:|---:|---|
+| Llama-3.1-8B, 1 GPU (Gate 2-FAIRNESS) | 28.5 ms | ~30 ms (steady) | 1.05× | dense, 2 tenants, single GPU |
+| Llama-3.1-70B, 4 GPU TP=4 (this gate) | <TBD> | <TBD> | **<TBD>×** | dense, 2 tenants, TP=4 |
+
+If the 70B fairness ratio lands ≤1.5× (same ballpark as 8B), fairness is scale-invariant and the launch post can carry "works at frontier scale." If it blows up to 3-5×, we've identified a scale-dependent mechanism and the launch claim caps at 8B with 70B as roadmap.
+
+---
+
+## Pre-committed criteria (from advisor + runbook)
+
+| Criterion | Value | Result |
+|---|---|---|
+| Arm 5 quiet_p99 ≤ 2× Arm 0 solo baseline | <TBD> ms vs <TBD> ms | **<TBD>** |
+| Arm 5 quiet_p50 ≤ 1.5× Arm 0 solo baseline | <TBD> ms vs <TBD> ms | **<TBD>** |
+| Arm 5 flooder gets 429'd (rate-limit fires at 70B scale) | tenant_rejected=<TBD>; flooder count_err=<TBD> | **<TBD>** |
+| Arm 5 engine stays healthy under TP=4 | no NCCL timeout, no OOM, no sharding-broken output | **<TBD>** |
+| Absolute Arm 0 p50 consistent with published 70B TP=4 TTFT benchmarks | <TBD> ms (lit range ~<TBD> ms) | **<TBD>** |
+
+The fifth criterion is the "frontier credibility" check: if our Arm 0 solo-baseline TTFT at 70B TP=4 is wildly off from public benchmarks (e.g., 10× slower), the pod config is wrong and the fairness result is invalid regardless of what Arm 5 shows.
+
+---
+
+## All arms — full data table
+
+| Arm | Config | quiet_p50 | quiet_p99 | flood_p50 | flood_p99 | flood_err | Notes |
+|---|---|---:|---:|---:|---:|---:|---|
+| **0** | gate2_fairness_fifo_70b_tp4 + flooder_rps=0 (solo baseline) | **<TBD>** | **<TBD>** | n/a | n/a | n/a | <TBD> req |
+| **5** | gate2_fairness_drr_ratelimit_70b_tp4 (rate_limit=<TBD> RPM) | **<TBD>** | **<TBD>** | <TBD> | <TBD> | **<TBD>** | frontier fairness test |
+
+Arm 1 (FIFO-contended at 70B) intentionally omitted — see preamble rationale.
+
+---
+
+## What the data falsifies and confirms
+
+### Confirmed
+- <TBD>
+
+### Falsified
+- <TBD>
+
+### Diagnosed
+- <TBD>
+
+---
+
+## TP=4 engine diagnostics
+
+Per-GPU utilization trace (from `gpu_trace.csv`):
+
+| GPU | Avg util | Peak util | Avg VRAM | Peak VRAM |
+|---|---:|---:|---:|---:|
+| GPU 0 | <TBD>% | <TBD>% | <TBD> GB | <TBD> GB |
+| GPU 1 | <TBD>% | <TBD>% | <TBD> GB | <TBD> GB |
+| GPU 2 | <TBD>% | <TBD>% | <TBD> GB | <TBD> GB |
+| GPU 3 | <TBD>% | <TBD>% | <TBD> GB | <TBD> GB |
+| **TP imbalance (max/min util)** | — | **<TBD>** | — | — |
+
+NCCL / all-reduce timing (if vLLM exposes it in engine_logs):
+- Median all-reduce latency: **<TBD> ms**
+- p99 all-reduce latency: **<TBD> ms**
+- NCCL timeouts during the run: **<TBD>**
+
+If TP imbalance stays near 1.0× and all-reduce p99 is clean, the TP substrate is operating normally and any fairness result is attributable to the admission layer (which is what we want to test). If imbalance is high or NCCL p99 spikes, the fairness signal may be contaminated by engine-level noise.
+
+---
+
+## Operational notes
+
+- <TBD: 70B weight download time (much longer than 8B — ~140GB bf16)>
+- <TBD: TP=4 NCCL setup stability — any all-reduce timeouts on pod boot>
+- <TBD: VRAM pressure at gpu_memory_utilization=0.90 on 4× 80GB (need ~140GB for weights + KV cache headroom)>
+- <TBD: cost actual vs ceiling — this is the most expensive gate of the ladder>
+
+---
+
+## Implications for the launch post
+
+<TBD: 1-4 bullets. If CONFIRM → this is the headline claim-enabler: "InferGrid fairness works from 8B to 70B, single-GPU to TP=4 — the admission-layer architecture is genuinely scale-invariant." If FAIL → the launch post caps at 8B and 70B becomes the first roadmap milestone with honest framing about what scale introduces.>
+
+**Hero number for launch post:** <TBD>
+
+---
+
+## Rsync'd artifacts
+
+- `<TBD_arm0_70b_dir>/` — 300s solo baseline (FIFO, flooder_rps=0, 70B TP=4)
+- `<TBD_arm5_70b_dir>/` — **DRR + rate_limit (the fix, 70B TP=4)**
+
+Each contains tarball + extracted: `benchmarks/{tenant_flooder.csv, tenant_quiet_user.csv, summary.json}`, `engine_logs/` (including NCCL/all-reduce timing if available), `prometheus_dump.txt`, `gpu_trace.csv` (all 4 GPUs), `server.log`, `phase_*.ts`, `status_{before,after}.json`, `pip_freeze.txt`, `metadata.json` (records actual GPU model — see Caveats).
+
+---
+
+## Caveats not yet investigated
+
+1. **GPU substitution.** A100-SXM4 80GB availability collapsed during scheduling; Gate 2.1 pivoted to **H100 SXM 80GB HBM3** and Gate 2.3 may follow. Actual pod GPU recorded in the `metadata.json` tarball; absolute numbers may differ from the A100 spec but the per-tenant fairness ratio should preserve since fairness is a property of the admission+scheduling layer, not the compute substrate. Note that on H100 at TP=4 the absolute TTFT will be noticeably better than A100 TP=4 — the ratio, not the absolute, is what carries the launch claim.
+2. **Two arms, not three.** No FIFO-contended arm at 70B; the 8B FIFO-contended (Arm 1, 523× starvation) carries the "starvation exists" baseline. If a reviewer insists on a same-scale contended arm, that's a follow-up experiment at ~$<TBD> additional cost.
+3. **N=2 tenants only.** Doing N=8 on 70B TP=4 would cost ~4× this gate. The scale-invariance claim is "fairness ratio ≤1.5× at 70B with 2 tenants" — we're not claiming N=8 at 70B.
+4. **Fixed prompt + output lengths.** Mixed-prompt (Gate 2.2) at 70B is not scheduled. The long-tail interaction from Gate 2.2 + frontier-scale interaction from this gate may compound in ways neither gate individually tests.
+5. **vLLM TP=4 behavior may vary by version.** Pin recorded in `pip_freeze.txt`.
+
+These are enhancements to consider post-launch, not blockers for the launch story.
+
+---
+
+## Decision tree from here
+
+<TBD: conditional on outcome. If CONFIRM → frontier credibility secured; launch post claims "works at 70B TP=4." If FAIL with clean engine → honest scope cap at 8B + 70B roadmap. If FAIL with dirty engine (TP imbalance, NCCL) → separate "fairness signal" from "engine noise," potentially rerun on stable pod before making a launch call. If gate was never completed due to GPU scarcity or OOM → 8B Gate 2.1 + Gate 2.2 results alone have to carry the launch post, and 70B becomes a demo-only stretch goal.>
+
+This OUTCOME is interpretation-friendly per the runbook contract: raw numbers + diagnostic decomposition + the user calls the shot on framing.

--- a/results/gate24_mixtral_TBD/GATE24_MIXTRAL_OUTCOME.md
+++ b/results/gate24_mixtral_TBD/GATE24_MIXTRAL_OUTCOME.md
@@ -1,0 +1,142 @@
+# Gate 2.4 (Mixtral-8×7B MoE) — Fairness on an MoE Model with Expert-Routing Variance
+
+**Date:** <TBD_DATE>
+**Hardware:** 2× <TBD_GPU_MODEL> on RunPod (SECURE on-demand, ~$<TBD_HOURLY>/hr, TP=2) — see Caveats re: GPU substitution from A100-SXM4 80GB.
+**Total cost:** ~$<TBD_COST_ACTUAL> actual (ceiling $<TBD_COST_CEILING>)
+**main tip at start:** `<TBD_SHA>` (<TBD_PR_POINTER>).
+**Model:** `mistralai/Mixtral-8x7B-Instruct-v0.1`, bfloat16, tensor_parallel_size=2, max_model_len=4096, gpu_memory_utilization=0.90
+**Workload:** 1 flooder + N=<TBD> quiet tenants, 300s sustained, 128-token outputs. **First MoE model test.**
+**Status:** **<TBD_STATUS>.** <TBD_STATUS_ONELINER>
+
+**Hypothesis going in:** expert-routing variance in Mixtral (2 of 8 experts activated per token, per-token routing decisions) doesn't leak past the InferGrid budget gate. That is, even though different requests activate different expert subsets — and therefore have different per-token compute/memory bandwidth costs, different GPU utilization patterns, and different batching efficiency inside vLLM — the per-tenant fairness property observed on dense Llama-3.1-8B still holds. The rate-limit gate operates on request arrivals and tenant-identity, and is agnostic to whether the engine internally routes tokens to expert_3 or expert_7.
+
+Null: MoE routing variance creates per-request compute heterogeneity that vLLM's batcher handles in a way that reintroduces head-of-line blocking for quiet tenants. Specifically — if flooder's traffic pattern happens to hit a "hot" expert (sustained routing to one physical GPU in TP=2), that GPU becomes the bottleneck and all tenants on that GPU's share of the batch wait, including quiet's requests that ended up batched with flooder's.
+
+---
+
+## Headline numbers
+
+| | Arm 0 solo baseline (Mixtral) | Arm 1 FIFO contended (Mixtral) | Arm 5 DRR + rate_limit (Mixtral) |
+|---|---:|---:|---:|
+| `quiet_user.ttft_p50` | **<TBD> ms** | <TBD> ms | **<TBD> ms** |
+| `quiet_user.ttft_p99` | <TBD> ms | <TBD> ms | <TBD> ms |
+| `quiet_user.count_ok` | <TBD> / 300s | <TBD> / 300s | <TBD> / 300s |
+| `flooder.count_ok` | (n/a) | <TBD> | <TBD> |
+| `flooder.count_err` (429) | (n/a) | <TBD> | **<TBD>** |
+
+**p50 starvation reduction (Arm 1 → Arm 5): <TBD>× improvement.**
+**Cross-model fairness-ratio comparison (Arm 5 quiet_p50 / Arm 0 quiet_p50):**
+
+| Model | Arm 0 p50 | Arm 5 p50 | Ratio | Notes |
+|---|---:|---:|---:|---|
+| Llama-3.1-8B (dense, Gate 2-FAIRNESS) | 28.5 | ~30 (steady) | 1.05× | dense, single GPU |
+| Mixtral-8×7B (MoE, this gate) | <TBD> | <TBD> | **<TBD>×** | 8 experts, TP=2 |
+
+If the Mixtral ratio lands in the same ballpark (≤1.5×) as the Llama ratio, fairness is model-class-agnostic. If Mixtral blows up to 3-5×, we've identified a real interaction between MoE routing and admission-layer fairness that's launch-post-worthy as a footnote or follow-up-gate target.
+
+---
+
+## Pre-committed criteria (from advisor + runbook)
+
+| Criterion | Value | Result |
+|---|---|---|
+| Arm 5 quiet_p99 ≤ 2× Arm 0 solo baseline | <TBD> ms vs <TBD> ms | **<TBD>** |
+| Arm 5 quiet_p50 ≤ 1.5× Arm 0 solo baseline | <TBD> ms vs <TBD> ms | **<TBD>** |
+| Arm 5 flooder gets 429'd (rate-limit fires on MoE engine) | tenant_rejected=<TBD> | **<TBD>** |
+| Arm 5 engine stays healthy under TP=2 MoE pressure | no OOM, no crash, no degraded sharding | **<TBD>** |
+
+The fourth criterion matters more than on Llama: TP=2 on Mixtral is the first time we're testing InferGrid against a tensor-parallel engine. Rate-limit and admission don't change, but engine-level failure modes (all-reduce stalls, NCCL timeouts, expert-weight loading hiccups) are new.
+
+---
+
+## All arms — full data table
+
+| Arm | Config | quiet_p50 | quiet_p99 | flood_p50 | flood_p99 | flood_err | Notes |
+|---|---|---:|---:|---:|---:|---:|---|
+| **0** | gate2_fairness_fifo_mixtral + flooder_rps=0 (solo baseline, Mixtral TP=2) | **<TBD>** | **<TBD>** | n/a | n/a | n/a | <TBD> req |
+| **1** | gate2_fairness_fifo_mixtral + flooder_rps=<TBD> (no fairness) | **<TBD>** | **<TBD>** | <TBD> | <TBD> | <TBD> | expected: starvation |
+| **5** | gate2_fairness_drr_ratelimit_mixtral (rate_limit=<TBD> RPM) | **<TBD>** | **<TBD>** | <TBD> | <TBD> | **<TBD>** | expected: quiet near baseline |
+
+---
+
+## What the data falsifies and confirms
+
+### Confirmed
+- <TBD>
+
+### Falsified
+- <TBD>
+
+### Diagnosed
+- <TBD>
+
+---
+
+## MoE-specific diagnostics
+
+Expert-routing pattern (from vLLM engine logs `moe_expert_routing_histogram` if available):
+
+| Expert | Activations (flooder) | Activations (quiet) | Relative load |
+|---|---:|---:|---:|
+| expert_0 | <TBD> | <TBD> | <TBD> |
+| expert_1 | <TBD> | <TBD> | <TBD> |
+| expert_2 | <TBD> | <TBD> | <TBD> |
+| expert_3 | <TBD> | <TBD> | <TBD> |
+| expert_4 | <TBD> | <TBD> | <TBD> |
+| expert_5 | <TBD> | <TBD> | <TBD> |
+| expert_6 | <TBD> | <TBD> | <TBD> |
+| expert_7 | <TBD> | <TBD> | <TBD> |
+
+If flooder and quiet expert histograms are statistically similar (both broadly uniform over 8 experts because prompts are diverse), fairness doesn't depend on routing. If flooder concentrates on 1-2 experts and those become bottlenecks, we've found an MoE-specific unfairness mechanism InferGrid can't see from the admission gate alone.
+
+Per-GPU utilization trace (from `gpu_trace.csv`):
+- GPU 0 avg util: **<TBD>%**, peak **<TBD>%**
+- GPU 1 avg util: **<TBD>%**, peak **<TBD>%**
+- TP imbalance ratio (max/min): **<TBD>**
+
+---
+
+## Operational notes
+
+- <TBD: Mixtral weight download time on first pod spin — can be 30+ min, factor into cost>
+- <TBD: TP=2 NCCL setup stability>
+- <TBD: vLLM MoE-specific flags used>
+- <TBD: cost actual vs ceiling>
+
+---
+
+## Implications for the launch post
+
+<TBD: 1-4 bullets. If CONFIRM → the claim "fairness works across model classes, not just dense Llama" is defensible. MoE is a headline-worthy model class because Mixtral + DeepSeek + GPT-oss are the dominant open MoE deployments. If FAIL → honest footnote + clear follow-up: "MoE routing variance is a known interaction; our launch claim is dense-model-only until we add routing-aware admission.">
+
+**Hero number for launch post:** <TBD>
+
+---
+
+## Rsync'd artifacts
+
+- `<TBD_arm0_mixtral_dir>/` — 300s solo baseline (FIFO, flooder_rps=0, Mixtral TP=2)
+- `<TBD_arm1_mixtral_dir>/` — FIFO contended (no fairness, Mixtral TP=2)
+- `<TBD_arm5_mixtral_dir>/` — **DRR + rate_limit (the fix, Mixtral TP=2)**
+
+Each contains tarball + extracted: `benchmarks/{tenant_flooder.csv, tenant_quiet_user.csv, summary.json}`, `engine_logs/` (including MoE expert-routing histograms if available), `prometheus_dump.txt`, `gpu_trace.csv` (both GPUs), `server.log`, `phase_*.ts`, `status_{before,after}.json`, `pip_freeze.txt`, `metadata.json` (records actual GPU model — see Caveats).
+
+---
+
+## Caveats not yet investigated
+
+1. **GPU substitution.** A100-SXM4 80GB availability collapsed during scheduling; Gate 2.1 pivoted to **H100 SXM 80GB HBM3** and other gates may follow. Actual pod GPU recorded in the `metadata.json` tarball; absolute numbers may differ from the A100 spec but the per-tenant fairness ratio should preserve since fairness is a property of the admission+scheduling layer, not the compute substrate.
+2. **Expert routing histograms may not be exposed by the vLLM version we're pinning.** If the engine doesn't surface per-expert activation counts, the MoE-specific diagnostics table above will be incomplete and the "routing-hot-expert" hypothesis is only indirectly testable via per-GPU utilization imbalance.
+3. **Single-model MoE class.** Mixtral is one specific MoE architecture (8×7B, top-2 routing). DeepSeek-MoE (16×routing, finer experts) or GPT-oss would stress different routing regimes. Deferred.
+4. **TP=2 only.** TP=4 MoE has different all-reduce patterns and may surface interactions the TP=2 baseline hides. Gate 2.3 covers TP=4 on a dense 70B; a TP=4 MoE gate is not scheduled.
+5. **Prompt distribution uniform.** Mixed-prompt-length (Gate 2.2) + MoE is a 2×2 untested; doing it well needs both. Deferred.
+
+These are enhancements to consider post-launch, not blockers for the launch story.
+
+---
+
+## Decision tree from here
+
+<TBD: conditional on outcome. If CONFIRM → launch post can claim MoE coverage. If FAIL → frame as a scoped limitation (dense models work, MoE has a known routing-variance interaction, roadmapped). If the engine itself was unstable (NCCL timeouts, OOM) → separate out the "fairness property" from the "engine stability" axis and report on each.>
+
+This OUTCOME is interpretation-friendly per the runbook contract: raw numbers + diagnostic decomposition + the user calls the shot on framing.


### PR DESCRIPTION
## Summary

Pre-filled OUTCOME.md templates for the four gate-ladder v0.2 benches currently executing on RunPod. Voice/structure mirrors `results/gate2_fairness_20260419/GATE2_FAIRNESS_OUTCOME.md`.

## Files

- `results/gate21_n8_TBD/GATE21_N8_OUTCOME.md` -- N=8 fairness, 1 flooder + 7 quiets, Llama-3.1-8B, 1xGPU, 300s
- `results/gate22_mixed_TBD/GATE22_MIXED_OUTCOME.md` -- mixed prompt-length dist, same pod as 2.1, `--prompt-length-dist "64:0.4,512:0.3,2048:0.2,8192:0.1"`
- `results/gate24_mixtral_TBD/GATE24_MIXTRAL_OUTCOME.md` -- Mixtral-8x7B MoE on 2xGPU TP=2, first MoE test
- `results/gate23_70b_tp4_TBD/GATE23_70B_TP4_OUTCOME.md` -- Llama-3.1-70B on 4xGPU TP=4, frontier-credibility gate, 2 arms

## Sed-replace seams

All `<TBD>` tokens are the substitution points. They live inside:
- Table cells: `| <TBD> ms |` / `| **<TBD>** |`
- Metadata lines: `**Date:** <TBD_DATE>`, `**Hardware:** 1x <TBD_GPU_MODEL>`, `**main tip at start:** \`<TBD_SHA>\``
- Headline bold values: `**<TBD> ms**`
- Rsync'd artifact directory names: `<TBD_arm0_dir>/`

Each `<TBD_*>` suffix distinguishes positional placeholders (`<TBD_DATE>`, `<TBD_GPU_MODEL>`, `<TBD_SHA>`, `<TBD_COST_ACTUAL>`, `<TBD_HOURLY>`, `<TBD_STATUS>`, `<TBD_STATUS_ONELINER>`) from numeric `<TBD>` placeholders that appear inside tables.

## Critical caveat embedded in each template

Because A100-SXM4-80GB availability collapsed during scheduling, Gate 2.1 pivoted to H100 SXM 80GB HBM3, and other gates may follow. Each template's Caveats block notes: GPU substitution is recorded in the pod's `metadata.json`; absolute numbers may differ from A100 spec but the per-tenant fairness ratio should preserve (fairness is an admission-layer property, not a compute-substrate one).

## Do NOT admin-merge

Templates are numbers-pending; merge will happen when the sed-replace lands real values, not before.

## Test plan

- [ ] User verifies voice/structure matches gate2_fairness_20260419 expectations
- [ ] User verifies `<TBD>` placeholder coverage matches what the bench will emit
- [ ] After bench completes, user sed-replaces placeholders and renames dirs (e.g., `gate21_n8_TBD` -> `gate21_n8_20260420` or similar)
- [ ] User merges or follow-up PR once numbers land