### PR TITLE
docs: rename plan — infergrid → gpufair (ship-ready playbook)

### DIFF
--- a/docs/naming/email_samuel_bell.md
+++ b/docs/naming/email_samuel_bell.md
@@ -1,0 +1,29 @@
+# Draft email to Samuel Bell (infergrid.net)
+
+**Status:** draft. Do not send until the rename sweep has landed on `main` and `gpufair.org` is live. Send from `patelshrey77@gmail.com`.
+
+**Contact discovery:** Samuel's site lists a Calendly handle (`samueljamesbell`) but no public email. Reasonable lookups:
+- His GitHub profile (https://github.com/samueljamesbell) — check the public email there first.
+- His Cambridge / FAIR page for an academic email. Prefer the academic address over the FAIR address for a non-work-hours note.
+- If nothing public surfaces, book a 15-min Calendly slot and send the same text as the booking note.
+
+**Subject:** quick heads-up about the InferGrid name
+
+---
+
+Hi Samuel,
+
+I hope this lands well. I'm Shrey Patel, an independent engineer working on LLM serving. I wanted to give you a heads-up about something before it potentially becomes awkward.
+
+I spent the last couple of months building a Python project around multi-tenant fairness on a single GPU, and I had called it InferGrid. I picked the name independently, did a cursory availability check, saw the PyPI name was free and the .org domain was free, and moved forward. I was a few days from a public launch (Show HN, a landing page, a PyPI release) when I ran a more thorough naming audit and found infergrid.net — your landing page, your Calendly, your product in what looks like a pretty adjacent space. Domain created August 2025, mine didn't go up until April 2026. You have the senior claim under US common-law trademark, and frankly the thesis overlap means any traction on either side would eventually cause user confusion.
+
+I've already renamed to **gpufair**. The sweep is committed, the domains are bought, the PyPI name is reserved, the old `infergrid` PyPI package will ship a deprecation stub that points at the new name. No press has the old name yet, and I'm deleting the launch drafts that used it. I'd rather eat the rename cost than have either of us get a C&D later.
+
+No ask here — just wanted you to hear it from me rather than stumble into a cached Google result months from now and wonder what was going on. I think what you're building looks great and I hope it flies.
+
+If you're ever curious about what I landed on — it's at https://gpufair.org, and the repo is github.com/coconut-labs/gpufair. Happy to chat if you're ever interested.
+
+Cheers,
+Shrey Patel
+patelshrey77@gmail.com
+github.com/ShreyPatel4

--- a/docs/naming/rename_plan.md
+++ b/docs/naming/rename_plan.md
@@ -1,0 +1,328 @@
+# Rename plan — `infergrid` → `gpufair`
+
+**Status:** READY. Do not execute until the two in-flight agents (reproduce-hero bench, RTX 4090 consumer run) have landed their PRs. This doc is the playbook; `rename_sequence.md` is the copy-paste runbook.
+
+**Decision already made** in `docs/naming/infergrid_name_audit.md`. Rationale not re-audited here.
+
+---
+
+## 1. Naming rules (the sed map)
+
+There are **five** spelling forms in the tree. Replacement order matters — do the hyphen/underscore and PascalCase first so a bulk lowercase pass doesn't swallow them.
+
+| Rank | Old form             | New form          | Context                                            | Examples                                                     |
+| ---- | -------------------- | ----------------- | -------------------------------------------------- | ------------------------------------------------------------ |
+| 1    | `infer-grid`         | `gpufair`         | npm-style hyphen (audit doc only, cosmetic)        | `pypi.org/pypi/infer-grid/json` → `pypi.org/pypi/gpufair/json` |
+| 2    | `infer_grid`         | `gpufair`         | snake-case (audit doc only)                        | same as above                                                |
+| 3    | `InferGrid`          | `GPUFair`         | PascalCase prose (README titles, docstrings)       | `"InferGrid -- tenant-fair LLM…"` → `"GPUFair -- tenant-fair LLM…"` |
+| 4    | `INFERGRID_`         | `GPUFAIR_`        | env vars only — **anchored to trailing underscore** | `INFERGRID_TELEMETRY_URL` → `GPUFAIR_TELEMETRY_URL`          |
+| 5    | `infergrid`          | `gpufair`         | everything else (lowercase: imports, URLs, pkg)    | `src/infergrid/` → `src/gpufair/`                            |
+
+**Brand capitalization decision.** `GPUFair` (capital G-P-U, capital F, rest lowercase) is the chosen PascalCase form. This is the form that matches how people say the word — "GPU-fair" — and mirrors "GitHub", "OpenAI". Do **not** use `Gpufair` or `GPUFAIR` in prose.
+
+**Full-word boundary hazards.** `infergrid` appears as a substring inside commit SHAs in `pip_freeze.txt` files (`#egg=infergrid`) — those files are frozen evidence, see Section 5 exclusions. No other natural substring collisions.
+
+---
+
+## 2. Scope — what gets rewritten
+
+Only files in one of these classes:
+- `src/**` (Python package)
+- `tests/**`
+- `docs/**` (excluding `docs/naming/infergrid_name_audit.md` — the audit is evidence, keep the name it was written under)
+- `configs/**`
+- `benchmarks/**`
+- `scripts/**`
+- `profiling/**`
+- `dashboards/**`
+- `telemetry-worker/**` (code + docs; the live D1 database is a separate user-side migration — see `user_checklist.md`)
+- `docker/**`
+- Top-level: `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `pyproject.toml`, `requirements-gpu.txt`, `research_roadmap.md`, `.gitignore`
+- `.github/**` (workflows + issue templates + PR template)
+
+---
+
+## 3. Explicit exclusions — **do not** rewrite
+
+These paths are historical evidence. Rewriting corrupts reproducibility.
+
+- **`results/**`** — every `.log`, `.json`, `.txt`, `.md`, `.yaml` under `results/`. These are committed outputs of gates that ran under the `infergrid` name. They are the record.
+- **`docs/naming/infergrid_name_audit.md`** — the audit doc. Keep the filename and contents unchanged. It references the old name *because* it is the audit of the old name.
+- **`PROGRESS.md`** — historical PR log entries are brand-archaeology. Leave them. (This PR's task spec also excludes PROGRESS.md.)
+- **`infergrid_results_*.tar.gz`** (top-level tarballs) — frozen artifacts.
+- **`*.egg-info/`**, **`__pycache__/`**, **`.ruff_cache/`**, **`.pytest_cache/`** — generated; the rename will regenerate them.
+- **Commit history / git SHAs** — never rewrite.
+
+---
+
+## 4. Sequence — the order of operations
+
+Each step gates on the previous. Do not parallelize.
+
+### 4a. Pre-gate (founder, out-of-band)
+1. **Domains purchased** (`gpufair.org`, `.com`, `.ai`, `.dev`) — `user_checklist.md` item 1.
+2. **PyPI `gpufair` reserved** via `twine upload` of a 0.0.1 stub — `user_checklist.md` item 2.
+3. **npm `gpufair` + `@gpufair` scope reserved** — `user_checklist.md` item 3.
+4. **Twitter/X handles reserved** — `user_checklist.md` item 4.
+5. **GitHub org repo rename** (`coconut-labs/infergrid` → `coconut-labs/gpufair`, `coconut-labs/infergrid-root` → `coconut-labs/gpufair-root`) — `user_checklist.md` item 5. GitHub's 301 redirects mean the tree rename can proceed before or after this step; placing it before means the new URLs in docs point at a repo that already answers under the new name.
+
+### 4b. In-flight merges (blocking)
+6. `feat/bench-reproduce-hero` lands to `main`. The branch's PR references the old name; that's fine — step 4d sweeps it.
+7. The RTX 4090 consumer run (branch name TBD — the task references `results/consumer-4090-20260421` but that branch did not yet exist as of 2026-04-21 15:36 UTC) lands to `main`.
+
+### 4c. Sanity — clean tree
+8. `git fetch origin && git checkout main && git pull --ff-only`. Working tree empty.
+
+### 4d. The sweep (one branch, one PR)
+9. `git checkout -b rename/infergrid-to-gpufair`.
+10. Run `rename_sequence.md` top-to-bottom. It does sed passes 1→5 in order, then the directory rename, then the pyproject edits, then the manual-review targets (docstrings, YAML comments).
+11. `pytest tests/unit/ -v --tb=short` — imports must resolve under `gpufair`.
+12. `ruff check src/ tests/` and `ruff format --check src/ tests/` — CI parity.
+13. `git grep -iE 'InferGrid|infergrid|INFERGRID'` — should only return hits in the **excluded** paths (Section 3). If any hit is outside Section 3, fix and re-run.
+14. Commit in logical chunks (directory rename, sed sweep, pyproject, configs, docs) so the diff is reviewable.
+15. Open PR `rename: infergrid → gpufair (tree sweep)`. Reference this plan doc.
+
+### 4e. Post-merge cutover
+16. **PyPI deprecate**: publish `infergrid==0.1.3` whose README says the package moved. See `user_checklist.md` item 7.
+17. **Cloudflare Worker cutover**: deploy `gpufair-telemetry` worker, update LP's `WAITLIST_API` to the new subdomain, then take down `infergrid-telemetry`. See `user_checklist.md` item 6.
+18. **DNS cutover**: point `gpufair.org` at the same Vercel deployment that currently serves `infergrid.org`. See `user_checklist.md` item 8.
+19. **Send Samuel Bell a heads-up** using `docs/naming/email_samuel_bell.md`.
+
+---
+
+## 5. Per-file sed targets
+
+The table below lists every file in-scope (excluding Section 3 exclusions) that matches one of the five forms. Counts are from `git grep -c` on `origin/main` at commit `a9353da`.
+
+### 5a. Python package — `src/infergrid/`
+
+Directory rename: `src/infergrid/` → `src/gpufair/` (whole-tree `git mv`).
+
+| File                                              | Form(s)                     | Hits | Replacement notes                                         |
+| ------------------------------------------------- | --------------------------- | ---- | --------------------------------------------------------- |
+| `src/infergrid/__init__.py`                       | `InferGrid`, `infergrid`    | 2    | Docstring + `version("infergrid")` → `version("gpufair")` |
+| `src/infergrid/cli.py`                            | `infergrid`                 | 58   | Manpage URLs + CLI name string; keep CLI entry-point name `gpufair` (see ambiguity #1) |
+| `src/infergrid/_manpages.py`                      | `InferGrid`, `infergrid`    | 35   | URLs to `github.com/coconut-labs/gpufair/...`             |
+| `src/infergrid/_telemetry.py`                     | `INFERGRID_`, `infergrid`   | 9    | `INFERGRID_TELEMETRY` → `GPUFAIR_TELEMETRY`, `INFERGRID_TELEMETRY_URL` → `GPUFAIR_TELEMETRY_URL`; and the default telemetry URL constant |
+| `src/infergrid/_bench/__init__.py`                | `infergrid`                 | 2    | Module docstring                                          |
+| `src/infergrid/_bench/hero.py`                    | `infergrid`                 | 10   | CLI name in usage strings, repo URL                       |
+| `src/infergrid/_bench/compare.py`                 | `infergrid`                 | —    | Check during sweep                                        |
+| `src/infergrid/_bench/pod.py`                     | `INFERGRID_`, `infergrid`   | 4    | `INFERGRID_AUTO_SERVE` → `GPUFAIR_AUTO_SERVE` env name    |
+| `src/infergrid/cache/__init__.py`                 | `infergrid`                 | 2    | Module docstring                                          |
+| `src/infergrid/cache/manager.py`                  | `infergrid`                 | 1    | Import path / docstring                                   |
+| `src/infergrid/common/__init__.py`                | `infergrid`                 | 5    | Module docstring                                          |
+| `src/infergrid/common/config.py`                  | `infergrid`                 | 7    |                                                          |
+| `src/infergrid/common/metrics.py`                 | `infergrid`                 | 15   | Prometheus metric `namespace=infergrid` → `namespace=gpufair` — **this changes label names and is a breaking change for any dashboard consuming the old metric names**; the dashboards JSON in `dashboards/` is in-tree and updated in the same PR. External users: called out in PyPI 0.1.3 deprecation README. |
+| `src/infergrid/engines/__init__.py`               | `infergrid`                 | 4    |                                                          |
+| `src/infergrid/engines/base.py`                   | `INFERGRID_`, `infergrid`   | 4    | `INFERGRID_ENGINE_LOG_DIR` → `GPUFAIR_ENGINE_LOG_DIR`, `INFERGRID_DEV_SKIP_ENGINE_LAUNCH` → `GPUFAIR_DEV_SKIP_ENGINE_LAUNCH` |
+| `src/infergrid/engines/sglang_adapter/__init__.py`| `infergrid`                 | 1    |                                                          |
+| `src/infergrid/engines/sglang_adapter/adapter.py` | `infergrid`                 | 1    |                                                          |
+| `src/infergrid/engines/vllm_adapter/__init__.py`  | `infergrid`                 | 1    |                                                          |
+| `src/infergrid/engines/vllm_adapter/adapter.py`   | `infergrid`                 | 1    |                                                          |
+| `src/infergrid/router/__init__.py`                | `infergrid`                 | 3    |                                                          |
+| `src/infergrid/router/router.py`                  | `INFERGRID_`, `infergrid`   | 13   | `INFERGRID_STREAM_MAX_DURATION_S` → `GPUFAIR_STREAM_MAX_DURATION_S` |
+| `src/infergrid/router/admission.py`               | `infergrid`                 | 5    |                                                          |
+| `src/infergrid/tenant/__init__.py`                | `infergrid`                 | 2    |                                                          |
+| `src/infergrid/tenant/manager.py`                 | `infergrid`                 | 1    |                                                          |
+
+### 5b. Tests — `tests/unit/`
+
+| File                                               | Hits | Notes                              |
+| -------------------------------------------------- | ---- | ---------------------------------- |
+| `tests/unit/test_admission.py`                     | 1    | `from infergrid...` import         |
+| `tests/unit/test_bench_hero.py`                    | 8    | (added by in-flight reproduce-hero branch — will be on `main` before sweep) |
+| `tests/unit/test_cache_manager.py`                 | 1    |                                    |
+| `tests/unit/test_metrics.py`                       | 31   | Metric name assertions — update    |
+| `tests/unit/test_metrics_ttft.py`                  | 4    |                                    |
+| `tests/unit/test_multi_model.py`                   | 3    |                                    |
+| `tests/unit/test_router.py`                        | 10   |                                    |
+| `tests/unit/test_router_ensure_model_loaded_race.py` | 4  |                                    |
+| `tests/unit/test_router_health_gating.py`          | 4    |                                    |
+| `tests/unit/test_telemetry.py`                     | 29   | `INFERGRID_TELEMETRY*` env mocks   |
+| `tests/unit/test_tenant_manager.py`                | 1    |                                    |
+| `tests/unit/test_tenant_priority.py`               | 2    |                                    |
+| `tests/unit/test_tenant_token_bucket.py`           | 1    |                                    |
+
+### 5c. Configs — `configs/`
+
+| File                                            | Hits | Brand-text only? |
+| ----------------------------------------------- | ---- | ---------------- |
+| `configs/gate0_multi_model.yaml`                | 1    | Comment          |
+| `configs/gate2_fairness_drr.yaml`               | 1    | Comment          |
+| `configs/gate2_fairness_drr_cap16.yaml`         | 1    | Comment          |
+| `configs/gate2_fairness_drr_ratelimit.yaml`     | 1    | Comment          |
+| `configs/gate2_fairness_fifo.yaml`              | 2    | Comment          |
+| `configs/gate2_multi_tenant.yaml`               | 1    | Comment          |
+| `configs/gate23_fairness_70b_tp4.yaml`          | 1    | Comment          |
+| `configs/quickstart_fairness.yaml`              | 3    | Comment + example command |
+
+No YAML *key* references the brand — hits are all in comments. Pure sed is safe.
+
+### 5d. Benchmarks and scripts
+
+| File                                             | Hits | Notes                         |
+| ------------------------------------------------ | ---- | ----------------------------- |
+| `benchmarks/scripts/benchmark_admission.py`      | 11   |                               |
+| `benchmarks/scripts/benchmark_chat_rag_burst.py` | 2    |                               |
+| `benchmarks/scripts/benchmark_multi_model.py`    | 11   |                               |
+| `benchmarks/scripts/benchmark_n_tenant_single_model.py` | 1 |                             |
+| `benchmarks/scripts/benchmark_two_tenant_single_model.py` | 3 |                           |
+| `benchmarks/scripts/mock_engine.py`              | 1    |                               |
+| `benchmarks/scripts/repro_gate0_stall.sh`        | 7    | `INFERGRID_*` env exports     |
+| `benchmarks/scripts/run_baseline_comparison.py`  | 1    |                               |
+| `benchmarks/scripts/smoke_bench.sh`              | 12   | `INFERGRID_*` env exports     |
+| `scripts/cloud_benchmark.sh`                     | 2    |                               |
+| `scripts/cost_cap_smoke.sh`                      | 1    |                               |
+| `scripts/gate_pod_bootstrap.sh`                  | 10   | Clone URL + env exports       |
+| `scripts/gate1_dress_rehearsal.sh`               | 11   |                               |
+| `scripts/gate2_fairness_dress_rehearsal.sh`      | 6    |                               |
+| `scripts/generate_launch_chart_v3.py`            | 2    | Title strings                 |
+| `scripts/gpu_monitor.py`                         | 2    |                               |
+| `scripts/provision_runpod.py`                    | 12   | Default `--repo-url`          |
+| `scripts/run_all_baselines.sh`                   | 3    |                               |
+| `scripts/run_multi_model_demo.sh`                | 25   | `INFERGRID_*` env vars + `INFERGRID_CMD` + `python -m infergrid` invocation → `python -m gpufair` |
+| `scripts/setup_gpu_env.sh`                       | 5    |                               |
+| `scripts/setup_venv.sh`                          | 6    | `INFERGRID_VENV` env var      |
+| `scripts/summarize_results.py`                   | 1    |                               |
+| `scripts/track_d_runner.sh`                      | 8    |                               |
+| `profiling/analysis/scheduling_overhead_analysis.ipynb` | 1 | Notebook markdown cell      |
+| `profiling/scripts/profile_sglang_scheduler.py`  | 1    |                               |
+| `profiling/scripts/profile_vllm_scheduler.py`    | 1    |                               |
+| `profiling/scripts/profiling_utils.py`           | 1    |                               |
+
+### 5e. Docs (top-level + `docs/`)
+
+| File                                                      | Hits | Notes                                                    |
+| --------------------------------------------------------- | ---- | -------------------------------------------------------- |
+| `README.md`                                               | 34   | Title, badges, repo URL, domain `infergrid.org` → `gpufair.org` |
+| `CONTRIBUTING.md`                                         | 9    | Clone URL                                                |
+| `SECURITY.md`                                             | 2    |                                                          |
+| `research_roadmap.md`                                     | 6    |                                                          |
+| `docs/demo_script.md`                                     | 18   |                                                          |
+| `docs/gap_analysis_verification_april2026.md`             | 1    |                                                          |
+| `docs/inference_orchestration_gaps_report.md`             | 4    |                                                          |
+| `docs/metrics_audit_20260421.md`                          | 40   | Prometheus metric-name audit — metric-namespace rename flows in here |
+| `docs/phase_b_roadmap.md`                                 | 14   |                                                          |
+| `docs/phase1_findings.md`                                 | 3    |                                                          |
+| `docs/pitch.md`                                           | 9    | Repo URL + product title                                 |
+| `docs/reproduce_hero.md`                                  | 6    | (added by in-flight reproduce-hero branch)               |
+| `docs/strategic_analysis.md`                              | 16   |                                                          |
+| `docs/tuning_guide.md`                                    | 18   |                                                          |
+| `docs/launch/faq.md`                                      | 8    |                                                          |
+| `docs/launch/gate0_launch_post.md`                        | 14   |                                                          |
+| `docs/launch/gate1_runbook.md`                            | 7    |                                                          |
+| `docs/launch/gate2_design.md`                             | 10   |                                                          |
+| `docs/launch/gate2_fairness_runbook.md`                   | 9    |                                                          |
+| `docs/launch/one_pager.md`                                | 8    |                                                          |
+| `docs/launch/show_hn.md`                                  | 4    |                                                          |
+| `docs/launch/twitter_thread.md`                           | 8    |                                                          |
+| `docs/launch/why_not_upstream.md`                         | 9    |                                                          |
+| `docs/privacy/telemetry.md`                               | 12   | `INFERGRID_TELEMETRY` env                                |
+| `docs/runbooks/secrets.md`                                | 11   |                                                          |
+
+**Exclusion reiterated:** `docs/naming/infergrid_name_audit.md` is **not** rewritten.
+
+### 5f. Infrastructure / build
+
+| File                                    | Hits | Notes                                                                |
+| --------------------------------------- | ---- | -------------------------------------------------------------------- |
+| `pyproject.toml`                        | 6    | `name = "infergrid"` → `"gpufair"`; `[project.scripts] infergrid = "infergrid.cli:main"` → `gpufair = "gpufair.cli:main"`; all `[project.urls]` repo URLs |
+| `requirements-gpu.txt`                  | 1    | Comment header                                                       |
+| `.gitignore`                            | 1    | Any `infergrid/` entry → `gpufair/`                                  |
+| `docker/docker-compose.yml`             | 1    | Comment header                                                       |
+| `.github/ISSUE_TEMPLATE/bug_report.yml` | 4    | Title templates                                                      |
+| `.github/ISSUE_TEMPLATE/feature_request.yml` | 3 |                                                                     |
+| `.github/ISSUE_TEMPLATE/config.yml`     | 1    | Discussions URL                                                      |
+| `.github/workflows/ci.yml`              | 0    | **No brand text** — CI references `src/` and `tests/` by path, not by package name. Badge in README is renamed because its URL path changes. |
+| `.github/PULL_REQUEST_TEMPLATE.md`      | 0    | Verify during sweep                                                  |
+
+### 5g. telemetry-worker
+
+| File                                    | Hits | Notes                                                                |
+| --------------------------------------- | ---- | -------------------------------------------------------------------- |
+| `telemetry-worker/README.md`            | 8    | Product name + wrangler d1 command examples                          |
+| `telemetry-worker/schema.sql`           | 3    | Comment headers                                                      |
+| `telemetry-worker/src/index.ts`         | 1    | Comment header                                                       |
+| `telemetry-worker/wrangler.toml`        | 3    | **Requires operator action, not pure sed.** `name = "infergrid-telemetry"` → `"gpufair-telemetry"` changes the deployed Worker URL. `database_name = "infergrid-telemetry"` and `database_id = ...` point at a **live D1 database** — creating a new D1 named `gpufair-telemetry` is a data-migration decision (new DB vs. rename-in-place via Cloudflare dashboard). See `user_checklist.md` item 6. |
+
+### 5h. Dashboards
+
+| File                                      | Hits | Notes                                                                |
+| ----------------------------------------- | ---- | -------------------------------------------------------------------- |
+| `dashboards/infergrid-fairness.json`      | 11   | **File rename**: `infergrid-fairness.json` → `gpufair-fairness.json`. Grafana panel titles + queries reference `infergrid_*` Prometheus metric names. |
+| `docs/grafana/infergrid-overview.json`    | 10   | **File rename**: `infergrid-overview.json` → `gpufair-overview.json`. Same metric-name references. |
+
+---
+
+## 6. pyproject.toml — precise edits
+
+| Line  | Old                                                            | New                                                            |
+| ----- | -------------------------------------------------------------- | -------------------------------------------------------------- |
+| 2     | `name = "infergrid"`                                           | `name = "gpufair"`                                             |
+| 3     | `version = "0.1.2"`                                            | `version = "0.1.0"` (fresh line on PyPI; old 0.1.3 stub lives under `infergrid`) |
+| 4     | `description = "...InferGrid..."`                              | Keep tagline but drop the old brand from it if present        |
+| 29    | `Homepage = "https://github.com/coconut-labs/infergrid"`       | `Homepage = "https://github.com/coconut-labs/gpufair"`         |
+| 30    | `Documentation = ".../infergrid#readme"`                        | `Documentation = ".../gpufair#readme"`                         |
+| 31    | `Repository = ".../infergrid"`                                  | `Repository = ".../gpufair"`                                   |
+| 32    | `Issues = ".../infergrid/issues"`                               | `Issues = ".../gpufair/issues"`                                |
+| 58    | `infergrid = "infergrid.cli:main"`                              | `gpufair = "gpufair.cli:main"`                                 |
+
+**Entry point ambiguity:** the task invites the question — do we keep `infergrid` as a deprecated CLI alias? Default answer in this plan: **no**. Rationale: the deprecated PyPI `infergrid==0.1.3` README redirects users to `pip install gpufair`, which is simpler than maintaining two binaries in one package. Flag this for founder review — adding an alias is a one-line `[project.scripts]` entry if desired.
+
+---
+
+## 7. Prometheus metrics — the breaking edge
+
+`src/infergrid/common/metrics.py` defines metrics under a `namespace="infergrid"` argument. The sweep renames the namespace. **Downstream effect**: every label in scraped Prometheus data becomes `gpufair_*` instead of `infergrid_*`. Consumers:
+
+1. **In-tree dashboards** (`dashboards/infergrid-fairness.json`, `docs/grafana/infergrid-overview.json`) — updated in the same PR.
+2. **External users of the PyPI `infergrid` package** — get the old labels under the old package name (unchanged). The 0.1.3 deprecation stub has no engine code, just a README; installed bases don't break.
+3. **Grafana dashboards not in the tree** (none known) — call out in the 0.1.3 deprecation README and in the PyPI `gpufair` 0.1.0 release notes.
+
+---
+
+## 8. In-flight PR handling
+
+Branches open at the time this plan was drafted:
+- `feat/bench-reproduce-hero` — contains `src/infergrid/_bench/`, `tests/unit/test_bench_hero.py`, `docs/reproduce_hero.md`. Lands under the old name. Sweep picks it up.
+- RTX 4090 consumer run — task spec names it `results/consumer-4090-20260421`, but as of 2026-04-21 15:36 UTC no such branch existed locally or on origin. **Ambiguity: verify branch name at sweep time.** The branch almost certainly writes to `results/**`, which is Section 3-excluded from the rename, so even if the directory name bakes in the old brand (`results/consumer-4090-*`) it does not need to be rewritten — `results/**` is the historical record.
+
+**PR body action**: on each in-flight PR, the PR body copy under the old name is fine. No retroactive edit. The landing-sweep PR supersedes.
+
+---
+
+## 9. CI — no changes needed in workflow yaml
+
+`.github/workflows/ci.yml` was reviewed on `origin/main`. The workflow:
+- checks out the repo
+- installs via `pip install -e ".[dev]"` (resolves from `pyproject.toml`, which carries the new name after the sweep)
+- runs `pytest tests/unit/`
+- runs `ruff check src/ tests/` and `ruff format --check src/ tests/`
+
+No brand string in the workflow itself. **However**, the README CI badge URL (`https://github.com/coconut-labs/infergrid/actions/workflows/ci.yml/badge.svg`) changes when the GitHub repo is renamed — handled in the `README.md` sed pass.
+
+---
+
+## 10. Post-sweep verification
+
+After the sweep PR lands, run:
+
+```bash
+# Must return nothing except Section 3 exclusions
+git grep -iE 'InferGrid|infergrid|INFERGRID|infer-grid|infer_grid' -- \
+    ':(exclude)results/' \
+    ':(exclude)docs/naming/infergrid_name_audit.md' \
+    ':(exclude)PROGRESS.md' \
+    ':(exclude)*.tar.gz'
+```
+
+If any hit survives, add to this plan's excluded list with a reason or fix.
+
+---
+
+## 11. Related docs
+
+- `docs/naming/infergrid_name_audit.md` — the original decision memo.
+- `docs/naming/rename_sequence.md` — the copy-paste bash playbook.
+- `docs/naming/user_checklist.md` — founder-only manual steps.
+- `docs/naming/email_samuel_bell.md` — courtesy email draft.

--- a/docs/naming/rename_sequence.md
+++ b/docs/naming/rename_sequence.md
@@ -1,0 +1,304 @@
+# Rename sequence — the copy-paste playbook
+
+This is the exact shell sequence that executes the tree sweep once preconditions hold. It is idempotent (re-running after partial completion is safe) and ends with a `git grep` audit that must return only expected hits. Run it from the repo root on a clean checkout of `origin/main`.
+
+Reference: `rename_plan.md` for the reasoning, `user_checklist.md` for out-of-tree steps.
+
+---
+
+## 0. Preconditions — verify before starting
+
+```bash
+# All must be true before starting.
+[[ "$(git rev-parse --abbrev-ref HEAD)" == "main" ]] || { echo "Not on main"; exit 1; }
+git pull --ff-only origin main
+[[ -z "$(git status --porcelain)" ]] || { echo "Dirty tree"; exit 1; }
+
+# Confirm the in-flight agents have landed.
+# feat/bench-reproduce-hero — must be merged:
+git log --oneline origin/main | head -20 | grep -iE 'reproduce.hero|bench.hero' \
+  || { echo "reproduce-hero bench not yet merged"; exit 1; }
+
+# RTX 4090 consumer run — presumed branch name results/consumer-4090-20260421.
+# Verify it landed OR adjust branch name; if its artifacts live only under
+# results/**, the sweep does not need to wait for it (results/** is excluded).
+```
+
+Out-of-tree blocking items from `user_checklist.md` — confirm manually:
+- `pip index versions gpufair` → returns 0.0.1 (you own the PyPI name)
+- `npm view gpufair` → shows your placeholder
+- `dig +short gpufair.org` → returns a Cloudflare IP (you own the domain)
+- `gh repo view coconut-labs/gpufair --json name` → name is `gpufair`
+
+If any of the above fails, stop and finish the checklist item first.
+
+---
+
+## 1. Create the sweep branch
+
+```bash
+git checkout -b rename/infergrid-to-gpufair
+```
+
+---
+
+## 2. Directory rename — `src/infergrid/` → `src/gpufair/`
+
+```bash
+# Preserves git history through a rename-detection pass.
+git mv src/infergrid src/gpufair
+
+# Remove the generated egg-info — rebuild picks up the new name.
+rm -rf src/infergrid.egg-info src/gpufair.egg-info
+```
+
+---
+
+## 3. Define the exclusion pathspec once
+
+Every subsequent `git grep` and sed pass honors this exclusion list. Save it to a variable so the incantations stay short.
+
+```bash
+EXCLUDE='
+:(exclude)results/
+:(exclude)docs/naming/infergrid_name_audit.md
+:(exclude)PROGRESS.md
+:(exclude)*.tar.gz
+:(exclude)*.egg-info/
+:(exclude)__pycache__/
+:(exclude).ruff_cache/
+:(exclude).pytest_cache/
+'
+
+# `printf '%s\n' $EXCLUDE` expands correctly when quoted in `git grep`:
+_grep() { git grep "$@" -- $EXCLUDE ; }
+```
+
+---
+
+## 4. sed pass 1 — hyphen + underscore forms
+
+Only two files in-tree reference these forms (the audit doc), but run the pass for completeness and future-proofing.
+
+```bash
+files="$(_grep -l -E 'infer-grid|infer_grid' | grep -v docs/naming/infergrid_name_audit.md || true)"
+if [[ -n "$files" ]]; then
+  echo "$files" | xargs sed -i '' \
+    -e 's/infer-grid/gpufair/g' \
+    -e 's/infer_grid/gpufair/g'
+fi
+```
+
+Note: on Linux use `sed -i` (no `''`). The `sed -i ''` form above is macOS BSD sed.
+
+---
+
+## 5. sed pass 2 — `InferGrid` → `GPUFair`
+
+```bash
+files="$(_grep -l 'InferGrid' || true)"
+if [[ -n "$files" ]]; then
+  echo "$files" | xargs sed -i '' 's/InferGrid/GPUFair/g'
+fi
+```
+
+---
+
+## 6. sed pass 3 — `INFERGRID_` → `GPUFAIR_` (env vars, anchored)
+
+The trailing underscore anchor protects against any hypothetical `INFERGRIDX` collision (none exist today, but the anchor is free insurance).
+
+```bash
+files="$(_grep -l 'INFERGRID_' || true)"
+if [[ -n "$files" ]]; then
+  echo "$files" | xargs sed -i '' 's/INFERGRID_/GPUFAIR_/g'
+fi
+```
+
+---
+
+## 7. sed pass 4 — lowercase `infergrid` → `gpufair`
+
+Runs last so it does not clobber any form handled above.
+
+```bash
+files="$(_grep -l 'infergrid' || true)"
+if [[ -n "$files" ]]; then
+  echo "$files" | xargs sed -i '' 's/infergrid/gpufair/g'
+fi
+```
+
+---
+
+## 8. File renames — dashboards and grafana
+
+```bash
+git mv dashboards/infergrid-fairness.json dashboards/gpufair-fairness.json
+git mv docs/grafana/infergrid-overview.json docs/grafana/gpufair-overview.json
+```
+
+(These also received content rewrites from the sed passes; the `git mv` here is just the filename.)
+
+---
+
+## 9. telemetry-worker wrangler.toml — **review and confirm**
+
+```bash
+# The sed passes already changed name = "infergrid-telemetry" to "gpufair-telemetry".
+# But database_id was "REPLACE_WITH_WRANGLER_OUTPUT" on main and still needs
+# the real id from the new D1 database created in user_checklist.md item 6.
+# If user_checklist step 6 has been done, paste the new id here manually.
+$EDITOR telemetry-worker/wrangler.toml
+```
+
+---
+
+## 10. Quick sanity — package imports resolve
+
+```bash
+# Without installing — just the AST:
+python -c "import ast; ast.parse(open('src/gpufair/__init__.py').read())"
+
+# Full install + import:
+pip install -e ".[dev]"
+python -c "import gpufair; print(gpufair.__version__)"
+
+# CLI entry point:
+gpufair --help | head -5
+```
+
+---
+
+## 11. Tests pass
+
+```bash
+pytest tests/unit/ -v --tb=short
+```
+
+If any test fails because it hard-codes a metric name with the old prefix that the sed didn't catch (e.g. inside a string literal split across lines), fix it and commit.
+
+---
+
+## 12. Lint and format
+
+```bash
+ruff check src/ tests/
+ruff format --check src/ tests/
+
+# If format check fails:
+ruff format src/ tests/
+```
+
+---
+
+## 13. The verification grep — must return nothing
+
+```bash
+_grep -iE 'InferGrid|infergrid|INFERGRID|infer-grid|infer_grid' && {
+  echo "LEFTOVER HITS — inspect above, decide fix-or-exclude"
+  exit 1
+} || echo "VERIFICATION CLEAN"
+```
+
+Expected failure paths and fixes:
+- Leftover in a docstring line that was too exotic for sed (e.g. quoted inside a raw-string) — hand-edit.
+- Leftover in a committed log that slipped past the `results/` exclusion — add the specific file to `$EXCLUDE` in Section 3 of `rename_plan.md` and document why.
+
+---
+
+## 14. Commit in review-friendly chunks
+
+```bash
+# Chunk 1: directory rename (pure `git mv`, reviewers can skim).
+git add -A src/
+git commit --author="Shrey Patel <patelshrey77@gmail.com>" \
+  -m "rename: src/infergrid/ → src/gpufair/ (directory move)"
+
+# Chunk 2: pyproject.toml and build metadata.
+git add pyproject.toml requirements-gpu.txt .gitignore
+git commit --author="Shrey Patel <patelshrey77@gmail.com>" \
+  -m "rename: pyproject + build metadata (infergrid → gpufair)"
+
+# Chunk 3: configs + benchmark scripts.
+git add configs/ benchmarks/ scripts/ profiling/
+git commit --author="Shrey Patel <patelshrey77@gmail.com>" \
+  -m "rename: configs + scripts (infergrid → gpufair)"
+
+# Chunk 4: docs + README.
+git add README.md CONTRIBUTING.md SECURITY.md research_roadmap.md docs/ docker/
+git commit --author="Shrey Patel <patelshrey77@gmail.com>" \
+  -m "rename: docs + top-level (infergrid → gpufair)"
+
+# Chunk 5: telemetry-worker + dashboards + grafana.
+git add telemetry-worker/ dashboards/ docs/grafana/
+git commit --author="Shrey Patel <patelshrey77@gmail.com>" \
+  -m "rename: telemetry-worker + dashboards (infergrid → gpufair)"
+
+# Chunk 6: tests.
+git add tests/
+git commit --author="Shrey Patel <patelshrey77@gmail.com>" \
+  -m "rename: tests (infergrid → gpufair)"
+
+# Chunk 7: .github/.
+git add .github/
+git commit --author="Shrey Patel <patelshrey77@gmail.com>" \
+  -m "rename: .github issue templates + CI metadata"
+```
+
+If any of the above complains "nothing to commit" it means sed had no hits there — skip cleanly.
+
+---
+
+## 15. Push and open the sweep PR
+
+```bash
+git push -u origin rename/infergrid-to-gpufair
+
+gh pr create \
+  --title "rename: infergrid → gpufair (tree sweep)" \
+  --body "$(cat <<'EOF'
+Executes the rename playbook at docs/naming/rename_plan.md. All five spelling
+forms swapped in the order documented there. results/**, PROGRESS.md, and
+docs/naming/infergrid_name_audit.md are deliberately untouched — they are
+historical evidence.
+
+Preconditions (all held before this PR): domains purchased, PyPI gpufair
+0.0.1 reserved, npm gpufair + scope reserved, GitHub org repos renamed with
+301s active. See docs/naming/user_checklist.md for the full checklist.
+
+Post-merge follow-ups in docs/naming/user_checklist.md sections 6–8:
+Cloudflare Worker cutover, PyPI infergrid 0.1.3 deprecation stub, DNS
+cutover for gpufair.org.
+EOF
+)"
+```
+
+---
+
+## 16. Post-merge — tag and publish
+
+```bash
+git checkout main && git pull
+git tag v0.1.0
+git push --tags
+
+# Build and publish to PyPI (the gpufair name is already reserved):
+python -m build
+python -m twine upload dist/*
+```
+
+Then run `user_checklist.md` sections 6, 7, 8 for the Worker cutover, the `infergrid` 0.1.3 deprecation publish, and the DNS cutover.
+
+---
+
+## 17. Rollback — if the PR needs to be unwound
+
+The sweep is a set of ordinary commits on a branch. To back out:
+
+```bash
+git checkout main
+git branch -D rename/infergrid-to-gpufair
+git push origin --delete rename/infergrid-to-gpufair
+```
+
+The PyPI `gpufair` 0.0.1 placeholder remains (PyPI does not permit re-use of a version number, and the name reservation stands). The GitHub redirects remain. The domains remain. Those are all sunk-cost and useful even if the rename is aborted.

--- a/docs/naming/user_checklist.md
+++ b/docs/naming/user_checklist.md
@@ -1,0 +1,313 @@
+# User checklist — `gpufair` rename, founder-only steps
+
+Everything below requires either payment, a login, or a personal credential — no agent can execute these. Order matters for the items flagged **blocking**; the code sweep in `rename_sequence.md` can run in parallel with the non-blocking items.
+
+Execute as Shrey Patel, `patelshrey77@gmail.com`. Whenever a command needs a token or password, it's your personal credential — never commit it.
+
+---
+
+## 1. Buy the four TLDs — **blocking, do first** (~20 min, $40–$120)
+
+All four via Cloudflare Registrar. Single dashboard, at-cost pricing, no add-on upsells. Cloudflare supports `.org`, `.com`, `.ai`, and `.dev` (`.dev` lives in the Google Registry — Cloudflare is a reseller. Google Domains was sunset in 2024; its customers were migrated to Squarespace, which is not a recommended registrar for this).
+
+Direct links (logged into the existing Cloudflare account that already holds `infergrid.org`):
+
+- Dashboard: https://dash.cloudflare.com/ → Domain Registration → Register Domain
+- Search `gpufair` once and Cloudflare shows availability for all four TLDs.
+
+| Domain       | Approx cost (Cloudflare at-cost, 2026) | Purpose                                      |
+| ------------ | --------------------------------------- | -------------------------------------------- |
+| `gpufair.org`  | ~$11/yr | **Canonical landing page** — replaces `infergrid.org` |
+| `gpufair.com`  | ~$10/yr | Defensive — prevent typo-domain squatters    |
+| `gpufair.ai`   | ~$80/yr | AI-vertical defensive, often the first TLD folks try |
+| `gpufair.dev`  | ~$13/yr | Developer-audience defensive                 |
+
+Enable auto-renew on all four. Turn on Registrar Lock for each.
+
+---
+
+## 2. Reserve PyPI `gpufair` — **blocking** (~10 min)
+
+Publish a 0.0.1 placeholder so nobody else grabs the name while the sweep is in flight.
+
+```bash
+# In a scratch dir — do NOT do this inside the main repo
+mkdir -p /tmp/gpufair-stub && cd /tmp/gpufair-stub
+
+cat > pyproject.toml <<'EOF'
+[project]
+name = "gpufair"
+version = "0.0.1"
+description = "Tenant-fair LLM inference orchestration on a single GPU. Placeholder — real package coming soon."
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+authors = [{name = "Shrey Patel", email = "patelshrey77@gmail.com"}]
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+EOF
+
+cat > README.md <<'EOF'
+# gpufair
+
+Placeholder. Full package ships with 0.1.0. See https://gpufair.org.
+EOF
+
+mkdir -p src/gpufair && echo '__version__ = "0.0.1"' > src/gpufair/__init__.py
+
+python -m pip install --upgrade build twine
+python -m build
+python -m twine upload dist/*
+```
+
+Username: `__token__`. Password: a PyPI API token scoped to this project (create at https://pypi.org/manage/account/token/; scope "Entire account" for the first upload, then narrow to "Project: gpufair" after the first release lands).
+
+---
+
+## 3. Reserve npm `gpufair` + `@gpufair` scope — **blocking** (~10 min)
+
+Even though the project is Python, reserving the npm name + scope prevents someone from shipping an unrelated `npm install gpufair` that shows up in SERP for the brand.
+
+```bash
+mkdir -p /tmp/gpufair-npm-stub && cd /tmp/gpufair-npm-stub
+
+cat > package.json <<'EOF'
+{
+  "name": "gpufair",
+  "version": "0.0.1",
+  "description": "Placeholder. Real package is Python — see https://pypi.org/project/gpufair/",
+  "author": "Shrey Patel <patelshrey77@gmail.com>",
+  "license": "MIT",
+  "repository": { "type": "git", "url": "https://github.com/coconut-labs/gpufair" }
+}
+EOF
+
+cat > README.md <<'EOF'
+# gpufair
+
+Placeholder. The real package is Python: `pip install gpufair` (once 0.1.0 ships). See https://gpufair.org.
+EOF
+
+npm login          # prompts email, password, OTP
+npm publish --access public
+```
+
+Then reserve the scope. Scopes aren't reservable via a single command — npm creates the scope the first time you publish under it:
+
+```bash
+cd /tmp/gpufair-npm-stub
+# Rename the package to @gpufair/placeholder in package.json:
+#   "name": "@gpufair/placeholder"
+npm publish --access public
+```
+
+This establishes `@gpufair` as a scope under your npm account. Future packages under `@gpufair/...` require your login.
+
+---
+
+## 4. Reserve Twitter/X handles — ~10 min, **not verifiable via curl**
+
+x.com is a client-rendered SPA and returns HTTP 200 for every path, so handle availability can only be verified in a browser. Reserve in this order:
+
+| Handle              | Purpose                                 |
+| ------------------- | --------------------------------------- |
+| `@gpufair`          | Primary brand                           |
+| `@gpufair_ai`       | Defensive — many AI brands use `_ai`    |
+| `@gpufair_hq`       | Defensive — "headquarters" pattern      |
+
+For each:
+1. https://x.com/i/flow/signup
+2. Use `patelshrey77+gpufair@gmail.com`, `patelshrey77+gpufair_ai@gmail.com`, etc. (Gmail `+` aliases all land in your main inbox — legitimate, not a trick).
+3. After account creation, go to Settings → Your account → Account information → Username and confirm.
+4. Add a profile bio pointing at `https://gpufair.org` and set the profile image to the existing `infergrid.org` favicon — the LP will swap it when DNS cuts over.
+
+If any handle is taken, fall back to `@gpufair_dev` / `@gpufairhq` (no underscore) / `@gpu_fair`.
+
+---
+
+## 5. Rename GitHub org repos — **blocking** (~5 min, non-destructive)
+
+GitHub maintains permanent 301 redirects from the old names, so existing clone URLs, PR links, and badge URLs keep working. No rush to update every downstream reference, but the sweep PR does update the in-repo URLs.
+
+```bash
+# Primary repo
+gh repo rename gpufair --repo coconut-labs/infergrid
+
+# Landing-page repo
+gh repo rename gpufair-root --repo coconut-labs/infergrid-root
+```
+
+Verify:
+
+```bash
+gh repo view coconut-labs/gpufair --json name,url
+gh repo view coconut-labs/gpufair-root --json name,url
+
+# Confirm redirects work (expect 301 → new URL):
+curl -sI https://github.com/coconut-labs/infergrid | grep -i ^location
+```
+
+After the rename, update your local clone's origin:
+
+```bash
+# In this repo:
+git remote set-url origin git@github.com:coconut-labs/gpufair.git
+git remote set-url coconut git@github.com:coconut-labs/gpufair.git
+git remote -v   # confirm
+```
+
+Update the Vercel project bound to `coconut-labs/infergrid-root`:
+- Vercel dashboard → Project Settings → Git → Repository → re-link to `coconut-labs/gpufair-root`. Vercel follows the redirect automatically in most cases but re-linking is cleaner for the build log.
+
+---
+
+## 6. Cloudflare Worker cutover (~30 min)
+
+The current Worker is `infergrid-waitlist.shrey77-wrk.workers.dev` and the telemetry Worker is `infergrid-telemetry.shrey77-wrk.workers.dev`. **There is no `wrangler rename` subcommand** — you deploy a new Worker under the new name and retire the old one.
+
+For each Worker (waitlist + telemetry):
+
+```bash
+cd telemetry-worker   # adjust for waitlist worker repo
+
+# 1. Edit wrangler.toml:
+#      name = "infergrid-telemetry"   →   name = "gpufair-telemetry"
+#      database_name = "infergrid-telemetry"   →   "gpufair-telemetry"
+
+# 2. Create a fresh D1 database under the new name (telemetry only)
+wrangler d1 create gpufair-telemetry
+# Paste the returned database_id into wrangler.toml
+
+# 3. Apply the schema to the new DB
+wrangler d1 execute gpufair-telemetry --file=schema.sql
+
+# 4. Deploy the renamed worker — assigns gpufair-telemetry.shrey77-wrk.workers.dev
+wrangler deploy
+
+# 5. Update the LP's WAITLIST_API in coconut-labs/gpufair-root:
+#      window.WAITLIST_API = 'https://gpufair-waitlist.shrey77-wrk.workers.dev'
+#    (This also fixes the outstanding pending-user-action where WAITLIST_API = '')
+
+# 6. Keep the old Worker alive for ~30 days for any in-flight traffic, then:
+wrangler delete --name infergrid-telemetry
+wrangler delete --name infergrid-waitlist
+#    And drop the old D1:
+wrangler d1 delete infergrid-telemetry
+```
+
+**Data migration decision (telemetry D1)**: the existing `infergrid-telemetry` D1 holds opt-in install stats. Options:
+- **Fresh start (recommended).** New DB, old data stays queryable under the old Worker until it's deleted. Telemetry is ephemeral anyway — 90-day retention sweep is in the cron.
+- **Backfill.** `wrangler d1 export infergrid-telemetry --output dump.sql`, hand-edit the `CREATE TABLE` / row inserts if desired, `wrangler d1 execute gpufair-telemetry --file dump.sql`. Only worth it if there's install data you care about.
+
+---
+
+## 7. PyPI `infergrid` deprecation — after the sweep lands (~20 min)
+
+Once `gpufair` 0.1.0 is live on PyPI (published from the sweep PR's tag), ship a final `infergrid==0.1.3` that is README-only, pointing users at the new name.
+
+```bash
+mkdir -p /tmp/infergrid-deprecate && cd /tmp/infergrid-deprecate
+
+cat > pyproject.toml <<'EOF'
+[project]
+name = "infergrid"
+version = "0.1.3"
+description = "This package has moved. See README."
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+authors = [{name = "Shrey Patel", email = "patelshrey77@gmail.com"}]
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+EOF
+
+cat > README.md <<'EOF'
+# infergrid has moved to gpufair
+
+This package has been renamed to **gpufair**. Install with:
+
+```bash
+pip install gpufair
+```
+
+See https://gpufair.org for the current release and documentation.
+
+The rename was prompted by a naming collision with a senior commercial product
+at https://infergrid.net. Details in
+https://github.com/coconut-labs/gpufair/blob/main/docs/naming/.
+EOF
+
+mkdir -p src/infergrid
+cat > src/infergrid/__init__.py <<'EOF'
+import warnings
+warnings.warn(
+    "The 'infergrid' package has been renamed to 'gpufair'. "
+    "Please `pip install gpufair` and `import gpufair` instead. "
+    "See https://gpufair.org.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+EOF
+
+python -m build
+python -m twine upload dist/*
+```
+
+Do not add any runtime code to the stub — a `DeprecationWarning` on import is loud enough and safe.
+
+---
+
+## 8. DNS cutover — `gpufair.org` → Vercel (~15 min, after the sweep)
+
+Mirror the existing `infergrid.org` → Vercel config onto `gpufair.org`. The Vercel project is the `coconut-labs/gpufair-root` project (renamed in step 5).
+
+1. Cloudflare dashboard → `gpufair.org` → DNS. Add records that match the existing `infergrid.org` records — for Vercel that is typically:
+   - `A @ 76.76.21.21` (Vercel anycast)
+   - `CNAME www cname.vercel-dns.com`
+2. Vercel dashboard → the renamed project (`gpufair-root`) → Settings → Domains. Add `gpufair.org` and `www.gpufair.org`. Vercel will issue SSL automatically; expect propagation in <5 min.
+3. Once DNS is live and the cert is green, set a 302 redirect on `infergrid.org` pointing at `gpufair.org`. In Cloudflare: Rules → Page Rules → Forwarding URL (302) `infergrid.org/*` → `https://gpufair.org/$1`. Keep it 302 (temporary) for 30 days, then convert to 301 (permanent) if everything looks good.
+4. Hold `infergrid.org` in registration but **do not** let it expire — the redirect is the only thing keeping any existing inbound links alive.
+
+---
+
+## 9. Optional — USPTO trademark filing for `GPUFAIR` (~$350, own schedule)
+
+Not blocking. First-to-file wins in the US, so filing earlier is better. Class 9 (downloadable software) + Class 42 (SaaS). Retain a flat-fee trademark filer like Cognition IP or Stacks Law if you want this done right, ~$800–$1,500 all-in. Skip if cash-constrained at launch — the rename itself de-risks the Samuel Bell collision, which was the actual legal exposure.
+
+---
+
+## 10. Final verification after everything ships
+
+```bash
+# All should resolve correctly
+curl -sI https://gpufair.org | head -1
+curl -sI https://infergrid.org | head -1      # expect 302 → gpufair.org
+curl -sI https://github.com/coconut-labs/infergrid | grep -i ^location   # 301 → gpufair
+pip index versions gpufair      # 0.1.0 available
+pip index versions infergrid    # 0.1.3 deprecation stub
+npm view gpufair                 # lists your placeholder
+```
+
+---
+
+## Summary of blocking vs. non-blocking
+
+**Blocking the code sweep** (do before running `rename_sequence.md`):
+1. Domains purchased
+2. PyPI `gpufair` reserved
+3. npm `gpufair` + scope reserved
+
+**Can happen in parallel with the code sweep**:
+4. Twitter/X handles reserved
+5. GitHub repo renames (GitHub's redirects mean order doesn't strictly matter, but earlier is cleaner)
+
+**After the sweep lands**:
+6. Cloudflare Worker cutover
+7. PyPI `infergrid` 0.1.3 deprecation stub
+8. DNS cutover
+9. (Optional) USPTO filing
+10. Final verification


### PR DESCRIPTION
The name-collision audit in docs/naming/infergrid_name_audit.md flagged a senior commercial holder at infergrid.net and landed on gpufair as the replacement. This PR is the docs-only companion: rename_plan.md walks through every spelling form, every file, every excluded historical artifact; rename_sequence.md is the copy-paste shell playbook; user_checklist.md lists the founder-only manual steps (domains, PyPI, npm, GH org rename, Cloudflare Worker cutover); email_samuel_bell.md is a draft courtesy note to send after the sweep commits. Nothing in src/, configs/, README, or PROGRESS.md is touched here — the actual tree sweep is a separate PR that fires after the reproduce-hero bench and the RTX 4090 consumer run land on main. Leaving this open for your eyeball before the sweep executes.