### PR TITLE
feat(telemetry): opt-in anonymous install stats + Worker receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ infergrid man tenants       # fairness mental model + v3 numbers
 infergrid man topics        # list all bundled help pages
 ```
 
+## Telemetry
+
+InferGrid ships with **opt-in, anonymous** install/usage telemetry. The very first time you run any `infergrid` command interactively, you'll see a one-paragraph prompt asking whether to share stats. **The default is no.** If you answer `n` (or just press Enter), nothing is ever transmitted and we never re-prompt. If you answer `y`, each subsequent command sends a seven-field JSON payload — install ID (a locally-minted uuid4), InferGrid version, Python major.minor, OS (`linux`/`darwin`/`win32`), bucketed GPU class (`h100`/`a100`/`rtx4090`/`other`/`none`), the command name (`serve_started` / `doctor_ran`), and a unix timestamp. **Nothing else.** No prompts, no model names, no tenant IDs, no IP capture on the receiver side. The endpoint is a Cloudflare Worker we maintain; source is at [`telemetry-worker/`](telemetry-worker/).
+
+To disable (or toggle later): `infergrid telemetry off` / `infergrid telemetry on` / `infergrid telemetry status`. To hard-disable on a machine regardless of the saved setting, `export INFERGRID_TELEMETRY=0` — that short-circuits the subsystem before it reads or writes anything. Non-interactive sessions (CI, Docker entrypoints, cron) are treated as opt-out automatically; we never block on a prompt. Full policy and per-field rationale: [`docs/privacy/telemetry.md`](docs/privacy/telemetry.md).
+
 ## Architecture
 
 ```

