### PR TITLE
fix(metrics): retire dead metrics + engine label + up/cold-start/sse counters (audit PR #91 remediation)

### DIFF
--- a/src/infergrid/common/metrics.py
+++ b/src/infergrid/common/metrics.py
@@ -1,8 +1,8 @@
 """Prometheus-style metrics collector for InferGrid.
 
 Wraps prometheus_client to expose request counts, latency histograms,
-cache hit rates, and GPU memory usage as both Prometheus metrics and
-a plain-dict snapshot for the CLI status command.
+per-tenant TTFT, engine lifecycle, and SSE disconnect counters as both
+Prometheus metrics and a plain-dict snapshot for the CLI status command.
 """
 
 from __future__ import annotations
@@ -38,10 +38,14 @@ class MetricsCollector:
         self._start_time = time.monotonic()
 
         # --- Request metrics ---
+        # `engine` label (added in the 2026-04-21 metrics audit remediation)
+        # lets dashboards split 5xx/latency by engine kind — the single
+        # highest-value SRE question for a middleware tool that sits
+        # between clients and either vLLM or SGLang.
         self.request_count = Counter(
             "infergrid_requests_total",
             "Total number of incoming requests",
-            labelnames=["model", "tenant", "status"],
+            labelnames=["model", "tenant", "status", "engine"],
             registry=self._registry,
         )
         self.request_latency = Histogram(
@@ -64,25 +68,6 @@ class MetricsCollector:
             registry=self._registry,
         )
 
-        # --- Cache metrics ---
-        self.cache_hits = Counter(
-            "infergrid_cache_hits_total",
-            "Number of KV cache hits",
-            labelnames=["tier"],
-            registry=self._registry,
-        )
-        self.cache_misses = Counter(
-            "infergrid_cache_misses_total",
-            "Number of KV cache misses",
-            registry=self._registry,
-        )
-        self.cache_memory_bytes = Gauge(
-            "infergrid_cache_memory_bytes",
-            "Current cache memory usage in bytes",
-            labelnames=["tier"],
-            registry=self._registry,
-        )
-
         # --- Model lifecycle ---
         self.models_loaded = Gauge(
             "infergrid_models_loaded",
@@ -92,6 +77,36 @@ class MetricsCollector:
         self.model_evictions = Counter(
             "infergrid_model_evictions_total",
             "Total number of model evictions",
+            registry=self._registry,
+        )
+
+        # --- Engine lifecycle (added 2026-04-21, audit §2 row 10-11) ---
+        # Gauge tracks up/down state for each (model, engine) pair so
+        # SREs can wire a trivial "engine down for >1m" alert. Histogram
+        # captures cold-start latency; buckets cover 10s (warm model on
+        # fast disk) through 600s (first-time HF pull + CUDA init).
+        self.engine_up = Gauge(
+            "infergrid_engine_up",
+            "1 if the engine subprocess is healthy, 0 otherwise",
+            labelnames=["model", "engine"],
+            registry=self._registry,
+        )
+        self.engine_cold_start_seconds = Histogram(
+            "infergrid_engine_cold_start_seconds",
+            "Seconds from adapter.start() invocation to first healthy response",
+            labelnames=["model", "engine"],
+            buckets=(10.0, 30.0, 60.0, 120.0, 300.0, 600.0),
+            registry=self._registry,
+        )
+
+        # --- SSE stream disconnects (added 2026-04-21, audit §2 row 12) ---
+        # Reasons: client_disconnect | upstream_error | timeout. Fired
+        # from the router's SSE pass-through path — see
+        # router.handle_request and router._stream_with_admission.
+        self.sse_stream_disconnects = Counter(
+            "infergrid_sse_stream_disconnect_total",
+            "SSE streams that terminated abnormally, by reason",
+            labelnames=["reason"],
             registry=self._registry,
         )
 
@@ -133,14 +148,6 @@ class MetricsCollector:
             registry=self._registry,
         )
 
-        # --- GPU ---
-        self.gpu_memory_used_bytes = Gauge(
-            "infergrid_gpu_memory_used_bytes",
-            "GPU memory used in bytes",
-            labelnames=["gpu_index"],
-            registry=self._registry,
-        )
-
     # ------------------------------------------------------------------
     # Convenience helpers
     # ------------------------------------------------------------------
@@ -151,6 +158,7 @@ class MetricsCollector:
         tenant: str,
         status: str,
         latency_s: float,
+        engine: str = "unknown",
         tokens_in: int = 0,
         tokens_out: int = 0,
     ) -> None:
