### PR TITLE
launch: Show HN + Twitter + FAQ + one-pager drafts

### DIFF
--- a/docs/launch/faq.md
+++ b/docs/launch/faq.md
@@ -1,0 +1,47 @@
+# InferGrid — launch FAQ
+
+## Why not just use Modal / Replicate / Runpod?
+
+Those are managed inference clouds. You hand them your model and your traffic, they return tokens. InferGrid is the opposite: you keep the GPUs, you keep the traffic, you keep the model weights. There are three reasons teams stay on-prem or in their own cloud account and still need tenant fairness:
+
+1. **Data residency.** Healthcare, finance, EU customers, government — the traffic can't leave your perimeter. A managed cloud is a non-starter.
+2. **Custom-model support.** If you're serving a fine-tuned checkpoint, a proprietary architecture, or a quantization the managed provider doesn't support, you're running vLLM/SGLang yourself anyway. InferGrid makes that setup multi-tenant without you writing the fairness layer.
+3. **Cost-at-scale.** Managed per-token pricing is fine at 10 RPS. At 1,000 RPS sustained, owning an A100 or H100 is cheaper inside six months. Once you own the GPU, you need the orchestration.
+
+InferGrid is for the team that answered "yes" to any of those and then hit the noisy-neighbor problem on their own box.
+
+## Why not upstream this to vLLM as a PR?
+
+Per-tenant fairness is a middleware concern, not an engine concern — vLLM intentionally stays policy-agnostic about who a request belongs to, and merging a tenant model into the engine would either get rejected on scope grounds or bloat the engine with a responsibility it correctly refuses to own. The budget gate sits one layer up, where it can see the tenant identity the engine doesn't want to know about.
+
+## Why not Dynamo or llm-d?
+
+Both are excellent and both require Kubernetes. Dynamo v1.0 is NVIDIA's datacenter-shaped system; llm-d is the CNCF sandbox project aimed at pool-of-GPUs deployments. If you're running 50+ GPUs across multiple nodes, use one of those. If you're running 1–4 GPUs on a single box and your ops team does not want to learn k8s this quarter, InferGrid is the shape of tool that fits. The axis isn't "better/worse" — it's datacenter vs. single-node.
+
+## Is this production-ready?
+
+Honestly: no, not at scale yet. Here's the exact state. v0.1.2 on PyPI. 153 unit tests passing in ~10 seconds on CPU. The rate-limit mechanism is empirically validated at N=2 and N=6 tenants on A100 + Llama-3.1-8B + vLLM 0.19.1, with an N=8 CONFIRM and a Llama-3.1-70B TP=4 CONFIRM where the code path runs cleanly but the engine wasn't starved at our offered load. What I have not yet shipped: chaos testing, graceful engine-crash handling under active traffic, 7-day soak, or a real multi-week production deployment at a partner. I'm looking for beta users who will run it against real traffic and tell me where it breaks. File an issue with prometheus_dump.txt + server.log — that's the data I need.
+
+## What does "tenant" mean here?
+
+It's whatever partition key you want. Requests are routed by the `X-Tenant-ID` HTTP header, and the TenantManager treats each unique value as an independent bucket with its own token-bucket rate limit, concurrency cap, and priority weight. In practice that tends to be one of: an API key (per-customer fairness), a team identifier (per-internal-team fairness at a platform company), or a user ID (per-user fairness inside a single product). You pick the partition; InferGrid enforces isolation across it. The YAML lets you override defaults per-tenant — e.g. a paying customer can get a larger burst or higher sustained RPM than a free-tier tenant.
+
+## Does it work with X (custom engine)?
+
+Today: vLLM and SGLang, both via subprocess + HTTP proxy. The engine-adapter surface is public and lives at `src/infergrid/engines/` — it's an abstract base class plus two concrete adapters at 277 LOC total, and a new engine is typically a few hundred lines. TensorRT-LLM and Llama.cpp are the two I get asked about most; neither is merged yet, both are tractable. If you want to adapt a proprietary engine, the API surface you need to implement is small: subprocess launch, health check, HTTP proxy of the completion endpoint, and shutdown. PRs welcome.
+
+## Can I use this on CPU only?
+
+No. InferGrid requires CUDA because the engines it wraps require CUDA. vLLM and SGLang both target GPU inference; the CPU path in either is a debug fallback, not a real serving surface. If you're doing CPU inference, look at llama.cpp directly — tenant fairness at that scale typically isn't the bottleneck that matters. If you're doing ROCm / AMD, the answer is "pending" — vLLM has ROCm support but we haven't validated InferGrid on it.
+
+## How do I hand-wave the H100 vs A100 starvation delta if someone asks?
+
+The honest one-liner: *A100 at 32 RPS flooder is the saturation regime where FIFO starves and the mechanism is load-bearing. H100 at the same offered load has enough headroom that FIFO doesn't starve, so the TTFT delta shrinks — the mechanism is exercised but not stressed. Gate 2.1b reruns H100 at 128 RPS or N=16 to force saturation, and we'll publish that number next.* That's the full answer, and it's better than a tidier one because it names the exact axis — offered-load-to-capacity ratio — that determines whether fairness is load-bearing. If the questioner is sophisticated, they'll recognize that framing as correct. If they're not, the phrase "H100 has more headroom so FIFO doesn't starve as badly" is the five-word version.
+
+## What happens when a tenant exceeds their quota?
+
+They get a 429 Too Many Requests response, and the `tenant_rejected` Prometheus counter increments with a `{tenant_id}` label so you can alert on it. The rejection happens at the budget gate, before the engine is involved — so a misbehaving tenant cannot saturate the engine queue regardless of how much load they offer. The bucket refills at `rate_limit_rpm / 60` tokens per second and caps at `rate_limit_burst` tokens, so a tenant can burst up to `rate_limit_burst` requests immediately after a quiet period and then sustains at `rate_limit_rpm` per minute. This is the mechanism that holds the quiet-tenant p99 flat in the hero bench.
+
+## How does pricing / licensing work?
+
+MIT-licensed, pip-installable, free to run. There is no paid tier today. If you want engineering support, a deployment review, or a custom engine adapter, reach out — but the code is and will stay open. If I raise and monetize later, the self-hosted OSS path stays free; any paid offering would be a managed version or a support contract, not a license change. That commitment is in writing now because a rug-pull would destroy the exact thing I'm building.