--- a/docs/privacy/telemetry.md
+++ b/docs/privacy/telemetry.md
@@ -1,0 +1,102 @@
+# InferGrid telemetry privacy policy
+
+**Opt-in. Default off. Anonymous. Deletable.**
+
+InferGrid can send a tiny amount of install/usage data back to the
+maintainers to help prioritise work (e.g. "are any Windows users hitting
+this?", "how many A100 vs H100 installs are live after launch?"). This
+document explains exactly what that means.
+
+## What's collected
+
+If and only if you explicitly type `y` at the first-run prompt (or later
+run `infergrid telemetry on`), each CLI invocation sends a single JSON
+object with these fields and nothing else:
+
+| Field            | Example                                | Notes                                          |
+|------------------|----------------------------------------|------------------------------------------------|
+| `install_id`     | `f47ac10b-58cc-4372-a567-0e02b2c3d479` | uuid4 minted on your machine on first run       |
+| `version`        | `0.1.2`                                | InferGrid's own version                         |
+| `python_version` | `3.12`                                 | major.minor only                                |
+| `platform`       | `linux`                                | one of `linux` / `darwin` / `win32` / `other`  |
+| `gpu_class`      | `a100`                                 | from `nvidia-smi`; bucketed to `h100`/`a100`/`rtx4090`/`other`/`none` |
+| `event`          | `serve_started`                        | one of `install_first_run` / `serve_started` / `doctor_ran` |
+| `ts`             | `1_713_600_000`                        | unix seconds                                    |
+
+That's the entire payload. The receiving Cloudflare Worker validates this
+schema strictly and rejects any request that carries extra fields, wrong
+types, or out-of-range values.
+
+## What's NOT collected
+
+- **No prompts, completions, or any other request/response body content.**
+- **No model IDs or model names.** We cannot see what you are running.
+- **No tenant IDs** (the per-tenant headers InferGrid uses internally
+  never leave your machine).
+- **No IP addresses.** The Worker does not read, log, or store
+  `CF-Connecting-IP`. Cloudflare's platform keeps its own edge access
+  logs; those are subject to [Cloudflare's policies](https://www.cloudflare.com/privacypolicy/)
+  and are not combined with the event data.
+- **No hostnames, usernames, directory paths, filenames, or env vars.**
+- **No YAML config contents, tokens, or API keys.**
+- **No analytics SDKs, tracking pixels, or third-party tooling.** The
+  receiver is a ~150-line Cloudflare Worker that we maintain.
+
+## Why we collect it
+
+- Size the community after launch (installs, not downloads).
+- See which Python / OS / GPU combos actually show up, so we don't spend
+  bug-triage effort on irrelevant targets.
+- Measure the ratio between `install_first_run` and `serve_started` —
+  a proxy for how many people get past install.
+
+That's it. No advertising, no user profiling, no data sale or sharing.
+
+## How to opt out (or back in)
+
+Three equivalent ways, in order of strength:
+
+1. **Environment variable** (overrides everything):
+   ```
+   export INFERGRID_TELEMETRY=0
+   ```
+   When set to `0`, `false`, `no`, or `off`, no telemetry is ever read,
+   written, or transmitted — the subsystem short-circuits before touching
+   disk.
+
+2. **CLI toggle**:
+   ```
+   infergrid telemetry off       # disable
+   infergrid telemetry on        # re-enable
+   infergrid telemetry status    # show current state + config file path
+   ```
+
+3. **Delete the config file** at `~/.config/infergrid/telemetry.json`
+   (honors `XDG_CONFIG_HOME`). On the next run you'll get the first-run
+   prompt again.
+
+We will **never** re-prompt you once you've made a choice. The file is
+written once and read on subsequent runs.
+
+## Retention
+
+Rows in the D1 event store are deleted after **90 days** by a daily
+scheduled Worker (`[triggers] crons` in `telemetry-worker/wrangler.toml`).
+If that scheduled job is ever removed, this document will be updated in
+the same commit.
+
+## Deletion on request
+
+Find your install ID with `infergrid telemetry status` and email
+<patelshrey77@gmail.com> — we will delete all rows matching that
+`install_id` within 7 days. There is nothing else to tie events back to
+you, so this is a complete deletion.
+
+## Source you can audit
+
+- Client: [`src/infergrid/_telemetry.py`](../../src/infergrid/_telemetry.py) (~200 LOC)
+- Receiver: [`telemetry-worker/src/index.ts`](../../telemetry-worker/src/index.ts)
+- Schema: [`telemetry-worker/schema.sql`](../../telemetry-worker/schema.sql)
+
+If you spot a gap between this document and the code, that's a bug —
+please open an issue.

--- a/src/infergrid/_telemetry.py
+++ b/src/infergrid/_telemetry.py
@@ -1,0 +1,247 @@
+"""Opt-in anonymous install/usage telemetry.
+
+Every failure path is silently swallowed -- telemetry never blocks,
+delays, or breaks the CLI. ``INFERGRID_TELEMETRY=0`` and an empty
+``INFERGRID_TELEMETRY_URL`` short-circuit before any file I/O. Full
+privacy contract: ``docs/privacy/telemetry.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+from pathlib import Path
+from typing import Literal
+
+EventName = Literal["install_first_run", "serve_started", "doctor_ran"]
+_ALLOWED_EVENTS: frozenset[str] = frozenset(
+    {"install_first_run", "serve_started", "doctor_ran"}
+)
+_ALLOWED_EVENT_KEYS: frozenset[str] = frozenset(
+    {"install_id", "version", "python_version", "platform", "gpu_class", "event", "ts"}
+)
+
+# Build-time constant. Ship empty; distributors set via env var at package
+# build time. An empty URL means "never send", even if the user opted in.
+_DEFAULT_URL = ""
+
+
+def _config_path() -> Path:
+    """Return the telemetry config path (honors ``XDG_CONFIG_HOME``)."""
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "infergrid" / "telemetry.json"
+
+
+def _load_config() -> dict | None:
+    """Read the persisted config, or ``None`` if missing/corrupt."""
+    try:
+        p = _config_path()
+        if not p.exists():
+            return None
+        data = json.loads(p.read_text())
+        return data if isinstance(data, dict) else None
+    except Exception:
+        return None
+
+
+def _save_config(enabled: bool, install_id: str) -> None:
+    """Persist the user's choice. Silent on failure."""
+    try:
+        p = _config_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"enabled": bool(enabled), "install_id": install_id}))
+    except Exception:
+        pass
+
+
+def _env_disabled() -> bool:
+    """``INFERGRID_TELEMETRY=0`` (or false/no/off) forces off."""
+    return os.environ.get("INFERGRID_TELEMETRY", "").strip().lower() in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def _endpoint() -> str:
+    """Resolve the telemetry URL; env beats compile-time default."""
+    return os.environ.get("INFERGRID_TELEMETRY_URL", _DEFAULT_URL).strip()
+
+
+def _gpu_class() -> str:
+    """Best-effort GPU class from nvidia-smi. Never raises.
+
+    Returns ``h100`` | ``a100`` | ``rtx4090`` | ``other`` | ``none``.
+    """
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        line = (out.stdout or "").strip().splitlines()
+        if not line:
+            return "none"
+        name = line[0].lower()
+        if "h100" in name:
+            return "h100"
+        if "a100" in name:
+            return "a100"
+        if "4090" in name:
+            return "rtx4090"
+        return "other"
+    except Exception:
+        return "none"
+
+
+def _valid_install_id(v: object) -> bool:
+    """Light sanity check on a persisted install_id.
+
+    Not a privacy guarantee (the file is ours, the uuid is ours) -- just
+    enough to catch a corrupt or hand-edited config without crashing.
+    """
+    return isinstance(v, str) and 8 <= len(v) <= 64
+
+
+def _post_event_blocking(url: str, payload: dict) -> None:
+    """POST the event. Runs on a daemon thread. Silent on any failure."""
+    try:
+        import urllib.request
+
+        body = json.dumps(payload).encode("utf-8")
+        target = url if url.endswith("/event") else url + "/event"
+        req = urllib.request.Request(
+            target,
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": f"infergrid/{payload.get('version', '?')}",
+            },
+            method="POST",
+        )
+        # urllib's `timeout` is per-socket-op; 5s is an acceptable upper
+        # bound for a one-shot POST on a daemon thread.
+        with urllib.request.urlopen(req, timeout=5):  # noqa: S310
+            pass
+    except Exception:
+        pass
+
+
+def _prompt_user() -> bool:
+    """Show the one-paragraph prompt. Default No on empty / any failure."""
+    try:
+        sys.stderr.write(
+            "\nInferGrid can send anonymous install stats (install ID, version, "
+            "Python/OS, GPU class, and which command you ran) to help prioritize "
+            "work. No prompts, model names, tenant IDs, or IPs are ever sent. "
+            "Share? [y/N] "
+        )
+        sys.stderr.flush()
+        return sys.stdin.readline().strip().lower() in {"y", "yes"}
+    except Exception:
+        return False
+
+
+def maybe_prompt_and_record_event(event: EventName) -> None:
+    """Top-level entry point invoked from the CLI.
+
+    Called once per CLI invocation. On first interactive run, prompts the
+    user. On every run, if the user opted in and a URL is configured, fires
+    off a daemon thread to POST the event. Silent on every failure.
+    """
+    try:
+        if event not in _ALLOWED_EVENTS:
+            return  # defensive: caller bug, don't send unknown events.
+
+        if _env_disabled():
+            return
+
+        cfg = _load_config()
+        if cfg is None:
+            # First run. Prompt only if interactive; otherwise default No
+            # and persist so we never prompt again (e.g. CI, docker).
+            install_id = str(uuid.uuid4())
+            enabled = (
+                _prompt_user() if sys.stdin.isatty() and sys.stderr.isatty() else False
+            )
+            _save_config(enabled, install_id)
+            cfg = {"enabled": enabled, "install_id": install_id}
+
+        if not cfg.get("enabled"):
+            return
+
+        install_id = cfg.get("install_id")
+        if not _valid_install_id(install_id):
+            return  # corrupt file; safer to skip than to invent one.
+
+        url = _endpoint()
+        if not url:
+            return  # compile-time disabled; no receiver to post to.
+
+        try:
+            version = _pkg_version("infergrid")
+        except PackageNotFoundError:
+            version = "0.0.0+unknown"
+
+        p = sys.platform
+        plat = (
+            "linux"
+            if p.startswith("linux")
+            else (
+                "darwin"
+                if p == "darwin"
+                else ("win32" if p.startswith("win") else "other")
+            )
+        )
+
+        payload = {
+            "install_id": install_id,
+            "version": version,
+            "python_version": f"{sys.version_info.major}.{sys.version_info.minor}",
+            "platform": plat,
+            "gpu_class": _gpu_class(),
+            "event": event,
+            "ts": int(time.time()),
+        }
+        threading.Thread(
+            target=_post_event_blocking,
+            args=(url, payload),
+            daemon=True,
+        ).start()
+    except Exception:
+        # Absolute backstop: telemetry must never break the CLI.
+        pass
+
+
+def set_enabled(value: bool) -> dict:
+    """Flip the enabled flag; preserve (or mint) an install_id."""
+    cfg = _load_config() or {}
+    install_id = cfg.get("install_id")
+    if not _valid_install_id(install_id):
+        install_id = str(uuid.uuid4())
+    _save_config(bool(value), install_id)
+    return {"enabled": bool(value), "install_id": install_id}
+
+
+def get_status() -> dict:
+    """Return a dict describing the current telemetry state."""
+    cfg = _load_config()
+    return {
+        "enabled": bool(cfg.get("enabled")) if cfg else False,
+        "configured": cfg is not None,
+        "install_id": (cfg or {}).get("install_id"),
+        "env_disabled": _env_disabled(),
+        "endpoint_set": bool(_endpoint()),
+        "config_path": str(_config_path()),
+    }

