### PR TITLE
fix(ci): restore green — ruff errors + flaky integration tests

### DIFF
--- a/src/kvwarden/_bench/hero.py
+++ b/src/kvwarden/_bench/hero.py
@@ -181,10 +181,8 @@ def _port_listening(host: str, port: int) -> bool:
 
 def _import_bench_module():
     """Import the n-tenant bench script from the repo checkout."""
-    from pathlib import Path as _P
-
     script_dir = (
-        _P(__file__).resolve().parent.parent.parent.parent / "benchmarks" / "scripts"
+        Path(__file__).resolve().parent.parent.parent.parent / "benchmarks" / "scripts"
     )
     if str(script_dir) not in sys.path:
         sys.path.insert(0, str(script_dir))

--- a/src/kvwarden/_bench/pod.py
+++ b/src/kvwarden/_bench/pod.py
@@ -43,7 +43,9 @@ class PodContext:
             return
         try:
             self.runpod_mod.terminate_pod(self.pod_id)
-            self.console.print(f"[green]✓[/green] terminated pod [cyan]{self.pod_id}[/cyan]")
+            self.console.print(
+                f"[green]✓[/green] terminated pod [cyan]{self.pod_id}[/cyan]"
+            )
         except Exception as exc:
             self.console.print(
                 f"[yellow]![/yellow] failed to terminate pod {self.pod_id}: {exc}\n"
@@ -81,14 +83,20 @@ def ensure_pod(
 ) -> PodContext:
     """Provision a 1x A100 pod. SystemExit(2) with a hint on missing prereqs."""
     if not os.environ.get("RUNPOD_API_KEY"):
-        _bail(console, "--pod requires RUNPOD_API_KEY (https://runpod.io/console/user/settings).")
+        _bail(
+            console,
+            "--pod requires RUNPOD_API_KEY (https://runpod.io/console/user/settings).",
+        )
     hf_token = os.environ.get("HF_TOKEN", "")
     if not hf_token:
         _bail(console, "--pod requires HF_TOKEN for gated Llama-3.1-8B weights.")
     try:
         import runpod as _rp  # lazy; zero-new-deps
     except ImportError:
-        _bail(console, "`pip install runpod` required for --pod (not a core kvwarden dep).")
+        _bail(
+            console,
+            "`pip install runpod` required for --pod (not a core kvwarden dep).",
+        )
         return None  # unreachable; appeases the type-checker
 
     _rp.api_key = os.environ["RUNPOD_API_KEY"]
@@ -96,8 +104,12 @@ def ensure_pod(
     try:
         pod = _rp.create_pod(
             name="kvwarden-reproduce-hero",
-            image_name=_IMAGE, gpu_type_id=_GPU_TYPE, cloud_type="SECURE",
-            gpu_count=1, container_disk_in_gb=100, volume_in_gb=50,
+            image_name=_IMAGE,
+            gpu_type_id=_GPU_TYPE,
+            cloud_type="SECURE",
+            gpu_count=1,
+            container_disk_in_gb=100,
+            volume_in_gb=50,
             ports=f"{port}/http",
             env={"HF_TOKEN": hf_token, "KVWARDEN_AUTO_SERVE": "1"},
         )
@@ -120,8 +132,11 @@ def ensure_pod(
         return None
     console.print(f"  base-url [cyan]{url}[/cyan]")
     return PodContext(
-        pod_id=pod_id, base_url=url, runpod_mod=_rp,
-        delete_on_exit=delete_on_exit, console=console,
+        pod_id=pod_id,
+        base_url=url,
+        runpod_mod=_rp,
+        delete_on_exit=delete_on_exit,
+        console=console,
     )
 
 
@@ -129,7 +144,9 @@ def pod_signal_handler(ctx: PodContext) -> Callable[[int, Any], None]:
     """Return a handler that tears down the pod on SIGINT/SIGTERM."""
 
     def _handler(signum: int, _frame: Any) -> None:
-        ctx.console.print(f"\n[yellow]![/yellow] caught signal {signum}, terminating pod...")
+        ctx.console.print(
+            f"\n[yellow]![/yellow] caught signal {signum}, terminating pod..."
+        )
         ctx.teardown()
         sys.exit(130)
 

--- a/src/kvwarden/cli.py
+++ b/src/kvwarden/cli.py
@@ -175,7 +175,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     # ── bench ──
     bench_parser = sub.add_parser(
-        "bench", help="Benchmark helpers (reproduce the hero number, etc.)",
+        "bench",
+        help="Benchmark helpers (reproduce the hero number, etc.)",
         description="Benchmark helpers. See `kvwarden bench reproduce-hero --help`.",
     )
     bench_sub = bench_parser.add_subparsers(dest="bench_cmd", help="bench subcommand")
@@ -183,18 +184,35 @@ def build_parser() -> argparse.ArgumentParser:
         "reproduce-hero",
         help="Replicate the launch-post hero number against a running server",
         description="Run the published noisy-neighbor bench and print a "
-                    "side-by-side table vs docs/launch/gate0_launch_post.md.",
+        "side-by-side table vs docs/launch/gate0_launch_post.md.",
     )
-    repro.add_argument("--flavor", choices=["2tenant", "n6", "n8"], default="2tenant",
-                       help="Bench flavor (default: 2tenant — the hero).")
-    repro.add_argument("--duration-s", type=float, default=None,
-                       help="Bench wall time (default: 300 s).")
-    repro.add_argument("--base-url", default="http://localhost:8000",
-                       help="KVWarden server URL (default: http://localhost:8000).")
-    repro.add_argument("--pod", action="store_true",
-                       help="Provision a 1x A100 pod via RunPod and run against it.")
-    repro.add_argument("--no-delete", action="store_true",
-                       help="With --pod: keep the pod alive after the run.")
+    repro.add_argument(
+        "--flavor",
+        choices=["2tenant", "n6", "n8"],
+        default="2tenant",
+        help="Bench flavor (default: 2tenant — the hero).",
+    )
+    repro.add_argument(
+        "--duration-s",
+        type=float,
+        default=None,
+        help="Bench wall time (default: 300 s).",
+    )
+    repro.add_argument(
+        "--base-url",
+        default="http://localhost:8000",
+        help="KVWarden server URL (default: http://localhost:8000).",
+    )
+    repro.add_argument(
+        "--pod",
+        action="store_true",
+        help="Provision a 1x A100 pod via RunPod and run against it.",
+    )
+    repro.add_argument(
+        "--no-delete",
+        action="store_true",
+        help="With --pod: keep the pod alive after the run.",
+    )
 
     # ── man ──
     man_parser = sub.add_parser(

--- a/tests/unit/test_bench_hero.py
+++ b/tests/unit/test_bench_hero.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from rich.console import Console
 
-from kvwarden._bench import hero
+from kvwarden._bench import compare, hero
 
 
 class _FakeSession:
@@ -28,8 +28,11 @@ class _FakeSession:
         return None
 
     def get(self, url: str) -> "_FakeResp":
-        return (_FakeResp(self._h, {}) if url.endswith("/health")
-                else _FakeResp(200, self._m))
+        return (
+            _FakeResp(self._h, {})
+            if url.endswith("/health")
+            else _FakeResp(200, self._m)
+        )
 
 
 class _FakeResp:
@@ -51,6 +54,7 @@ class _FakeResp:
 
 # ── flavor + reference ──────────────────────────────────────────────────
 
+
 def test_flavors_match_references() -> None:
     for key in ("2tenant", "n6", "n8"):
         assert hero.FLAVORS[key].num_quiet == hero.REFERENCES[key].num_quiet
@@ -58,9 +62,12 @@ def test_flavors_match_references() -> None:
 
 def test_default_flavor_is_hero_2tenant() -> None:
     spec = hero.FLAVORS["2tenant"]
-    assert (spec.num_quiet, spec.flooder_rps, spec.quiet_rps, spec.default_duration_s) == (
-        1, 32.0, 1.0, 300.0
-    )
+    assert (
+        spec.num_quiet,
+        spec.flooder_rps,
+        spec.quiet_rps,
+        spec.default_duration_s,
+    ) == (1, 32.0, 1.0, 300.0)
 
 
 def test_config_hints_exist() -> None:
@@ -71,11 +78,12 @@ def test_config_hints_exist() -> None:
 
 # ── comparison math + rendering ─────────────────────────────────────────
 
+
 def test_delta_badge_color_thresholds() -> None:
-    assert "green" in hero._delta_badge(68.0, 61.5)      # ~10%
-    assert "yellow" in hero._delta_badge(85.0, 61.5)     # ~38%
-    assert "red" in hero._delta_badge(150.0, 61.5)       # ~144%
-    assert hero._delta_badge(10.0, 0.0) == "[dim]n/a[/dim]"
+    assert "green" in compare._delta_badge(68.0, 61.5)  # ~10%
+    assert "yellow" in compare._delta_badge(85.0, 61.5)  # ~38%
+    assert "red" in compare._delta_badge(150.0, 61.5)  # ~144%
+    assert compare._delta_badge(10.0, 0.0) == "[dim]n/a[/dim]"
 
 
 def test_render_comparison_runs() -> None:
@@ -84,6 +92,7 @@ def test_render_comparison_runs() -> None:
 
 
 # ── preflight errors ────────────────────────────────────────────────────
+
 
 async def test_connection_refused_hint() -> None:
     import aiohttp
@@ -112,8 +121,9 @@ async def test_wrong_model_hint() -> None:
 
 
 async def test_health_non_200_hint() -> None:
-    with patch("kvwarden._bench.hero.aiohttp.ClientSession",
-               return_value=_FakeSession(503, {})):
+    with patch(
+        "kvwarden._bench.hero.aiohttp.ClientSession", return_value=_FakeSession(503, {})
+    ):
         ok, hint = await hero._preflight_server(
             "http://localhost:8000", hero._HERO_MODEL, Console()
         )
@@ -122,6 +132,7 @@ async def test_health_non_200_hint() -> None:
 
 
 # ── result extraction ───────────────────────────────────────────────────
+
 
 def test_count_429s_missing_file(tmp_path: Path) -> None:
     assert hero._count_429s(tmp_path / "missing.csv") == (0, 0)
@@ -153,9 +164,14 @@ def test_build_report_schema() -> None:
         "quiet_aggregate": {"ttft_p99_ms": 62.5, "count_ok": 311},
     }
     r = hero._build_report(
-        hero.FLAVORS["2tenant"], summary, 0.93,
-        "http://localhost:8000", 300.0, "NVIDIA A100-SXM4-80GB",
-        "2026-04-21T15:00:00+00:00", "2026-04-21T15:05:00+00:00",
+        hero.FLAVORS["2tenant"],
+        summary,
+        0.93,
+        "http://localhost:8000",
+        300.0,
+        "NVIDIA A100-SXM4-80GB",
+        "2026-04-21T15:00:00+00:00",
+        "2026-04-21T15:05:00+00:00",
     )
     assert r["schema_version"] == 1 and r["flavor"] == "2tenant"
     assert r["user_result"]["quiet_aggregate_p99_ms"] == 62.5
@@ -165,21 +181,30 @@ def test_build_report_schema() -> None:
 
 # ── url parsing ─────────────────────────────────────────────────────────
 
-@pytest.mark.parametrize("url, expected", [
-    ("http://localhost:8000", ("localhost", 8000)),
-    ("https://example.com:8080/", ("example.com", 8080)),
-    ("http://example.com", ("example.com", 8000)),
-])
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("http://localhost:8000", ("localhost", 8000)),
+        ("https://example.com:8080/", ("example.com", 8080)),
+        ("http://example.com", ("example.com", 8000)),
+    ],
+)
 def test_split_host_port(url: str, expected: tuple[str, int]) -> None:
     assert hero._split_host_port(url) == expected
 
 
 # ── dispatch errors ─────────────────────────────────────────────────────
 
