### PR TITLE
docs(launch): paste-ready artifacts for the 4 user-side blockers

### DIFF
--- a/docs/launch/cold_outreach_template.md
+++ b/docs/launch/cold_outreach_template.md
@@ -1,0 +1,56 @@
+# Cold outreach template — customer discovery interviews
+
+**Purpose:** 20-minute calls with ML engineers and infra leads running multi-tenant LLM inference on shared GPUs. Goal is to validate (or kill) the ICP hypothesis: *small ML teams serving 2-8 models on shared GPUs*. Not a sales call. Not a pitch.
+
+---
+
+## How to customize per recipient
+
+- **Change:** the first sentence's hook — mirror something specific you saw in their job post, GitHub profile, blog, or talk. A name-drop of their stack beats a generic "saw your team is hiring."
+- **Keep constant:** the hero number (1,585 → 61.5 ms), the engine/model (vLLM 0.19.1, Llama-3.1-8B), the ask (20 min, no deck), and the honest framing that you're researching whether the problem shows up in their traffic.
+- **Do NOT say:** "I'd love to demo," "we've built the future of," "beta access," or anything implying a sales motion. No calendar links in the first email — let them propose.
+
+---
+
+## The email (5 sentences)
+
+**Subject:** quick question on multi-tenant vLLM at [company]
+
+Hi [name],
+
+I'm a solo engineer researching how small ML teams handle tenant fairness when a few models share one GPU — I just shipped a reproducible measurement where, on vLLM 0.19.1 serving Llama-3.1-8B on one A100, a quiet user's p99 TTFT drops from 1,585 ms to 61.5 ms once a per-tenant rate limit sits at the admission gate. I'm trying to figure out whether that starvation pattern shows up in real production traffic, or whether I've only found a benchmark artifact. You look like someone who'd actually know: you [one-sentence specific observation from their work — e.g., "run inference for multiple customer models at [company]" or "maintain [open-source router]"]. Could I steal 20 minutes to ask about your setup — no deck, no pitch, just questions? If the answer is no that's fine, and if the answer is yes I'll send a Google Meet for whatever slot works.
+
+Thanks,
+Shrey Patel
+patelshrey77@gmail.com — https://kvwarden.org
+
+---
+
+## Target-list scaffolding — 10 patterns to look for
+
+Don't hunt for specific names yet — build the list by scanning these patterns. Aim for ~30 candidates, then trim to the 10 you have the most specific hook for.
+
+1. **Startups mentioning vLLM or SGLang in their job posts.** Search LinkedIn or Wellfound for "vLLM" / "SGLang" in the last 90 days. Multi-tenant signal = they list "multi-model" or "customer-specific" serving.
+2. **Open-source maintainers of multi-model routers or gateways.** GitHub search for repos tagged `llm-gateway`, `model-router`, `inference-proxy` with ≥50 stars and commits in the last 30 days.
+3. **ML infra teams at Series A/B companies serving multiple customers' models.** Think fine-tuning-as-a-service, model-hosting, voice / agent platforms — anyone where each customer has "their" model.
+4. **Founding engineers at AI-product startups that moved off OpenAI.** Blog posts titled "why we moved off OpenAI" or "our self-hosted LLM stack" tend to name the engineer.
+5. **Authors of public inference benchmarks or cost comparisons.** If someone published a "we benchmarked vLLM at X RPS" writeup in the last 6 months, they have real traffic and opinions.
+6. **Contributors to vLLM / SGLang / TensorRT-LLM scheduler code.** Pull the last 50 merged PRs on each repo — contributors who touched scheduler or admission logic are the ones who'll push back on your hypothesis, which is what you want.
+7. **ML platform leads at mid-size AI labs (not FAANG).** 50-500 person companies where one person owns the serving stack. Too small and they use OpenAI; too big and they have a dedicated infra team with their own opinions.
+8. **Founders of voice-AI, agent-platform, or copilot companies.** Multi-tenant is structural for them — every customer gets their own fine-tune or agent policy.
+9. **Developer-experience engineers at LLM API resellers.** OpenRouter-adjacent companies, Together-adjacent, Fireworks-adjacent. They have tenant fairness as a first-class concern.
+10. **Authors on LinkedIn / Twitter of "how we run N models on one GPU" posts.** Tactical blog posts from the last 12 months. The author already self-identified as someone who thinks about this problem.
+
+---
+
+## After they reply
+
+- If they agree: send a Google Meet link for the slot they proposed. No prep doc. Show up with three open questions: *what does tenant isolation look like in your traffic today? what's the failure mode that actually pages you? if I gave you a knob for per-tenant rate limits at admission, what would you want it to do?*
+- If they ghost: one follow-up after 7 days. One more after 14. Then drop it.
+- If they say "sounds interesting but too busy": ask if there's someone on their team who owns serving. Warm intro is worth 10x a cold one.
+
+---
+
+## Tracking
+
+Keep one spreadsheet. Columns: name, company, role, hook (the specific thing you mentioned), date sent, date replied, call date, notes, follow-up status. Review weekly. A 15% reply rate is good; below 5% means the hook isn't specific enough.