--- a/docs/launch/one_pager.md
+++ b/docs/launch/one_pager.md
@@ -1,0 +1,64 @@
+# InferGrid — one-pager
+
+**Positioning.** InferGrid is open-source middleware that gives small teams per-tenant fairness for LLM inference on a single shared GPU, without Kubernetes.
+
+## The problem
+
+Multi-tenant LLM inference on a shared engine is a starvation problem. vLLM's continuous-batch scheduler is tenant-blind by design: once a flooder fills the engine queue, every other user's request sits behind flooder prefills. Every existing solution that fixes this requires Kubernetes (Dynamo, llm-d, Mammoth, AIBrix) or accepts no-fairness (Ollama, vanilla vLLM/SGLang). The "multi-tenant on a small shared box without K8s" cell is empty.
+
+## The wedge
+
+Three things engines cannot do internally:
+
+1. **Per-tenant token-bucket rate limiting at the budget gate** — load-bearing mechanism, validated empirically. Quiet-tenant p99 TTFT under contention: 1,585 ms (FIFO) → 61.5 ms (InferGrid token bucket), 1.14× of the solo baseline, A100 + vLLM 0.19.1, 300 s sustained, n=311. Generalized to N=6 tenants at 61.0 ms aggregate p99 (1.13× of solo).
+2. **Multi-model lifecycle on a single GPU** — frequency+recency eviction, hot-swap routing, no K8s.
+3. **OpenAI-compatible HTTP API** in front of multiple engines, so app code doesn't change.
+
+Ten lines of YAML. No application code change. Tenants routed by HTTP header.
+
+## Competitive map
+
+| System | K8s required | Multi-tenant fairness | Shape |
+|---|:---:|:---:|---|
+| NVIDIA Dynamo | Yes | No | Datacenter, NVIDIA-only |
+| llm-d (CNCF) | Yes | No | Datacenter pool-of-GPUs |
+| Mammoth (Modular) | Yes | No | Datacenter, multi-silicon |
+| Gimlet Labs ($92M Series A) | Managed cloud | Yes | Proprietary cloud, multi-silicon compiler |
+| Ollama | No | No | Single-node, LRU model eviction |
+| Vanilla vLLM/SGLang | No | No | Single engine, one model |
+| **InferGrid** | **No** | **Yes (validated)** | **1–4 GPUs, self-hosted** |
+
+Gimlet is the only production competitor with fairness, and they're a managed multi-silicon cloud — a different category from "self-hosted on your GPU." InferGrid is for the team that keeps the hardware.
+
+## Traction and validation
+
+- **PyPI:** `infergrid 0.1.2` live.
+- **Landing page:** infergrid.org with waitlist.
+- **Code:** 4,100 LOC src, 2,900 LOC tests, 153 unit tests passing, CI-gated lint + format.
+- **Empirical gate ladder v0.2 — 4 gates, 3 CONFIRM + 1 PASS:**
+  - Gate 2.1 (N=8 tenants, A100, Llama-3.1-8B): CONFIRM
+  - Gate 2.4 (Mixtral-8×7B MoE, 2×A100 TP=2): CONFIRM with engine-headroom caveat
+  - Gate 2.3 (Llama-3.1-70B, 4×H100 TP=4): CONFIRM — mechanism scales 8B→70B and 1-GPU→TP=4; p50 ratio flat (1.03× at 8B → 1.07× at 70B)
+  - Gate 2.2 (mixed prompt-length distribution): PASS
+- **Total compute spend across full experimental arc:** ~$17 on RunPod, self-funded.
+
+## Honest caveats
+
+Validated: A100 starvation regime at 32 RPS flooder, 2-tenant and 6-tenant, vLLM 0.19.1, Llama-3.1-8B. Mechanism code path exercised cleanly at 70B TP=4 and N=8. Not yet validated: saturated-H100 regime (Gate 2.1b on deck, bumps flooder to 128 RPS or N=16 to force H100 starvation). Not yet shipped: 7-day soak, chaos testing, production design-partner deployment. This is v0.1, not v1.0. Beta users wanted.
+
+## Use of funds — $500K–$1.5M pre-seed
+
+12–18 months runway to convert the validated mechanism into production-ready middleware with one lighthouse customer:
+
+- **Senior infra hire (~$300K loaded, 12 mo):** chaos/failure-mode engineering, multi-engine routing, production observability, engine-adapter surface hardening.
+- **One paid design partner (~$60K credits + integration time):** their traffic becomes the soak test; their failure modes become the roadmap; their logo becomes the reference.
+- **Compute (~$30K/yr):** Gate 2.1b through Gate 2.5 (32K long-context fairness) plus on-demand H100 SECURE for frontier benches.
+- **Founder runway + contractor design (~$180K):** focused solo builder plus one design contractor for the LP and CLI polish.
+
+Lower end ($500K) buys ~12 months solo + design partner. Upper end ($1.5M) buys the senior hire and extends to 18 months.
+
+## The ask
+
+Not formally raising today. Talking to angels and pre-seed funds who care about the inference infra gap between Ollama and Dynamo/llm-d and want to see the N=16 saturated-H100 number when it lands. If that's you, happy to share the full gate-ladder writeup and a live demo of the hero bench reproducing on a fresh RunPod pod in ~20 minutes.
+
+Contact: Shrey Patel, patelshrey77@gmail.com. Repo: github.com/coconut-labs/infergrid. Waitlist: infergrid.org.