+
 def test_unknown_flavor_exits_2() -> None:
-    ns = argparse.Namespace(flavor="nope", duration_s=None,
-                            base_url="http://localhost:8000",
-                            pod=False, no_delete=False)
+    ns = argparse.Namespace(
+        flavor="nope",
+        duration_s=None,
+        base_url="http://localhost:8000",
+        pod=False,
+        no_delete=False,
+    )
     with pytest.raises(SystemExit) as ei:
         hero.run_reproduce_hero(ns)
     assert ei.value.code == 2
@@ -187,9 +212,13 @@ def test_unknown_flavor_exits_2() -> None:
 
 def test_server_unreachable_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(hero, "_port_listening", lambda h, p: False)
-    ns = argparse.Namespace(flavor="2tenant", duration_s=5.0,
-                            base_url="http://localhost:8000",
-                            pod=False, no_delete=False)
+    ns = argparse.Namespace(
+        flavor="2tenant",
+        duration_s=5.0,
+        base_url="http://localhost:8000",
+        pod=False,
+        no_delete=False,
+    )
     with pytest.raises(SystemExit) as ei:
         hero.run_reproduce_hero(ns)
     assert ei.value.code == 2
@@ -197,12 +226,16 @@ def test_server_unreachable_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:
 
 # ── pod teardown & signal handler ───────────────────────────────────────
 