--- a/docs/launch/demo_video_script.md
+++ b/docs/launch/demo_video_script.md
@@ -1,0 +1,141 @@
+# 30-second terminal demo — Show HN
+
+Two variants below. **Pick one before filming.** The GPU-live variant is more honest (real numbers in real time) but requires a running A100 or equivalent. The dry-run variant uses `kvwarden bench reproduce-hero --flavor=2tenant` against a locally running vLLM and is filmable on a laptop talking to a remote engine — or on any box where the bench harness can stream pre-recorded results.
+
+---
+
+## Recording guidance (both variants)
+
+- **Resolution:** 1920x1080. Higher looks like a flex and compresses worse on Twitter.
+- **Terminal:** dark theme (anything dark — iTerm2 "Solarized Dark", Alacritty default, Ghostty "Catppuccin Mocha"). Light theme washes out in social-media previews.
+- **Font:** JetBrains Mono or Berkeley Mono, 18pt. Big enough that someone reading on a phone can see it without pinching.
+- **Window size:** 100 columns x 30 rows. Captures the full bench output without wrapping.
+- **Capture tool:** `asciinema rec` for a terminal-native recording (embeddable on Show HN / the LP), plus a screen recorder (macOS: Cmd-Shift-5, "Record Selected Portion") for the 30-second MP4 that Twitter / YouTube will accept. Record both in one take.
+- **No personal info on screen:** hide the shell prompt's hostname and user. Set `PS1='$ '` before recording. Close any tabs/panes showing `patelshrey77`, email, Slack, personal dotfiles.
+- **What the frame contains:** the terminal rectangle and nothing else. No desktop, no menu bar, no dock. On macOS, full-screen the terminal (Ctrl-Cmd-F) or use the record-rectangle tool to crop to the terminal bounds.
+- **Voiceover:** record separately. Read at a normal pace. Re-record until the timing matches the on-screen action within ±1 second per block.
+
+---
+
+# Variant A — GPU-live (pick this if you have an A100 up)
+
+Assumes kvwarden is already built and a vLLM engine is running on a reachable GPU at `$ENGINE_URL`. Preflight — not part of the recording:
+
+```bash
+# off-camera: start vLLM
+vllm serve meta-llama/Llama-3.1-8B-Instruct --host 0.0.0.0 --port 8000
+# off-camera: start kvwarden
+kvwarden serve --config configs/gate2_fairness_token_bucket.yaml
+```
+
+## Voiceover + screen — 30s in 5-second blocks
+
+### 0:00-0:05
+**Voiceover:** "One A100. One Llama-3.1-8B engine. Two tenants sharing it."
+**Terminal command:**
+```bash
+$ watch -n 1 'curl -s localhost:9000/metrics | grep kvwarden_p99'
+```
+**Viewer sees:** a live-updating metrics panel showing `kvwarden_p99_ttft_ms{tenant="quiet"}` and `...{tenant="flooder"}` both near baseline.
+
+### 0:05-0:10
+**Voiceover:** "I start the flooder at 32 requests per second. Watch the quiet tenant."
+**Terminal command (new pane or tmux split):**
+```bash
+$ kvwarden bench run --flooder-rps=32 --quiet-rps=1 --duration=60s
+```
+**Viewer sees:** the bench kicks off; the metrics panel shows `kvwarden_p99_ttft_ms{tenant="quiet"}` climbing sharply past 1000ms within 10 seconds.
+
+### 0:10-0:15
+**Voiceover:** "Under vanilla FIFO, the quiet tenant's p99 TTFT hits sixteen hundred milliseconds. Starved."
+**Terminal:** nothing new typed.
+**Viewer sees:** the quiet-tenant p99 line stabilizes around 1500-1600ms while the flooder line sits near 200ms. The contrast is the whole point — one line is red-colored by `grep --color` or by dashboard styling.
+
+### 0:15-0:20
+**Voiceover:** "Now I flip on kvwarden's per-tenant rate limit at the admission gate. One YAML field."
+**Terminal command:**
+```bash
+$ kvwarden config set tenants.flooder.rate_limit_rps=4 && kvwarden reload
+```
+**Viewer sees:** a short log line `[kvwarden] reloaded config in 12ms, admission policy: token-bucket`. The metrics panel is still running.
+
+### 0:20-0:25
+**Voiceover:** "Quiet tenant recovers in under two seconds. Sixty-one milliseconds p99. One-point-one-four times solo baseline."
+**Terminal:** nothing new typed.
+**Viewer sees:** the quiet-tenant p99 line drops sharply from ~1500ms to ~60ms within the visible frame. Flooder line stays flat.
+
+### 0:25-0:30
+**Voiceover:** "Ten lines of YAML. No application code. `pip install kvwarden`."
+**Terminal command:**
+```bash
+$ pip install kvwarden
+```
+**Viewer sees:** pip output flashing briefly (use `--quiet` if it's too noisy), ending on `Successfully installed kvwarden-0.1.0`. Cut to black / kvwarden.org card.
+
+---
+
+# Variant B — dry-run (pick this if no GPU is up)
+
+Uses `kvwarden bench reproduce-hero --flavor=2tenant` pointed at a locally running vLLM. The hero bench replays the validated Gate 2-FAIRNESS measurement and prints a side-by-side comparison against the published numbers. Ships with the CLI — no remote GPU needed if you have an engine reachable, and the harness degrades gracefully with a mock engine for demo purposes.
+
+Preflight (off-camera):
+```bash
+# off-camera: any reachable vLLM at $ENGINE_URL, or the shipped mock
+pip install kvwarden
+```
+
+## Voiceover + screen — 30s in 5-second blocks
+
+### 0:00-0:05
+**Voiceover:** "This is the starvation fix kvwarden ships. I'll replay it live in thirty seconds."
+**Terminal command:**
+```bash
+$ pip install kvwarden
+```
+**Viewer sees:** pip install flashing past, ending on `Successfully installed kvwarden-0.1.0`. If already installed, `Requirement already satisfied` is fine.
+
+### 0:05-0:10
+**Voiceover:** "One command spins up the reproducible hero bench — 2 tenants on Llama-3.1-8B, vLLM 0.19.1."
+**Terminal command:**
+```bash
+$ kvwarden bench reproduce-hero --flavor=2tenant
+```
+**Viewer sees:** startup banner — "KVWarden hero reproduction — 2tenant, 32 RPS flooder, 1 RPS quiet, 300s", plus a rich progress bar with ETA.
+
+### 0:10-0:15
+**Voiceover:** "Under vanilla FIFO, quiet-tenant p99 is sixteen hundred milliseconds. That's the baseline."
+**Terminal:** no new input. The progress bar advances.
+**Viewer sees:** a live-updating table with columns `tenant | condition | p99 TTFT | ref`. The `fifo / quiet` row shows `1585 ms` next to `ref: 1585 ms`.
+
+### 0:15-0:20
+**Voiceover:** "Flip on per-tenant rate limits at admission. Same workload. Same engine."
+**Terminal:** still no new input — the bench runs the next phase automatically.
+**Viewer sees:** the table adds a `token-bucket / quiet` row showing the p99 dropping in real time: 1200ms, 600ms, 200ms, 61ms. The delta column lights up green.
+
+### 0:20-0:25
+**Voiceover:** "Sixty-one-point-five milliseconds. Within one-point-one-four times of solo baseline. Twenty-six-x recovery."
+**Terminal:** no new input.
+**Viewer sees:** final comparison panel — side-by-side reference vs. observed numbers, all green checks. `OVERALL: CONFIRMS reference within tolerance.`
+
+### 0:25-0:30
+**Voiceover:** "Ten lines of YAML. No application code. kvwarden.org."
+**Terminal command:**
+```bash
+$ open https://kvwarden.org
+```
+**Viewer sees:** a brief flash of the LP, then fade to black.
+
+---
+
+## Post-production
+
+- **Add captions.** Social autoplay is muted by default. Burn in the voiceover as captions or use a clean sans-serif overlay (Inter, 24pt, white with 40% black drop shadow). 30 seconds of captions is about 75 words — the voiceover above is within that budget.
+- **End card:** logo + kvwarden.org + "pip install kvwarden" in large text. 2 seconds. Static.
+- **Output formats:** export 1:1 square (1080x1080) for Twitter/LinkedIn autoplay, and 16:9 (1920x1080) for YouTube / Hacker News embeds. Same source take, two crops.
+- **File size:** keep under 10MB for the square cut so it plays natively in Twitter. H.264, 30fps, CRF 23 is the sweet spot.
+
+## Which variant to record
+
+- **Default: Variant A (GPU-live).** If an A100 is up and the engine is stable, this is more persuasive — the numbers move in real time and the viewer sees the fix land.
+- **Fallback: Variant B (dry-run).** If the GPU is down or unreliable, the reproduce-hero flow is already validated and the numbers are truthful replays of published measurements. Acceptable for a Show HN; note "reproduced from Gate 2-FAIRNESS, reference v3" in the caption.
+- **Don't mix.** Pick one. Mixing a mock and a live demo in the same take looks sloppy.

--- a/docs/launch/pypi_reservation.md
+++ b/docs/launch/pypi_reservation.md
@@ -1,0 +1,54 @@
+# PyPI reservation — `kvwarden` stub
+
+## When to run this
+
+**Before Show HN.** The moment the new brand is public — even a tweet — someone will try to `pip install kvwarden` and find nothing, and a squatter can claim the name in the window between the rename becoming visible and the real 0.1.0 release. Ship the 0.0.1 placeholder first so the name is yours before any traffic arrives.
+
+Quick checklist before you run the script:
+- You're logged into PyPI as `patelshrey77@gmail.com`.
+- You have a PyPI API token ready — create at https://pypi.org/manage/account/token/. Scope it to "Entire account" for this first upload; narrow to "Project: kvwarden" after the project page exists.
+- You're OK with this being publicly visible the moment the upload finishes. PyPI does not offer private packages.
+
+## One-liner
+
+```bash
+TWINE_USERNAME=__token__ TWINE_PASSWORD=pypi-<your-token> \
+  ./scripts/publish_kvwarden_stub.sh
+```
+
+Or run it without env vars and twine will prompt:
+
+```bash
+./scripts/publish_kvwarden_stub.sh
+# username: __token__
+# password: pypi-<your-token>
+```
+
+The script works in a temp directory and cleans itself up. It does not modify `src/kvwarden/` or anything else in this repo.
+
+## After the upload
+
+1. **Verify the project page renders.** Visit https://pypi.org/project/kvwarden/ and confirm: the description mentions https://kvwarden.org, the version is 0.0.1, the author email is right, the license is MIT. If any of that is wrong, fix the pyproject template in the script and re-upload as 0.0.2.
+2. **Optionally add a longer README via the PyPI web UI.** Not required — the 0.0.1 README is already a one-liner pointing at kvwarden.org. Skip this unless you want the project page to look less barren before launch.
+3. **Confirm `pip install kvwarden` works.** From a fresh venv, run `pip install kvwarden` and `python -c "import kvwarden; print(kvwarden.__version__)"`. Should print `0.0.1`. This is the squatter-proof.
+4. **Tag the PyPI token as used once.** If you created an "Entire account" token for this upload, revoke it now and create a new one scoped to "Project: kvwarden" for future uploads.
+
+## Bumping to 0.1.0 when the real release ships
+
+When the real package is ready to ship from this repo:
+
+1. Bump `pyproject.toml` in the main tree: `version = "0.1.0"`. (The 0.0.1 stub does not block a 0.1.0 upload — PyPI versions are ordered, not gated.)
+2. Build and upload from the repo root:
+   ```bash
+   python -m build
+   python -m twine upload dist/*
+   ```
+3. The project page at pypi.org/project/kvwarden/ will update to 0.1.0. The 0.0.1 wheel stays queryable via `pip install kvwarden==0.0.1` but `pip install kvwarden` will resolve to 0.1.0.
+4. If you want to hide 0.0.1, mark it yanked in the PyPI web UI — it stays installable by version pin but disappears from the resolver for unpinned installs. Not required; most projects leave placeholder versions visible.
+
+## Troubleshooting
+
+- **`HTTPError: 403 Forbidden`** — the token is wrong or not scoped to upload. Regenerate a token with "Entire account" scope for the first upload.
+- **`HTTPError: 400 File already exists`** — a version with this name + version number was already uploaded. Bump to 0.0.2 in the script and re-run.
+- **`build` fails with `setuptools.build_meta` missing** — your Python is very old; upgrade to 3.11+.
+- **The script runs but nothing appears on pypi.org** — check https://pypi.org/manage/projects/ logged in; sometimes propagation takes 60 seconds.

--- a/docs/naming/email_samuel_bell.md
+++ b/docs/naming/email_samuel_bell.md
@@ -1,27 +1,25 @@
-# Draft email to Samuel Bell (kvwarden.net)
+# Email to Samuel Bell (infergrid.net)
 
-**Status:** draft. Do not send until the rename sweep has landed on `main` and `kvwarden.org` is live. Send from `patelshrey77@gmail.com`.
+**Status:** ready to send. The rename sweep has landed on `main`, `kvwarden.org` is live, and the public launch artifacts carry the new name. Send from `patelshrey77@gmail.com`.
 
-**Contact discovery:** Samuel's site lists a Calendly handle (`samueljamesbell`) but no public email. Reasonable lookups:
+**Contact discovery:** Samuel's site lists a Calendly handle (`samueljamesbell`) but no public email. Reasonable lookups, in order:
 - His GitHub profile (https://github.com/samueljamesbell) — check the public email there first.
-- His Cambridge / FAIR page for an academic email. Prefer the academic address over the FAIR address for a non-work-hours note.
-- If nothing public surfaces, book a 15-min Calendly slot and send the same text as the booking note.
+- His Cambridge / FAIR page for an academic address. Prefer the academic address over a FAIR email for an after-hours, non-corporate note.
+- If nothing public surfaces, book a 15-min Calendly slot and paste the same text as the booking note.
 
-**Subject:** quick heads-up about the KVWarden name
+**Subject:** heads-up on a name collision I already resolved
 
 ---
 
 Hi Samuel,
 
-I hope this lands well. I'm Shrey Patel, an independent engineer working on LLM serving. I wanted to give you a heads-up about something before it potentially becomes awkward.
+I'm Shrey Patel, an independent engineer working on LLM serving. I wanted to flag something short so it doesn't come up sideways later.
 
-I spent the last couple of months building a Python project around multi-tenant fairness on a single GPU, and I had called it KVWarden. I picked the name independently, did a cursory availability check, saw the PyPI name was free and the .org domain was free, and moved forward. I was a few days from a public launch (Show HN, a landing page, a PyPI release) when I ran a more thorough naming audit and found kvwarden.net — your landing page, your Calendly, your product in what looks like a pretty adjacent space. Domain created August 2025, mine didn't go up until April 2026. You have the senior claim under US common-law trademark, and frankly the thesis overlap means any traction on either side would eventually cause user confusion.
+Over the last couple of months I built a Python project around multi-tenant fairness on a single GPU, and I had called it **InferGrid**. I picked the name independently and did a quick availability check, but didn't find infergrid.net on the first pass. A thorough audit before launch turned it up — your landing page, your Calendly, an adjacent product in the inference-cost space, and a domain that predates mine by about eight months. You've got the senior common-law claim and the thesis overlap is real, so I renamed.
 
-I've already renamed to **kvwarden**. The sweep is committed, the domains are bought, the PyPI name is reserved, the old `kvwarden` PyPI package will ship a deprecation stub that points at the new name. No press has the old name yet, and I'm deleting the launch drafts that used it. I'd rather eat the rename cost than have either of us get a C&D later.
+The project is now **kvwarden**, live at https://kvwarden.org, repo at https://github.com/coconut-labs/kvwarden. The sweep is merged, the PyPI name is reserved under the new brand, and the old `infergrid` PyPI package is a deprecation stub pointing at kvwarden. No press carries the old name and I've dropped the launch drafts that did.
 
-No ask here — just wanted you to hear it from me rather than stumble into a cached Google result months from now and wonder what was going on. I think what you're building looks great and I hope it flies.
-
-If you're ever curious about what I landed on — it's at https://kvwarden.org, and the repo is github.com/coconut-labs/kvwarden. Happy to chat if you're ever interested.
+No ask — just wanted you to hear it from me rather than stumble into a cached result months from now. What you're building looks great and I hope it flies.
 
 Cheers,
 Shrey Patel

--- a/docs/naming/email_samuel_bell.md
+++ b/docs/naming/email_samuel_bell.md
@@ -1,6 +1,10 @@
 # Email to Samuel Bell (infergrid.net)
 
-**Status:** ready to send. The rename sweep has landed on `main`, `kvwarden.org` is live, and the public launch artifacts carry the new name. Send from `patelshrey77@gmail.com`.
+**Status:** ready to send *after* the PyPI 0.0.1 stub ships under `kvwarden` and the `infergrid` package has been pushed as a redirect stub (both claims appear in the body below). The rename sweep has landed on `main` and `kvwarden.org` is live. Send from `patelshrey77@gmail.com`.
+
+**Prereqs before sending:**
+- `pip install kvwarden` returns a valid package (run `./scripts/publish_kvwarden_stub.sh` — see `docs/launch/pypi_reservation.md`).
+- `pip install infergrid` still works but the package is a 0.1.3+ deprecation stub whose README points at kvwarden.org. If that's not done yet, drop the phrase "the old `infergrid` PyPI package is a deprecation stub pointing at kvwarden" from the body.
 
 **Contact discovery:** Samuel's site lists a Calendly handle (`samueljamesbell`) but no public email. Reasonable lookups, in order:
 - His GitHub profile (https://github.com/samueljamesbell) — check the public email there first.

--- a/scripts/publish_kvwarden_stub.sh
+++ b/scripts/publish_kvwarden_stub.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# publish_kvwarden_stub.sh — reserve PyPI `kvwarden` with a 0.0.1 placeholder.
+#
+# Run this before Show HN to pre-empt squatters. Does NOT touch src/kvwarden/
+# in this repo. Works in a mktemp dir, cleans up on exit.
+#
+# Auth: set TWINE_USERNAME=__token__ and TWINE_PASSWORD=<pypi-api-token> in
+# your shell, OR leave them unset and twine will prompt. Create a token at
+# https://pypi.org/manage/account/token/ scoped to "Entire account" for the
+# first upload, then narrow to "Project: kvwarden" afterward.
+
+set -euo pipefail
+
+STUB_DIR="$(mktemp -d -t kvwarden-stub-XXXXXX)"
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+echo "[stub] Working in $STUB_DIR"
+cd "$STUB_DIR"
+
+cat > pyproject.toml <<'EOF'
+[project]
+name = "kvwarden"
+version = "0.0.1"
+description = "Tenant-fair LLM inference orchestration on a single GPU. Placeholder — see https://kvwarden.org."
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+authors = [{name = "Shrey Patel", email = "patelshrey77@gmail.com"}]
+keywords = ["llm", "inference", "vllm", "sglang", "multi-tenant", "fairness"]
+classifiers = [
+    "Development Status :: 1 - Planning",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+
+[project.urls]
+Homepage = "https://kvwarden.org"
+Repository = "https://github.com/coconut-labs/kvwarden"
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+EOF
+
+cat > README.md <<'EOF'
+# kvwarden
+
+Placeholder for version 0.0.1. The real package ships with 0.1.0.
+
+See https://kvwarden.org for the current release, benchmarks, and documentation.
+EOF
+
+mkdir -p src/kvwarden
+cat > src/kvwarden/__init__.py <<'EOF'
+"""kvwarden — placeholder package. See https://kvwarden.org."""
+
+__version__ = "0.0.1"
+EOF
+
+echo "[stub] Installing build + twine"
+python -m pip install --quiet --upgrade build twine
+
+echo "[stub] Building sdist + wheel"
+python -m build
+
+echo "[stub] Uploading to PyPI"
+if [ -n "${TWINE_USERNAME:-}" ] && [ -n "${TWINE_PASSWORD:-}" ]; then
+    python -m twine upload dist/*
+else
+    # Interactive prompt — user enters __token__ and the token string.
+    python -m twine upload dist/*
+fi
+
+echo "[stub] Done. Verify at https://pypi.org/project/kvwarden/"


### PR DESCRIPTION
This PR bundles four paste-ready artifacts so the four user-side launch blockers stop being vague homework. `docs/naming/email_samuel_bell.md` is the rewritten courtesy note to Samuel Bell now that kvwarden is live and the rename is public. `docs/launch/cold_outreach_template.md` is a 5-sentence cold email plus a 10-pattern target-list scaffold for customer-discovery interviews with ML infra teams running multi-tenant inference. `scripts/publish_kvwarden_stub.sh` plus `docs/launch/pypi_reservation.md` reserve the PyPI name with a 0.0.1 placeholder in a throwaway temp dir, and `docs/launch/demo_video_script.md` gives two 30-second terminal-demo variants (GPU-live and dry-run via `kvwarden bench reproduce-hero`) so the founder can record whichever fits the environment at the moment of filming. Use each when the corresponding blocker is next on deck; do not merge until reviewed.