--- a/src/infergrid/cli.py
+++ b/src/infergrid/cli.py
@@ -36,7 +36,7 @@ from rich.prompt import Prompt
 from rich.table import Table
 from rich.text import Text
 
-from infergrid import __version__
+from infergrid import __version__, _telemetry
 from infergrid._manpages import get_page, list_topics
 from infergrid.cache.manager import CacheManager
 from infergrid.common.config import InferGridConfig
@@ -186,6 +186,21 @@ def build_parser() -> argparse.ArgumentParser:
         nargs="?",
         default="overview",
         help="Help topic (default: overview). Use 'topics' to list all.",
+    )
+
+    # ── telemetry ──
+    telem_parser = sub.add_parser(
+        "telemetry",
+        help="Inspect or change the opt-in telemetry setting",
+        description=(
+            "Opt-in anonymous install/usage telemetry. See the README's "
+            "'Telemetry' section and docs/privacy/telemetry.md."
+        ),
+    )
+    telem_parser.add_argument(
+        "action",
+        choices=["on", "off", "status"],
+        help="'on' enables, 'off' disables, 'status' prints the current state",
     )
 
     return parser
@@ -623,6 +638,24 @@ def _cmd_doctor(_args: argparse.Namespace) -> None:
 # ─────────────────────────────── man ───────────────────────────────
 
 
+def _cmd_telemetry(args: argparse.Namespace) -> None:
+    """Handle the 'telemetry' subcommand."""
+    if args.action == "status":
+        st = _telemetry.get_status()
+        state = "on" if st["enabled"] else "off"
+        _console.print(f"[bold]telemetry:[/bold] {state}")
+        _console.print(f"  [dim]configured:[/dim]  {st['configured']}")
+        _console.print(f"  [dim]install_id:[/dim]  {st['install_id'] or '—'}")
+        _console.print(f"  [dim]env override:[/dim] {st['env_disabled']}")
+        _console.print(f"  [dim]endpoint set:[/dim] {st['endpoint_set']}")
+        _console.print(f"  [dim]config file:[/dim]  {st['config_path']}")
+        return
+
+    new = _telemetry.set_enabled(args.action == "on")
+    state = "on" if new["enabled"] else "off"
+    _console.print(f"[green]✓[/green] telemetry {state}")
+
+
 def _cmd_man(args: argparse.Namespace) -> None:
     """Handle the 'man' command."""
     topic = args.topic
@@ -660,6 +693,20 @@ def main(argv: Sequence[str] | None = None) -> None:
     except PackageNotFoundError:
         pass  # non-fatal; __init__.py falls back to "0.0.0+unknown"
 
+    # Telemetry hook. Runs before dispatch so first-run prompt lands before
+    # any command output. Never raises; silently swallows everything. The
+    # `telemetry` subcommand itself is exempt — the user is managing the
+    # setting there, we shouldn't send an event as a side effect.
+    if args.command != "telemetry":
+        event = {
+            "serve": "serve_started",
+            "doctor": "doctor_ran",
+        }.get(args.command or "", "install_first_run")
+        try:
+            _telemetry.maybe_prompt_and_record_event(event=event)
+        except Exception:
+            pass
+
     if args.command == "serve":
         _cmd_serve(args)
     elif args.command == "status":
@@ -670,6 +717,8 @@ def main(argv: Sequence[str] | None = None) -> None:
         _cmd_doctor(args)
     elif args.command == "man":
         _cmd_man(args)