+
 def _mk_pod_ctx(delete: bool = True):
     from kvwarden._bench import pod as pod_mod
 
     return pod_mod.PodContext(
-        pod_id="abc", base_url="http://ignored",
-        runpod_mod=MagicMock(), delete_on_exit=delete, console=Console(),
+        pod_id="abc",
+        base_url="http://ignored",
+        runpod_mod=MagicMock(),
+        delete_on_exit=delete,
+        console=Console(),
     )
 
 


### PR DESCRIPTION
Main has been red since commit 04e33df refactored bench reproduce-hero (moved `_delta_badge` from `hero.py` to `compare.py` without updating `test_bench_hero.py`), with a later N814 tripwire added in the same area (`from pathlib import Path as _P` aliased uppercase → constant-looking name).

The fix: update the stale test import to point at `compare._delta_badge`, drop the redundant local `Path` alias (it was already imported at module scope), and run `ruff format` over the three files the format gate flagged. No test logic changed, no tests skipped, no markers added. I investigated whether any HF-network integration tests were hiding — none exist (`grep` for transformers/huggingface/HF_TOKEN/etc. across `tests/` returns zero hits, and the CI log for the failing main run shows 252 collected / 1 failed, not the 260/9 I was briefed on).

One unrelated pre-existing gap worth founder eyeball: `python -m kvwarden --help` has never worked (there's no `__main__.py` in the package, and none ever existed in `infergrid` either). Left alone here — that's scope for a separate tiny PR.

Not merging — leaving open for review.