### PR TITLE
docs(launch): brand-voice polish on kvwarden sweep

### DIFF
--- a/docs/launch/one_pager.md
+++ b/docs/launch/one_pager.md
@@ -10,7 +10,7 @@ Multi-tenant LLM inference on a shared engine is a starvation problem. vLLM's co
 
 Three things engines cannot do internally:
 
-1. **Per-tenant token-bucket rate limiting at the budget gate** — load-bearing mechanism, validated empirically. Quiet-tenant p99 TTFT under contention: 1,585 ms (FIFO) → 61.5 ms (KVWarden token bucket), 1.14× of the solo baseline, A100 + vLLM 0.19.1, 300 s sustained, n=311. Generalized to N=6 tenants at 61.0 ms aggregate p99 (1.13× of solo).
+1. **Per-tenant token-bucket rate limiting at the budget gate** — load-bearing mechanism, validated empirically. Quiet-tenant p99 TTFT under contention: 1,585 ms (FIFO) → 61.5 ms (KVWarden's token bucket), 1.14× of the solo baseline, A100 + vLLM 0.19.1, 300 s sustained, n=311. Generalized to N=6 tenants at 61.0 ms aggregate p99 (1.13× of solo).
 2. **Multi-model lifecycle on a single GPU** — frequency+recency eviction, hot-swap routing, no K8s.
 3. **OpenAI-compatible HTTP API** in front of multiple engines, so app code doesn't change.
 


### PR DESCRIPTION
Read the four target launch docs (show_hn.md, twitter_thread.md, faq.md, one_pager.md) after the mechanical InferGrid to KVWarden rename. The sweep was cleaner than expected — the two names slot into the same grammatical positions, so almost nothing read awkwardly.

One polish change: `one_pager.md` line 13 parenthetical went from "(KVWarden token bucket)" to "(KVWarden's token bucket)" to match the possessive pattern used in the show_hn hero ("KVWarden's per-tenant token-bucket rate limit"). All numbers, caveats, URLs, and structure left untouched.

One sed-miss worth flagging for a follow-up (not touched here because out of scope): `docs/launch/why_not_upstream.md` line 41 reads "not an KVWarden invention" — the article "an" was correct before "InferGrid" but "KVWarden" takes "a". Trivial fix; leaving it for founder call since the 4-file scope excluded this path.