@@ -159,12 +167,17 @@ class MetricsCollector:
         Args:
             model: Model identifier.
             tenant: Tenant identifier.
-            status: "ok" or "error".
+            status: "ok", "error", or "timeout".
             latency_s: Total latency in seconds.
+            engine: Engine kind ("vllm" / "sglang"). Defaults to
+                "unknown" so ad-hoc callers don't crash; production
+                call sites should always pass the real engine kind.
             tokens_in: Number of input tokens.
             tokens_out: Number of output tokens.
         """
-        self.request_count.labels(model=model, tenant=tenant, status=status).inc()
+        self.request_count.labels(
+            model=model, tenant=tenant, status=status, engine=engine
+        ).inc()
         self.request_latency.labels(model=model).observe(latency_s)
         self.tenant_request_count.labels(tenant=tenant).inc()
         if tokens_in > 0:
@@ -185,17 +198,37 @@ class MetricsCollector:
             return
         self.tenant_ttft_seconds.labels(model=model, tenant=tenant).observe(ttft_s)
 
-    def record_cache_access(self, hit: bool, tier: str = "gpu") -> None:
-        """Record a cache hit or miss.
+    def set_engine_up(self, model: str, engine: str, up: bool) -> None:
+        """Flip the engine_up gauge for a (model, engine) pair.
 
         Args:
-            hit: True for a cache hit, False for a miss.
-            tier: Cache tier name ("gpu", "cpu", "ssd").
+            model: Model identifier.
+            engine: Engine kind ("vllm" / "sglang").
+            up: True iff the engine is currently healthy.
         """