--- a/docs/launch/show_hn.md
+++ b/docs/launch/show_hn.md
@@ -1,0 +1,9 @@
+# Show HN: InferGrid — per-tenant fairness for vLLM/SGLang without Kubernetes
+
+On one A100, Llama-3.1-8B, vLLM 0.19.1, with a flooder at 32 RPS sharing the engine with a quiet user at 1 RPS over a 300 s sustained bench, the quiet user's p99 TTFT goes from **1,585 ms** under vanilla FIFO admission to **61.5 ms** with InferGrid's per-tenant token-bucket rate limit at the budget gate — within **1.14× of the quiet user's solo baseline** (53.9 ms). That's a 26× recovery, and the fix is ten lines of YAML with no application code change.
+
+InferGrid is middleware that sits on top of vLLM or SGLang and adds three things engines can't do internally: per-tenant token-bucket rate limiting, multi-model lifecycle on a single GPU, and an OpenAI-compatible HTTP API in front of multiple engines. It's aimed at teams running multi-tenant inference on a shared box (1–4 GPUs) who don't want to stand up Dynamo or llm-d. The load-bearing mechanism is the rate limit *at the budget gate* — before the engine admits the request — because vLLM's continuous batcher is tenant-blind by design, and we empirically falsified admission caps and DRR-only reordering as solutions.
+
+What's validated: the 2-tenant hero above, plus N=6 generalization (aggregate p99 61.0 ms, 1.13× of solo), plus a Gate 2.3 Llama-3.1-70B TP=4 replication where the code path runs cleanly but H100 at our offered load doesn't saturate enough for FIFO to starve. What's not validated: "works at every scale" — the starvation regime is A100 at this load; a saturated-H100 rerun (Gate 2.1b) is on deck. v0.1.2 on PyPI, 153 unit tests, ~$17 total compute across the full experimental arc.
+
+Repo: https://github.com/coconut-labs/infergrid. Waitlist + launch post: https://infergrid.org. The data I actually need is adversarial benches — run it against your own traffic, tell me where it breaks. That's worth more to me than a star.