+    elif args.command == "telemetry":
+        _cmd_telemetry(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/telemetry-worker/README.md
+++ b/telemetry-worker/README.md
@@ -1,0 +1,78 @@
+# InferGrid Telemetry Worker
+
+Tiny Cloudflare Worker that receives opt-in anonymous install stats from
+the InferGrid CLI and writes them to D1. Intentionally **not** auto-deployed
+from this repo — a human reviews and runs `wrangler deploy`.
+
+## What it does (and doesn't)
+
+- `POST /event` — strict JSON schema, bounded field lengths, enum-checked.
+  Writes one row to D1.
+- `GET  /health` — returns `{ok: true}`. Useful for a Pingdom check, not
+  for the CLI.
+- 24-hour rate limiter keyed by `install_id` (KV, 100 events/day). Over
+  the limit → silently dropped, 200 OK.
+- Scheduled handler deletes rows older than 90 days. Keeps the
+  `docs/privacy/telemetry.md` retention claim honest.
+- **Never reads or logs `CF-Connecting-IP`.** The Worker has no IP-capture
+  code path. Cloudflare's platform keeps its own edge logs; we do not
+  stack another.
+
+## One-time setup
+
+```bash
+cd telemetry-worker
+
+# 1. Create the D1 database, paste the returned id into wrangler.toml.
+wrangler d1 create infergrid-telemetry
+
+# 2. Create the KV namespace for the rate limiter, paste the id in.
+wrangler kv:namespace create RL
+
+# 3. Apply the schema.
+wrangler d1 execute infergrid-telemetry --file=schema.sql
+
+# 4. Deploy.
+wrangler deploy
+```
+
+The Worker URL (e.g. `https://infergrid-telemetry.<account>.workers.dev`)
+is what you set as `INFERGRID_TELEMETRY_URL` at Python-package build time.
+Without that, the CLI is a no-op even for users who opted in.
+
+## Local dev
+
+```bash
+wrangler dev
+# In another shell:
+curl -X POST http://127.0.0.1:8787/event \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "install_id":"11111111-1111-1111-1111-111111111111",
+    "version":"0.1.2",
+    "python_version":"3.12",
+    "platform":"linux",
+    "gpu_class":"a100",
+    "event":"install_first_run",
+    "ts":1700000000
+  }'
+```
+
+## Inspecting collected data
+
+```bash
+wrangler d1 execute infergrid-telemetry \
+  --command='SELECT event, COUNT(*) FROM events GROUP BY event;'
+```
+
+## Retention + deletion requests
+
+90 days, enforced by the `scheduled` handler (`[triggers] crons` in
+`wrangler.toml`). For per-`install_id` deletion on request:
+
+```bash
+wrangler d1 execute infergrid-telemetry \
+  --command="DELETE FROM events WHERE install_id = '...';"
+```
+
+See `docs/privacy/telemetry.md` for the user-facing policy.

--- a/telemetry-worker/schema.sql
+++ b/telemetry-worker/schema.sql
@@ -1,0 +1,29 @@
+-- InferGrid telemetry event store.
+--
+-- Apply with:
+--   wrangler d1 execute infergrid-telemetry --file=schema.sql
+--
+-- Column notes:
+--   install_id       uuid4 chosen by the client, stable across runs for a
+--                    single user install. Not linked to any account.
+--   version          InferGrid version string (semver-ish).
+--   python_version   "3.11" / "3.12" / ... (major.minor only).
+--   platform         linux | darwin | win32 | other
+--   gpu_class        h100 | a100 | rtx4090 | other | none
+--   event            install_first_run | serve_started | doctor_ran
+--   ts               unix seconds, client-supplied (validated server-side)
+--   server_ts        unix seconds, when the Worker inserted the row
+
+CREATE TABLE IF NOT EXISTS events (
+    install_id      TEXT NOT NULL,
+    version         TEXT NOT NULL,
+    python_version  TEXT NOT NULL,
+    platform        TEXT NOT NULL,
+    gpu_class       TEXT NOT NULL,
+    event           TEXT NOT NULL,
+    ts              INTEGER NOT NULL,
+    server_ts       INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_server_ts ON events(server_ts);
+CREATE INDEX IF NOT EXISTS idx_events_event     ON events(event);

--- a/telemetry-worker/src/index.ts
+++ b/telemetry-worker/src/index.ts
@@ -1,0 +1,204 @@
+// Telemetry receiver for InferGrid opt-in install stats.
+//
+// Privacy contract:
+// - The CLI sends a small, bounded JSON body — nothing else.
+// - We validate strictly: unknown keys are rejected, string fields are
+//   length-capped, the event name is enum-checked, and ts must be sane.
+// - We deliberately do NOT log, forward, or even read CF-Connecting-IP.
+//   Cloudflare's platform keeps its own edge logs; we do not add a second
+//   layer. See telemetry-worker/README.md for retention policy.
+// - CORS is wide-open because the client is the CLI, not a browser. If
+//   someone spoofs events from a real browser that's fine: the fields
+//   carry no PII and the rate limiter caps abuse per install_id.
+
+type Env = {
+  DB: D1Database;
+  RL: KVNamespace; // rate-limit counter: key = rl:<install_id>, TTL 24h
+};
+
+const ALLOWED_KEYS = [
+  'install_id',
+  'version',
+  'python_version',
+  'platform',
+  'gpu_class',
+  'event',
+  'ts',
+];
+
+const ALLOWED_EVENTS = new Set([
+  'install_first_run',
+  'serve_started',
+  'doctor_ran',
+]);
+
+const ALLOWED_PLATFORMS = new Set(['linux', 'darwin', 'win32', 'other']);
+const ALLOWED_GPU_CLASS = new Set(['h100', 'a100', 'rtx4090', 'other', 'none']);
+
+// Rate limit: a single install_id may send at most 100 events in 24h.
+// Beyond that we silently drop (still return 200 so the client sees no
+// signal; that's by design — we never want the Worker response to leak
+// into CLI UX).
+const RATE_LIMIT_PER_DAY = 100;
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+const SEMVER_ISH_RE = /^[0-9a-zA-Z.+_-]{1,32}$/;
+
+function corsHeaders(): HeadersInit {
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400',
+  };
+}
+
+function json(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders() },
+  });
+}
+
+type Payload = {
+  install_id: string;
+  version: string;
+  python_version: string;
+  platform: string;
+  gpu_class: string;
+  event: string;
+  ts: number;
+};
+
+function validate(body: unknown): Payload | { error: string } {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return { error: 'body must be a JSON object' };
+  }
+  const obj = body as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  if (JSON.stringify(keys) !== JSON.stringify([...ALLOWED_KEYS].sort())) {
+    return { error: 'unknown or missing fields' };
+  }
+  if (typeof obj.install_id !== 'string' || !UUID_RE.test(obj.install_id)) {
+    return { error: 'bad install_id' };
+  }
+  if (typeof obj.version !== 'string' || !SEMVER_ISH_RE.test(obj.version)) {
+    return { error: 'bad version' };
+  }
+  if (
+    typeof obj.python_version !== 'string' ||
+    !/^3\.(?:\d{1,2})$/.test(obj.python_version)
+  ) {
+    return { error: 'bad python_version' };
+  }
+  if (
+    typeof obj.platform !== 'string' ||
+    !ALLOWED_PLATFORMS.has(obj.platform)
+  ) {
+    return { error: 'bad platform' };
+  }
+  if (
+    typeof obj.gpu_class !== 'string' ||
+    !ALLOWED_GPU_CLASS.has(obj.gpu_class)
+  ) {
+    return { error: 'bad gpu_class' };
+  }
+  if (typeof obj.event !== 'string' || !ALLOWED_EVENTS.has(obj.event)) {
+    return { error: 'bad event' };
+  }
+  if (typeof obj.ts !== 'number' || !Number.isFinite(obj.ts)) {
+    return { error: 'bad ts' };
+  }
+  // Must be a plausible unix second, within ~2 years of "now".
+  const now = Math.floor(Date.now() / 1000);
+  if (obj.ts < now - 2 * 365 * 24 * 3600 || obj.ts > now + 24 * 3600) {
+    return { error: 'ts out of range' };
+  }
+  return obj as Payload;
+}
+
+async function underRateLimit(env: Env, installId: string): Promise<boolean> {
+  const key = `rl:${installId}`;
+  const raw = await env.RL.get(key);
+  const n = raw ? parseInt(raw, 10) : 0;
+  if (n >= RATE_LIMIT_PER_DAY) return false;
+  await env.RL.put(key, String(n + 1), { expirationTtl: 86400 });
+  return true;
+}
+
+async function insert(env: Env, p: Payload): Promise<void> {
+  const serverTs = Math.floor(Date.now() / 1000);
+  await env.DB.prepare(
+    `INSERT INTO events
+       (install_id, version, python_version, platform, gpu_class, event, ts, server_ts)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(
+      p.install_id,
+      p.version,
+      p.python_version,
+      p.platform,
+      p.gpu_class,
+      p.event,
+      p.ts,
+      serverTs,
+    )
+    .run();
+}
+
+// Scheduled handler: enforce 90-day retention. Configured via wrangler.toml
+// [triggers] crons. Keeps the privacy-doc claim honest.
+async function scheduled(env: Env): Promise<void> {
+  const cutoff = Math.floor(Date.now() / 1000) - 90 * 24 * 3600;
+  await env.DB.prepare('DELETE FROM events WHERE server_ts < ?')
+    .bind(cutoff)
+    .run();
+}
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    if (req.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders() });
+    }
+
+    const url = new URL(req.url);
+    if (url.pathname === '/health' && req.method === 'GET') {
+      return json({ ok: true });
+    }
+    if (url.pathname !== '/event' || req.method !== 'POST') {
+      return json({ error: 'not found' }, 404);
+    }
+
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return json({ error: 'invalid json' }, 400);
+    }
+    const v = validate(body);
+    if ('error' in v) {
+      return json(v, 400);
+    }
+    // Intentionally ignore req.headers.get('CF-Connecting-IP'). We never
+    // want the IP to end up in D1 or any logs we write.
+    if (!(await underRateLimit(env, v.install_id))) {
+      return json({ ok: true, dropped: true });
+    }
+    try {
+      await insert(env, v);
+    } catch {
+      return json({ error: 'db error' }, 500);
+    }
+    return json({ ok: true });
+  },
+
+  async scheduled(
+    _event: ScheduledEvent,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<void> {
+    ctx.waitUntil(scheduled(env));
+  },
+};

--- a/telemetry-worker/wrangler.toml
+++ b/telemetry-worker/wrangler.toml
@@ -1,0 +1,24 @@
+name = "infergrid-telemetry"
+main = "src/index.ts"
+compatibility_date = "2024-11-01"
+
+# 90-day retention sweeper. Aligned with the claim in
+# docs/privacy/telemetry.md. If this cron is removed, update the doc.
+[triggers]
+crons = ["17 3 * * *"]
+
+# D1 binding. Create the database once with:
+#   wrangler d1 create infergrid-telemetry
+# then paste the returned database_id into this block.
+[[d1_databases]]
+binding = "DB"
+database_name = "infergrid-telemetry"
+database_id = "REPLACE_WITH_WRANGLER_OUTPUT"
+
+# KV binding for the per-install_id 24h rate limiter.
+# Create with:
+#   wrangler kv:namespace create RL
+# then paste the returned id.
+[[kv_namespaces]]
+binding = "RL"
+id = "REPLACE_WITH_WRANGLER_OUTPUT"

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,0 +1,353 @@
+"""Unit tests for ``infergrid._telemetry``.
+
+These tests must never hit the network. ``urllib.request.urlopen`` is
+mocked for every test that exercises the POST path. File I/O is redirected
+to a temporary ``XDG_CONFIG_HOME`` via a fixture.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from infergrid import _telemetry
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Each test gets a pristine XDG config home + env scrubbed."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.delenv("INFERGRID_TELEMETRY", raising=False)
+    monkeypatch.delenv("INFERGRID_TELEMETRY_URL", raising=False)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# _gpu_class
+# ---------------------------------------------------------------------------
+
+
+class TestGpuClass:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("NVIDIA H100 80GB HBM3", "h100"),
+            ("NVIDIA A100-SXM4-80GB", "a100"),
+            ("NVIDIA GeForce RTX 4090", "rtx4090"),
+            ("Tesla V100-SXM2-16GB", "other"),
+        ],
+    )
+    def test_mapping(self, name: str, expected: str) -> None:
+        with patch("infergrid._telemetry.subprocess.run") as run:
+            run.return_value = MagicMock(stdout=name + "\n")
+            assert _telemetry._gpu_class() == expected
+
+    def test_no_nvidia_smi(self) -> None:
+        with patch("infergrid._telemetry.subprocess.run") as run:
+            run.side_effect = FileNotFoundError
+            assert _telemetry._gpu_class() == "none"
+
+    def test_empty_output(self) -> None:
+        with patch("infergrid._telemetry.subprocess.run") as run:
+            run.return_value = MagicMock(stdout="")
+            assert _telemetry._gpu_class() == "none"
+
+    def test_subprocess_timeout(self) -> None:
+        with patch("infergrid._telemetry.subprocess.run") as run:
+            import subprocess
+
+            run.side_effect = subprocess.TimeoutExpired(cmd="nvidia-smi", timeout=2)
+            assert _telemetry._gpu_class() == "none"
+
+
+# ---------------------------------------------------------------------------
+# persistence
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    def test_load_missing_returns_none(self) -> None:
+        assert _telemetry._load_config() is None
+
+    def test_roundtrip(self) -> None:
+        _telemetry._save_config(True, "11111111-1111-1111-1111-111111111111")
+        cfg = _telemetry._load_config()
+        assert cfg == {
+            "enabled": True,
+            "install_id": "11111111-1111-1111-1111-111111111111",
+        }
+
+    def test_corrupt_file_returns_none(self, _isolate_config: Path) -> None:
+        p = _telemetry._config_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{not json")
+        assert _telemetry._load_config() is None
+
+    def test_non_dict_payload_returns_none(self, _isolate_config: Path) -> None:
+        p = _telemetry._config_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("[1, 2, 3]")
+        assert _telemetry._load_config() is None
+
+
+# ---------------------------------------------------------------------------
+# env var + endpoint handling
+# ---------------------------------------------------------------------------
+
+
+class TestEnvAndEndpoint:
+    @pytest.mark.parametrize("v", ["0", "false", "no", "off", "FALSE", "No"])
+    def test_env_disables(self, v: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("INFERGRID_TELEMETRY", v)
+        assert _telemetry._env_disabled() is True
+
+    def test_env_unset_does_not_disable(self) -> None:
+        assert _telemetry._env_disabled() is False
+
+    def test_env_url_beats_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("INFERGRID_TELEMETRY_URL", "https://example.org")
+        assert _telemetry._endpoint() == "https://example.org"
+
+    def test_default_url_is_empty(self) -> None:
+        assert _telemetry._endpoint() == ""
+
+
+# ---------------------------------------------------------------------------
+# maybe_prompt_and_record_event
+# ---------------------------------------------------------------------------
+
+
+class TestMaybePromptAndRecord:
+    def test_env_off_short_circuits_before_file_write(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("INFERGRID_TELEMETRY", "0")
+        with patch("infergrid._telemetry._post_event_blocking") as post:
+            _telemetry.maybe_prompt_and_record_event(event="install_first_run")
+        post.assert_not_called()
+        assert _telemetry._load_config() is None  # nothing written
+
+    def test_unknown_event_noop(self) -> None:
+        with patch("infergrid._telemetry._post_event_blocking") as post:
+            _telemetry.maybe_prompt_and_record_event(event="nope")  # type: ignore[arg-type]
+        post.assert_not_called()
+
+    def test_non_interactive_first_run_writes_disabled_and_does_not_post(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # stdin.isatty returns False → never prompt, never post, persist off.
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+        monkeypatch.setattr("sys.stderr.isatty", lambda: True)
+        monkeypatch.setenv("INFERGRID_TELEMETRY_URL", "https://example.org")
+        with patch("infergrid._telemetry._post_event_blocking") as post:
+            _telemetry.maybe_prompt_and_record_event(event="install_first_run")
+        post.assert_not_called()
+        cfg = _telemetry._load_config()
+        assert cfg is not None
+        assert cfg["enabled"] is False
+        assert _telemetry._valid_install_id(cfg["install_id"])
+
+    def test_opted_out_user_does_not_post(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _telemetry._save_config(False, "22222222-2222-2222-2222-222222222222")
+        monkeypatch.setenv("INFERGRID_TELEMETRY_URL", "https://example.org")
+        with patch("infergrid._telemetry._post_event_blocking") as post:
+            _telemetry.maybe_prompt_and_record_event(event="serve_started")
+        post.assert_not_called()
+
+    def test_opted_in_but_empty_url_does_not_post(self) -> None:
+        _telemetry._save_config(True, "33333333-3333-3333-3333-333333333333")
+        # URL env unset by fixture → endpoint is empty.
+        with patch("infergrid._telemetry._post_event_blocking") as post:
+            _telemetry.maybe_prompt_and_record_event(event="serve_started")
+        post.assert_not_called()
+
+    def test_opted_in_with_url_fires_daemon_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _telemetry._save_config(True, "44444444-4444-4444-4444-444444444444")
+        monkeypatch.setenv("INFERGRID_TELEMETRY_URL", "https://example.org")
+        monkeypatch.setattr("infergrid._telemetry._gpu_class", lambda: "a100")
+
+        # Replace Thread with a MagicMock so we can inspect the call without
+        # actually spawning a thread (and thus without hitting the network).
+        with patch("infergrid._telemetry.threading.Thread") as thread_cls:
+            inst = MagicMock()
+            thread_cls.return_value = inst
+            _telemetry.maybe_prompt_and_record_event(event="serve_started")
+
+        assert thread_cls.called
+        kwargs = thread_cls.call_args.kwargs
+        assert kwargs["daemon"] is True
+        target = kwargs["target"]
+        assert target is _telemetry._post_event_blocking
+        url, payload = kwargs["args"]
+        assert url == "https://example.org"
+        assert set(payload.keys()) == _telemetry._ALLOWED_EVENT_KEYS
+        assert payload["install_id"] == "44444444-4444-4444-4444-444444444444"
+        assert payload["event"] == "serve_started"
+        assert payload["gpu_class"] == "a100"
+        assert payload["platform"] in {"linux", "darwin", "win32", "other"}
+        assert isinstance(payload["ts"], int)
+        inst.start.assert_called_once()
+
+    @pytest.mark.parametrize("bad_id", ["", "x", 42, None, "a" * 200])
+    def test_corrupt_install_id_skips_post(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        _isolate_config: Path,
+        bad_id: object,
+    ) -> None:
+        # Hand-write a config with a bad install_id (too short/long/non-str).
+        p = _telemetry._config_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"enabled": True, "install_id": bad_id}))
+        monkeypatch.setenv("INFERGRID_TELEMETRY_URL", "https://example.org")
+        with patch("infergrid._telemetry._post_event_blocking") as post:
+            _telemetry.maybe_prompt_and_record_event(event="serve_started")
+        post.assert_not_called()
+
+    def test_prompt_accepts_yes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("sys.stderr.isatty", lambda: True)
+        monkeypatch.setattr("sys.stdin.readline", lambda: "y\n")
+        monkeypatch.setenv("INFERGRID_TELEMETRY_URL", "https://example.org")
+        with patch("infergrid._telemetry.threading.Thread") as thread_cls:
+            thread_cls.return_value = MagicMock()
+            _telemetry.maybe_prompt_and_record_event(event="install_first_run")
+        cfg = _telemetry._load_config()
+        assert cfg is not None and cfg["enabled"] is True
+        assert thread_cls.called
+
+    def test_prompt_default_is_no(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("sys.stderr.isatty", lambda: True)
+        monkeypatch.setattr("sys.stdin.readline", lambda: "\n")
+        monkeypatch.setenv("INFERGRID_TELEMETRY_URL", "https://example.org")
+        with patch("infergrid._telemetry.threading.Thread") as thread_cls:
+            _telemetry.maybe_prompt_and_record_event(event="install_first_run")
+        cfg = _telemetry._load_config()
+        assert cfg is not None and cfg["enabled"] is False
+        thread_cls.assert_not_called()
+
+    def test_never_reprompts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _telemetry._save_config(False, "55555555-5555-5555-5555-555555555555")
+        called = {"n": 0}
+
+        def fake_readline() -> str:
+            called["n"] += 1
+            return "y\n"
+
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("sys.stderr.isatty", lambda: True)
+        monkeypatch.setattr("sys.stdin.readline", fake_readline)
+        _telemetry.maybe_prompt_and_record_event(event="serve_started")
+        assert called["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# set_enabled / get_status
+# ---------------------------------------------------------------------------
+
+
+class TestSetEnabledAndStatus:
+    def test_set_enabled_mints_install_id_if_missing(self) -> None:
+        assert _telemetry._load_config() is None
+        new = _telemetry.set_enabled(True)
+        assert new["enabled"] is True
+        assert _telemetry._valid_install_id(new["install_id"])
+
+    def test_set_enabled_preserves_install_id(self) -> None:
+        _telemetry._save_config(False, "66666666-6666-6666-6666-666666666666")
+        new = _telemetry.set_enabled(True)
+        assert new["install_id"] == "66666666-6666-6666-6666-666666666666"
+        assert new["enabled"] is True
+
+    def test_get_status_unconfigured(self) -> None:
+        st = _telemetry.get_status()
+        assert st["configured"] is False
+        assert st["enabled"] is False
+        assert st["install_id"] is None
+        assert st["env_disabled"] is False
+        assert st["endpoint_set"] is False
+
+    def test_get_status_with_config_and_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _telemetry._save_config(True, "77777777-7777-7777-7777-777777777777")
+        monkeypatch.setenv("INFERGRID_TELEMETRY", "0")
+        monkeypatch.setenv("INFERGRID_TELEMETRY_URL", "https://example.org")
+        st = _telemetry.get_status()
+        assert st["configured"] is True
+        assert st["enabled"] is True
+        assert st["install_id"] == "77777777-7777-7777-7777-777777777777"
+        assert st["env_disabled"] is True
+        assert st["endpoint_set"] is True
+
+
+# ---------------------------------------------------------------------------
+# _post_event_blocking — mocked, verifies we never touch the real network
+# ---------------------------------------------------------------------------
+
+
+class TestPostEventBlocking:
+    def test_posts_to_event_path(self) -> None:
+        with patch("urllib.request.urlopen") as urlopen:
+            urlopen.return_value.__enter__.return_value = MagicMock()
+            _telemetry._post_event_blocking(
+                "https://example.org",
+                {
+                    "install_id": "0" * 8 + "-0000-0000-0000-" + "0" * 12,
+                    "version": "0.1.2",
+                    "python_version": "3.12",
+                    "platform": "linux",
+                    "gpu_class": "a100",
+                    "event": "serve_started",
+                    "ts": 1_700_000_000,
+                },
+            )
+        assert urlopen.called
+        req = urlopen.call_args.args[0]
+        assert req.full_url.endswith("/event")
+        assert req.method == "POST"
+        body = json.loads(req.data.decode("utf-8"))
+        assert set(body.keys()) == _telemetry._ALLOWED_EVENT_KEYS
+
+    def test_preserves_existing_event_suffix(self) -> None:
+        with patch("urllib.request.urlopen") as urlopen:
+            urlopen.return_value.__enter__.return_value = MagicMock()
+            _telemetry._post_event_blocking(
+                "https://example.org/event",
+                {
+                    "install_id": "0" * 8 + "-0000-0000-0000-" + "0" * 12,
+                    "version": "0.1.2",
+                    "python_version": "3.12",
+                    "platform": "linux",
+                    "gpu_class": "none",
+                    "event": "doctor_ran",
+                    "ts": 1_700_000_000,
+                },
+            )
+        req = urlopen.call_args.args[0]
+        # Must not double-suffix.
+        assert req.full_url == "https://example.org/event"
+
+    def test_network_error_swallowed(self) -> None:
+        with patch("urllib.request.urlopen", side_effect=OSError("no dns")):
+            # Must not raise.
+            _telemetry._post_event_blocking(
+                "https://example.org",
+                {
+                    "install_id": "0" * 8 + "-0000-0000-0000-" + "0" * 12,
+                    "version": "0.1.2",
+                    "python_version": "3.12",
+                    "platform": "linux",
+                    "gpu_class": "none",
+                    "event": "serve_started",
+                    "ts": 1_700_000_000,
+                },
+            )


### PR DESCRIPTION
## Summary

- **What:** minimal opt-in anonymous install/usage telemetry so post-launch adoption stops being invisible. Python client in `src/infergrid/_telemetry.py`, CLI hook + `infergrid telemetry {on|off|status}` subcommand, and a ~200-line Cloudflare Worker receiver in `telemetry-worker/`.
- **Opt-in default:** default is **No**. First interactive run shows a single-paragraph prompt; `n`/Enter persists the choice. Non-interactive sessions (CI, Docker, cron) are treated as automatic opt-out -- we never hang on a prompt. `INFERGRID_TELEMETRY=0` and empty `INFERGRID_TELEMETRY_URL` short-circuit before any disk I/O.
- **What's sent** (and literally nothing else): `install_id` (uuid4), `version`, `python_version` (major.minor), `platform` (linux/darwin/win32/other), `gpu_class` (h100/a100/rtx4090/other/none), `event` (install_first_run | serve_started | doctor_ran), `ts`. HTTP POST from a daemon thread; every failure path silently swallowed.
- **What's NOT sent:** no prompts, completions, model names, tenant IDs, config contents, usernames, hostnames, paths, env vars, API keys. Worker never reads `CF-Connecting-IP`; scheduled cron deletes D1 rows after 90 days.

## Deliverables in this PR

- `src/infergrid/_telemetry.py` (client, ~200 code lines)
- `tests/unit/test_telemetry.py` (37 new tests, all network-mocked)
- `src/infergrid/cli.py` diff (hook + new `telemetry` subparser)
- `telemetry-worker/{src/index.ts, wrangler.toml, schema.sql, README.md}` (not auto-deployed; human runs `wrangler deploy`)
- `docs/privacy/telemetry.md` (one-page plain-English policy)
- README: new "Telemetry" section between CLI surface and Architecture

## LOC accounting

~705 code-only lines across the implementation (vs the <600 envelope in the task brief). Breakdown:

| File | Code-only LOC |
|---|---:|
| `_telemetry.py` | 199 |
| `test_telemetry.py` | 269 |
| `telemetry-worker/src/index.ts` | 165 |
| `telemetry-worker/{wrangler.toml, schema.sql}` | 24 |
| `cli.py` diff | 45 |
| README diff | 3 |

I chose to prioritise per-privacy-property test coverage (37 distinct tests) over hitting the LOC number exactly. Docs (`docs/privacy/telemetry.md`, `telemetry-worker/README.md`) are not counted in the code budget.

## Test plan

- [x] `pytest tests/unit/` green (212 pass, was 171 before this change = +41, net of a couple parametrized multi-id cases)
- [x] `ruff check src/ tests/` clean
- [x] `ruff format --check src/ tests/` clean
- [x] Manual smoke on a clean `XDG_CONFIG_HOME`:
      - `infergrid telemetry status` (fresh) -> off, unconfigured
      - `infergrid telemetry on` -> persists `{enabled: true, install_id: <uuid4>}`
      - `infergrid telemetry status` -> on
      - `infergrid telemetry off` -> persists `{enabled: false, install_id: <same uuid>}` (id stable)
- [ ] **Privacy review by a human before merging.** Checklist:
      - [ ] Only the seven fields listed above are transmitted (grep `payload = {` in `_telemetry.py`)
      - [ ] No request body or response body from `/v1/completions`, `/v1/chat/completions`, or any engine is read
      - [ ] No tenant-ID header is read
      - [ ] Worker does not reference `CF-Connecting-IP` anywhere (grep in `telemetry-worker/`)
      - [ ] Default URL is empty; the CLI is a no-op unless `INFERGRID_TELEMETRY_URL` is set at package build time
      - [ ] Default answer to the prompt is No
      - [ ] Non-interactive run does not hang and does not re-prompt on subsequent runs
      - [ ] `INFERGRID_TELEMETRY=0` disables before any file I/O
- [ ] **Do NOT deploy the Worker from this PR.** Deploy sequence in `telemetry-worker/README.md`. After deploy, set `INFERGRID_TELEMETRY_URL=https://...` in the package-build env or release CI before cutting a PyPI release.