-        if hit:
-            self.cache_hits.labels(tier=tier).inc()
-        else:
-            self.cache_misses.inc()
+        self.engine_up.labels(model=model, engine=engine).set(1 if up else 0)
+
+    def record_cold_start(self, model: str, engine: str, duration_s: float) -> None:
+        """Record the seconds from engine bring-up start to first healthy response.
+
+        Args:
+            model: Model identifier.
+            engine: Engine kind ("vllm" / "sglang").
+            duration_s: Elapsed seconds.
+        """
+        if duration_s < 0:
+            return
+        self.engine_cold_start_seconds.labels(model=model, engine=engine).observe(
+            duration_s
+        )
+
+    def record_sse_disconnect(self, reason: str) -> None:
+        """Increment the SSE abnormal-termination counter.
+
+        Args:
+            reason: One of "client_disconnect", "upstream_error", "timeout".
+        """
+        self.sse_stream_disconnects.labels(reason=reason).inc()
 
     def snapshot(self) -> dict[str, Any]:
         """Return a plain-dict snapshot of current metrics for the CLI.
@@ -212,27 +245,9 @@ class MetricsCollector:
                 if sample.name == "infergrid_requests_total":
                     total_requests += sample.value
 
-        total_cache_hits = 0.0
-        for metric in self.cache_hits.collect():
-            for sample in metric.samples:
-                if sample.name == "infergrid_cache_hits_total":
-                    total_cache_hits += sample.value
-
-        total_cache_misses = 0.0
-        for metric in self.cache_misses.collect():
-            for sample in metric.samples:
-                if sample.name == "infergrid_cache_misses_total":
-                    total_cache_misses += sample.value
-
-        total_accesses = total_cache_hits + total_cache_misses
-        hit_rate = (total_cache_hits / total_accesses) if total_accesses > 0 else 0.0
-
         return {
             "uptime_s": round(uptime, 1),
             "total_requests": int(total_requests),
-            "cache_hit_rate": round(hit_rate, 4),
-            "cache_hits": int(total_cache_hits),
-            "cache_misses": int(total_cache_misses),
         }
 
     def prometheus_output(self) -> bytes:

--- a/src/infergrid/router/router.py
+++ b/src/infergrid/router/router.py
@@ -306,12 +306,25 @@ class WorkloadRouter:
         port = config.port if config.port > 0 else self._allocate_port()
         adapter = self._create_adapter(config, port)
 
+        # Measure cold-start latency for the engine histogram. Observe only
+        # on success — aborted starts pollute the histogram with failure
+        # cases that don't represent "how long warmup takes."
+        cold_start_begin = time.monotonic()
         await adapter.start(timeout_s=self.config.engine_start_timeout_s)
+        cold_start_s = time.monotonic() - cold_start_begin
+        self.metrics.record_cold_start(
+            model=config.model_id,
+            engine=config.engine,
+            duration_s=cold_start_s,
+        )
 
         state = ModelState(config=config, adapter=adapter)
         self._models[config.model_id] = state
         self._model_configs[config.model_id] = config
         self.metrics.models_loaded.inc()
+        # Engine just passed its first health check — set up gauge to 1.
+        # Paired with the set-to-0 in unload_model.
+        self.metrics.set_engine_up(model=config.model_id, engine=config.engine, up=True)
 
         logger.info("Loaded model %s on port %d", config.model_id, port)
         return state
@@ -333,6 +346,8 @@ class WorkloadRouter:
         self.cache_manager.free_blocks_for_model(model_id)
         self.metrics.models_loaded.dec()
         self.metrics.model_evictions.inc()
+        # Engine subprocess has been torn down — flip gauge to 0.
+        self.metrics.set_engine_up(model=model_id, engine=state.config.engine, up=False)
 
         logger.info("Unloaded model %s", model_id)
         return True
@@ -513,6 +528,7 @@ class WorkloadRouter:
                 tenant=tenant_id,
                 status="ok",
                 latency_s=elapsed,
+                engine=state.config.engine,
                 tokens_in=tokens_in,
                 tokens_out=tokens_out,
             )
@@ -528,11 +544,21 @@ class WorkloadRouter:
             raise
         except Exception:
             elapsed = time.monotonic() - start_time
+            # state may or may not be bound if ensure_model_loaded failed;
+            # recover gracefully via the known model config map.
+            engine_kind = "unknown"
+            try:
+                engine_kind = state.config.engine  # type: ignore[name-defined]
+            except NameError:
+                cfg = self._model_configs.get(model_id)
+                if cfg is not None:
+                    engine_kind = cfg.engine
             self.metrics.record_request(
                 model=model_id,
                 tenant=tenant_id,
                 status="error",
                 latency_s=elapsed,
+                engine=engine_kind,
             )
             raise
         finally:
@@ -613,6 +639,9 @@ class WorkloadRouter:
                 sse_frames,
             )
             status = "timeout"
+            # Fire the SSE disconnect counter — router-internal max-duration
+            # fence counts as a `timeout` reason in dashboards.
+            self.metrics.record_sse_disconnect(reason="timeout")
             # Re-raise so the outer handle_request can return 504 to client.
             raise
         finally:
@@ -629,6 +658,7 @@ class WorkloadRouter:
                     tenant=tenant_id,
                     status=status,
                     latency_s=elapsed_real,
+                    engine=state.config.engine,
                     tokens_in=tokens_in,
                     tokens_out=sse_frames,
                 )
@@ -785,6 +815,13 @@ class WorkloadRouter:
                             await response.prepare(request)
                         await response.write(chunk)
                 except (asyncio.TimeoutError, aiohttp.ServerTimeoutError) as exc:
+                    # Engine-side timeout: counts as `upstream_error` for
+                    # the SSE disconnect counter. The router-internal
+                    # _STREAM_MAX_DURATION_S fence also raises
+                    # asyncio.TimeoutError but increments with reason=timeout
+                    # from _stream_with_admission — here we're catching
+                    # connection-level timeouts from the engine read.
+                    self.metrics.record_sse_disconnect(reason="upstream_error")
                     if response is None:
                         # Engine failed before first byte — clean 504.
                         logger.warning(
@@ -804,6 +841,30 @@ class WorkloadRouter:
                     )
                     await response.write_eof()
                     return response
+                except (
+                    ConnectionResetError,
+                    aiohttp.ClientConnectionError,
+                ) as exc:
+                    # Client went away mid-stream. aiohttp's
+                    # StreamResponse.write() raises one of these when the
+                    # TCP peer has closed. Record the disconnect and bail
+                    # — the response is already un-recoverable.
+                    self.metrics.record_sse_disconnect(reason="client_disconnect")
+                    logger.info(
+                        "req_id=%s EXIT client_disconnect detail=%s",
+                        req_id,
+                        exc,
+                    )
+                    # Best-effort EOF; ignore if the socket is already gone.
+                    if response is not None:
+                        try:
+                            await response.write_eof()
+                        except Exception:
+                            pass
+                        return response
+                    return web.json_response(
+                        {"error": "client disconnected"}, status=499
+                    )
 
                 if response is None:
                     # Iterator yielded nothing — treat as empty successful response.

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,259 @@
+"""Regression tests for the metrics audit remediation (PR #91 follow-up).
+
+Pins the three pillars of the 2026-04-21 audit fix:
+
+1. Four dead metrics (cache_hits, cache_misses, cache_memory_bytes,
+   gpu_memory_used_bytes) are no longer registered.
+2. `infergrid_requests_total` has the new `engine` label.
+3. Three new metrics are registered with the right names + labels:
+   - `infergrid_engine_up{model,engine}` gauge
+   - `infergrid_engine_cold_start_seconds{model,engine}` histogram
+   - `infergrid_sse_stream_disconnect_total{reason}` counter
+
+Each test creates an isolated ``CollectorRegistry`` so the suite stays
+process-safe regardless of ordering.
+"""
+
+from __future__ import annotations
+
+from prometheus_client import CollectorRegistry
+
+from infergrid.common.metrics import MetricsCollector
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _registered_metric_names(m: MetricsCollector) -> set[str]:
+    """Return every metric family name currently in the collector's registry.
+
+    ``fam.name`` is the prometheus_client "stem" — for a Counter declared
+    as ``infergrid_requests_total`` it returns ``infergrid_requests``.
+    """
+    return {fam.name for fam in m._registry.collect()}
+
+
+def _label_names_for(m: MetricsCollector, metric_stem: str) -> set[str]:
+    """Return the label names present on samples for ``metric_stem``.
+
+    ``metric_stem`` is the family-level name as prometheus_client reports
+    it (e.g. ``infergrid_requests`` for the ``infergrid_requests_total``
+    counter). Drops the histogram-only ``le`` label.
+    """
+    labels: set[str] = set()
+    for fam in m._registry.collect():
+        if fam.name != metric_stem:
+            continue
+        for sample in fam.samples:
+            labels.update(sample.labels.keys())
+    return labels - {"le"}  # histograms get `le` on _bucket samples
+
+
+# ---------------------------------------------------------------------------
+# 1. Dead metrics retired
+# ---------------------------------------------------------------------------
+
+
+class TestDeadMetricsRemoved:
+    """The four dead metrics flagged in docs/metrics_audit_20260421.md §1
+    must no longer appear in the Prometheus registry."""
+
+    def test_cache_hits_not_registered(self) -> None:
+        m = MetricsCollector(registry=CollectorRegistry())
+        assert "infergrid_cache_hits" not in _registered_metric_names(m)
+
+    def test_cache_misses_not_registered(self) -> None:
+        m = MetricsCollector(registry=CollectorRegistry())
+        assert "infergrid_cache_misses" not in _registered_metric_names(m)
+
+    def test_cache_memory_bytes_not_registered(self) -> None:
+        m = MetricsCollector(registry=CollectorRegistry())
+        assert "infergrid_cache_memory_bytes" not in _registered_metric_names(m)
+
+    def test_gpu_memory_used_bytes_not_registered(self) -> None:
+        m = MetricsCollector(registry=CollectorRegistry())
+        assert "infergrid_gpu_memory_used_bytes" not in _registered_metric_names(m)
+
+    def test_no_dead_metrics_in_prometheus_output(self) -> None:
+        """Belt-and-braces: a fresh collector must not render any of the
+        four dead names in its exposition text."""
+        m = MetricsCollector(registry=CollectorRegistry())
+        out = m.prometheus_output().decode()
+        for name in (
+            "infergrid_cache_hits_total",
+            "infergrid_cache_misses_total",
+            "infergrid_cache_memory_bytes",
+            "infergrid_gpu_memory_used_bytes",
+        ):
+            assert name not in out, f"dead metric {name} still exposed"
+
+    def test_record_cache_access_helper_removed(self) -> None:
+        """The convenience helper that fed the dead counters is gone."""
+        m = MetricsCollector(registry=CollectorRegistry())
+        assert not hasattr(m, "record_cache_access")
+        assert not hasattr(m, "cache_hits")
+        assert not hasattr(m, "cache_misses")
+        assert not hasattr(m, "cache_memory_bytes")
+        assert not hasattr(m, "gpu_memory_used_bytes")
+
+
+# ---------------------------------------------------------------------------
+# 2. `engine` label on infergrid_requests_total
+# ---------------------------------------------------------------------------
+
+
+class TestRequestsTotalEngineLabel:
+    """`infergrid_requests_total` must carry a `{engine}` label so
+    dashboards can split 5xx by engine kind (vllm / sglang)."""
+
+    def test_requests_total_has_engine_label(self) -> None:
+        m = MetricsCollector(registry=CollectorRegistry())
+        m.record_request(
+            model="llama31-8b",
+            tenant="t1",
+            status="ok",
+            latency_s=0.2,
+            engine="vllm",
+        )
+        # prometheus_client's family name strips the `_total` suffix on
+        # counters — the wire-level metric stays `infergrid_requests_total`.
+        assert "engine" in _label_names_for(m, "infergrid_requests")
+
+    def test_requests_total_splits_by_engine(self) -> None:
+        m = MetricsCollector(registry=CollectorRegistry())
+        m.record_request(
+            model="llama31-8b", tenant="t1", status="ok", latency_s=0.1, engine="vllm"
+        )
+        m.record_request(
+            model="llama31-8b",
+            tenant="t1",
+            status="ok",
+            latency_s=0.1,
+            engine="sglang",
+        )
+        out = m.prometheus_output().decode()
+        # Two distinct series, one per engine.
+        assert 'engine="vllm"' in out
+        assert 'engine="sglang"' in out
+
+    def test_requests_total_engine_defaults_to_unknown(self) -> None:
+        """Legacy callers that omit engine= must not crash; series lands
+        under engine=unknown so an alert on it surfaces the gap."""
+        m = MetricsCollector(registry=CollectorRegistry())
+        m.record_request(model="m", tenant="t", status="ok", latency_s=0.1)
+        out = m.prometheus_output().decode()
+        assert 'engine="unknown"' in out
+
+
+# ---------------------------------------------------------------------------
+# 3. Three new metrics registered
+# ---------------------------------------------------------------------------
+
+
+class TestNewMetricsRegistered:
+    """Audit §2 rows 10-12: engine_up gauge, engine_cold_start histogram,
+    sse_stream_disconnect counter."""
+
+    # ---- engine_up -------------------------------------------------
+
+    def test_engine_up_registered_with_labels(self) -> None:
+        m = MetricsCollector(registry=CollectorRegistry())
+        m.set_engine_up(model="llama31-8b", engine="vllm", up=True)
+        assert "infergrid_engine_up" in _registered_metric_names(m)
+        assert _label_names_for(m, "infergrid_engine_up") == {"model", "engine"}
+
+    def test_engine_up_values(self) -> None:
+        m = MetricsCollector(registry=CollectorRegistry())
+        m.set_engine_up(model="m", engine="vllm", up=True)
+        m.set_engine_up(model="m2", engine="sglang", up=False)
+        out = m.prometheus_output().decode()
+        assert 'infergrid_engine_up{engine="vllm",model="m"} 1.0' in out
+        assert 'infergrid_engine_up{engine="sglang",model="m2"} 0.0' in out
+
+    # ---- engine_cold_start_seconds ---------------------------------
+
+    def test_cold_start_histogram_registered_with_labels(self) -> None:
+        m = MetricsCollector(registry=CollectorRegistry())
+        m.record_cold_start(model="m", engine="vllm", duration_s=42.0)
+        assert "infergrid_engine_cold_start_seconds" in _registered_metric_names(m)
+        labels = _label_names_for(m, "infergrid_engine_cold_start_seconds")
+        assert labels == {"model", "engine"}
+
+    def test_cold_start_buckets_cover_10s_to_600s(self) -> None:
+        """Buckets must cover the 10 s - 600 s range called out in the
+        remediation task (audit §5 queue-for-v0.1.3)."""
+        m = MetricsCollector(registry=CollectorRegistry())
+        m.record_cold_start(model="m", engine="vllm", duration_s=45.0)
+        out = m.prometheus_output().decode()
+        for edge in ("10.0", "30.0", "60.0", "120.0", "300.0", "600.0"):
+            assert f'le="{edge}"' in out, f"missing cold-start bucket le={edge}"
+
+    def test_cold_start_ignores_negative(self) -> None:
+        m = MetricsCollector(registry=CollectorRegistry())
+        m.record_cold_start(model="m", engine="vllm", duration_s=-1.0)
+        out = m.prometheus_output().decode()
+        # No observations landed → _count stays 0.
+        assert (
+            'infergrid_engine_cold_start_seconds_count{engine="vllm",model="m"}'
+            not in out
+        )
+
+    # ---- sse_stream_disconnect_total -------------------------------
+
+    def test_sse_disconnect_counter_registered_with_reason_label(self) -> None:
+        m = MetricsCollector(registry=CollectorRegistry())
+        m.record_sse_disconnect(reason="client_disconnect")
+        assert "infergrid_sse_stream_disconnect" in _registered_metric_names(m)
+        assert _label_names_for(m, "infergrid_sse_stream_disconnect") == {"reason"}
+
+    def test_sse_disconnect_three_reasons(self) -> None:
+        """All three reason values must round-trip through the counter."""
+        m = MetricsCollector(registry=CollectorRegistry())
+        m.record_sse_disconnect(reason="client_disconnect")
+        m.record_sse_disconnect(reason="upstream_error")
+        m.record_sse_disconnect(reason="timeout")
+        out = m.prometheus_output().decode()
+        assert 'reason="client_disconnect"' in out
+        assert 'reason="upstream_error"' in out
+        assert 'reason="timeout"' in out
+
+
+# ---------------------------------------------------------------------------
+# Regression: existing metrics still register correctly
+# ---------------------------------------------------------------------------
+
+
+class TestSurvivingMetricsIntact:
+    """Sanity check that the audit remediation didn't accidentally drop
+    metrics it shouldn't have touched."""
+
+    def test_tenant_ttft_still_present(self) -> None:
+        m = MetricsCollector(registry=CollectorRegistry())
+        m.record_ttft(model="m", tenant="t", ttft_s=0.05)
+        assert "infergrid_tenant_ttft_seconds" in _registered_metric_names(m)
+
+    def test_request_latency_still_present(self) -> None:
+        m = MetricsCollector(registry=CollectorRegistry())
+        m.record_request(
+            model="m", tenant="t", status="ok", latency_s=0.1, engine="vllm"
+        )
+        assert "infergrid_request_latency_seconds" in _registered_metric_names(m)
+
+    def test_models_loaded_gauge_still_present(self) -> None:
+        m = MetricsCollector(registry=CollectorRegistry())
+        m.models_loaded.inc()
+        out = m.prometheus_output().decode()
+        assert "infergrid_models_loaded" in out
+
+    def test_snapshot_still_returns_dict_without_cache_keys(self) -> None:
+        """`snapshot()` used to emit cache_hit_rate / cache_hits / cache_misses
+        backed by the now-deleted counters. After the audit fix these keys
+        must be gone; uptime + total_requests remain."""
+        m = MetricsCollector(registry=CollectorRegistry())
+        snap = m.snapshot()
+        assert "uptime_s" in snap
+        assert "total_requests" in snap
+        assert "cache_hit_rate" not in snap
+        assert "cache_hits" not in snap
+        assert "cache_misses" not in snap


### PR DESCRIPTION
## Summary

Lands the three fix priorities from `docs/metrics_audit_20260421.md` (PR #91):

- **Audit §1 / §4 — dead metrics purged.** `infergrid_cache_hits_total`, `infergrid_cache_misses_total`, `infergrid_cache_memory_bytes`, and `infergrid_gpu_memory_used_bytes` were declared but never `.inc()` / `.set()` from any production call site. Declarations, the `record_cache_access()` helper, and the matching `snapshot()` keys are removed so a fresh `GET /metrics` no longer advertises empty entries.
- **Audit §2 row 7 / §5 ship-with-launch — `engine` label on `infergrid_requests_total`.** All three call sites in `router.py` (non-streaming success, error, and `_stream_with_admission`) now pass `state.config.engine`. Unblocks the "5xx by engine kind (vllm vs sglang)" dashboard question that's first on an SRE's list for a middleware tool.
- **Audit §2 rows 10-12 — three new metrics.** `infergrid_engine_up{model,engine}` gauge (flipped in `load_model` / `unload_model`), `infergrid_engine_cold_start_seconds{model,engine}` histogram around `adapter.start()` with 10 s - 600 s buckets, and `infergrid_sse_stream_disconnect_total{reason}` counter fired for `upstream_error` (engine timeout), `client_disconnect` (ConnectionReset / aiohttp.ClientConnectionError from `StreamResponse.write`), and `timeout` (router-internal `_STREAM_MAX_DURATION_S` fence).

No change to `docs/metrics_audit_20260421.md` (source of truth for what was wrong on 2026-04-21). Grafana dashboard JSON also left alone — separate PR after these metrics are confirmed live.

## Test plan

- [x] `tests/unit/test_metrics.py` added (20 assertions) covering: dead metrics no longer registered, `engine` label present on `infergrid_requests_total`, and all three new metrics registered with correct names + labels + bucket edges.
- [x] Full unit suite passes: 171 → 191 passing (no regressions). Pre-existing integration failures on `tests/integration/test_benchmark_client.py` are HuggingFace network issues unrelated to this diff (confirmed against `main`).
- [x] `ruff check` and `ruff format --check` clean on touched files.
- [ ] Grafana dashboard still imports cleanly (human to confirm on launch-day dashboard reload).