--- a/docs/launch/twitter_thread.md
+++ b/docs/launch/twitter_thread.md
@@ -1,0 +1,78 @@
+# Twitter thread — InferGrid launch
+
+**1/**
+A100 + Llama-3.1-8B + vLLM 0.19.1. One flooder at 32 RPS, one quiet user at 1 RPS, sharing the engine for 300 s.
+
+Vanilla FIFO: quiet user's p99 TTFT = 1,585 ms.
+With InferGrid's per-tenant token bucket: 61.5 ms. 1.14× of solo baseline.
+
+Ten lines of YAML.
+
+**2/**
+The problem: vLLM's continuous-batch scheduler is tenant-blind by design. Once a flooder fills the engine queue, your quiet user sits behind 30 flooder prefills no matter what header their request carried. The engine has no concept of a tenant. Adding one at the app layer is too late.
+
+**3/**
+We tried the obvious fixes first and they failed.
+
+- Admission cap alone: vLLM's internal queue absorbs overload as well as a coarse upstream cap. Sometimes worse.
+- DRR priority at admission: reordering the admission queue is a no-op when the saturation lives one layer down in the engine's batcher.
+
+**4/**
+What works: rate-limit the flooder at the budget gate, BEFORE its requests reach the engine queue. Token bucket, not sliding window — the bucket fires from t=0; a 60 s sliding window takes ~19 s to trigger 429s, during which the engine saturates anyway.
+
+The fix lives where the queue is.
+
+**5/**
+The YAML diff:
+
+```
+tenant_defaults:
+  max_concurrent_requests: 512
+  rate_limit_rpm: 600        # 10 RPS sustained refill per tenant
+  rate_limit_burst: 10       # 1 s burst; engages from t=0
+  priority: 1
+  scheduling: drr
+tenants:
+  - id: noisy
+  - id: quiet
+```
+
+Tenants matched on X-Tenant-ID header.
+
+**6/**
+Install and run:
+
+```
+pip install infergrid
+infergrid serve --config configs/quickstart_fairness.yaml
+curl localhost:8000/v1/completions -H "X-Tenant-ID: quiet" -d '{...}'
+```
+
+PyPI: v0.1.2. 153 unit tests. 4,100 LOC src, ~3,500 LOC middleware, OpenAI-compatible HTTP API, no Kubernetes.
+
+**7/**
+Honest caveats. This is validated at:
+- 1× A100-SXM4 80GB
+- Llama-3.1-8B bf16, vLLM 0.19.1
+- 2 tenants (hero) + 6 tenants (Track C generalization, aggregate p99 61.0 ms, 1.13× of solo)
+- 300 s sustained bench, n=311–1,456 post-warmup
+
+**8/**
+What's NOT validated: H100 replication under our offered load had smaller deltas (1.05–1.67×) because H100 has enough headroom that FIFO doesn't starve at 32 RPS. The mechanism is exercised, not stressed. Gate 2.1b (H100 at 128 RPS, N=16) is the saturated-regime rerun on deck.
+
+**9/**
+Also not proven: "works at 70B." Gate 2.3 ran the same code path on Llama-3.1-70B TP=4 across 4× H100 cleanly — zero engine OOMs, zero NCCL errors, mechanism engages — but the offered-load TTFT delta there is 1.62× because the engine isn't starved. Scale-invariant code path, not scale-invariant starvation.
+
+**10/**
+Competitive wedge. Dynamo and llm-d require Kubernetes and target datacenter shapes. Ollama gives you LRU model eviction but no per-tenant fairness. Vanilla vLLM/SGLang is one model per process, no tenant concept. The "multi-tenant on a small shared GPU without K8s" cell was empty. InferGrid fills it.
+
+**11/**
+Full launch post with all 5 arms, the per-window traces, the warmup-window caveat, and the 70B replication details:
+
+https://github.com/coconut-labs/infergrid/blob/main/docs/launch/gate0_launch_post.md
+
+Repo: https://github.com/coconut-labs/infergrid
+Waitlist: https://infergrid.org
+
+**12/**
+What I actually need: adversarial benches. Run it against your real traffic, your real tenant shape, your real prompt distribution. File an issue with prometheus_dump.txt + server.log when it breaks. That's worth more than a star — it's the data that tells me where the mechanism stops holding.


### PR DESCRIPTION
## Summary

- Adds 4 launch-content drafts under `docs/launch/`: `show_hn.md` (~250 words), `twitter_thread.md` (12 tweets), `faq.md` (10 Q/A, ~1000 words), `one_pager.md` (~500 words investor-facing).
- All numbers sourced from `docs/launch/gate0_launch_post.md` or `PROGRESS.md` — hero is the v3 vLLM-0.19.1 result (1,585 ms to 61.5 ms, 1.14x of solo), matching the source post's current lead; original 0.8.5 arc referenced as historical context only.
- Honest caveats throughout: A100 is the validated starvation regime; H100 and 70B code path runs cleanly but is under-saturated at our offered load; Gate 2.1b saturated-H100 rerun is the named follow-up.

## Test plan

- [ ] Reviewer confirms no number is invented (every figure traces to `gate0_launch_post.md` or `PROGRESS.md`)
- [ ] Reviewer confirms no emojis, no generated-with attributions, no fluff
- [ ] Reviewer confirms honest>hype framing: every strong claim has a caveat immediately after