### PR TITLE
docs(ops): W1 onboarding scaffolding

### DIFF
--- a/docs/ops/discovery-notes.md
+++ b/docs/ops/discovery-notes.md
@@ -1,0 +1,50 @@
+# Discovery call notes
+
+## How to use this file
+
+One section per 1:1 onboarding call. Append; don't edit earlier entries. Keep it terse — the point is that six weeks from now you can grep this file for "wants cost routing" or "Mixtral 8x22B" and remember which conversation it was. Always ask permission before quoting anyone; default assumption is the notes stay private.
+
+If a call produces a testimonial-worthy line, copy it verbatim into the "Quote-worthy" field and confirm permission in the followup email. Everything here feeds `docs/ops/installs.csv` — after each call, update the matching row.
+
+Template at the bottom of this file. Copy it, paste, fill.
+
+---
+
+## 2026-04-28 — alex chen (example-ai, small vertical SaaS)
+**Role:** solo platform eng, 4-person team, 3 customer tenants + 1 internal eval tenant on 1x A100
+**Tenant setup:** 4 tenants on vllm 0.19.x, Llama-3.1-8B-Instruct, peak ~30 RPS aggregate, bursty
+**Current pain:** one noisy tenant starves the other three during retrieval bursts; tried vllm request priorities but it's per-request not per-tenant
+**Tried before:** nothing real — read the llm-d docs, decided the Kubernetes lift wasn't worth it for a single box
+**kvwarden fit:** yes — exactly the shape we built for. Token-bucket config off the shelf.
+**Install blocker hit:** no — `quickstart_fairness.yaml` worked; had to bump the per-tenant cap once
+**Would pay for support:** maybe — "if this holds for a month we'd consider a $500-1000/mo support line to skip the self-host maintenance"
+**Followup:** send a 7-day check-in email 2026-05-05; share the Grafana dashboard JSON
+**Quote-worthy:** "FIFO starvation was our single biggest support ticket category last quarter. This fixes it." — asked permission, she said yes with name + company
+
+## 2026-04-29 — priya devops (synthco, RAG startup)
+**Role:** eng lead, 6 internal tenants (each an internal product surface) on 2x 4090
+**Tenant setup:** sglang 0.4.x, Qwen2.5-14B, each tenant has different token budgets and quality SLAs
+**Current pain:** new product surface ships every two weeks and capacity planning is done in a spreadsheet; no fairness guarantee means a shipped-Tuesday feature can flatten a shipped-last-month feature
+**Tried before:** homegrown python rate limiter in front of sglang, didn't handle in-flight requests correctly
+**kvwarden fit:** partial — sglang adapter is newer than vllm, some config knobs weren't obviously exposed (max_running_requests surfaces through a different YAML key). Worked it out live.
+**Install blocker hit:** yes — YAML key confusion for the sglang-specific cap; 5 min to resolve on call. Filed follow-up to add a doc note.
+**Would pay for support:** no — internal team, not a commercial fit, but willing to be a design partner for sglang adapter work
+**Followup:** open a docs issue for the sglang YAML key naming mismatch; invite them to the 2026-05-15 sglang adapter feedback call
+**Quote-worthy:** none requested yet — too early
+
+---
+
+## Template (copy this for each new call)
+
+```markdown
+## 2026-MM-DD — firstname lastname (company)
+**Role:** ...
+**Tenant setup:** N tenants, M GPUs, what models
+**Current pain:** (what made them click the waitlist?)
+**Tried before:** Dynamo/llm-d/homegrown/nothing
+**kvwarden fit:** yes / partial / no — and why
+**Install blocker hit:** yes/no — describe
+**Would pay for support:** yes/no/maybe — range if yes
+**Followup:** what I promised to send them, by when
+**Quote-worthy:** any verbatim line I can use (with permission)
+```

--- a/docs/ops/installs.csv
+++ b/docs/ops/installs.csv
@@ -1,0 +1,3 @@
+email,signed_up_at,first_contact_at,onboarded_at,engine,model,gpu,tenant_count,config_used,install_status,7day_check,30day_check,testimonial_ok,paid_interest,notes
+alex@example-ai.com,2026-04-18,2026-04-22,2026-04-28,vllm,Llama-3.1-8B-Instruct,1x A100 80GB,4,configs/quickstart_fairness.yaml,running,n-a,n-a,asked,warm,2026-04-28 onboarded in 28 min; tail latency dropped 4x on FIFO comparison; wants to re-check at 7d mark before quoting
+devops@synthco.io,2026-04-19,2026-04-23,2026-04-29,sglang,Qwen2.5-14B-Instruct,2x RTX 4090,6,configs/gate2_fairness_token_bucket.yaml,running,n-a,n-a,no,none,2026-04-29 install clean; 6 internal tenants for RAG app; not a paid prospect but useful design partner for sglang adapter coverage

--- a/docs/ops/onboarding_playbook.md
+++ b/docs/ops/onboarding_playbook.md
@@ -1,0 +1,87 @@
+# 1:1 onboarding playbook
+
+30-minute Zoom. Goal by minute 30: kvwarden is running against their real traffic and they've seen one graph that proves it. Not a demo, not a deck — their engine, their tenants, a dashboard they can keep.
+
+If you can't get there in 30 min, that's fine — schedule a 15-min followup. What you want to avoid is ending the call with "I'll send you some docs and we'll pick this up later."
+
+---
+
+## Pre-call (ask them to have ready ~10 min before)
+
+Send this in the calendar invite body:
+
+- URL of their vLLM / SGLang / TRT-LLM endpoint (or willingness to screenshare the box)
+- A scratch YAML listing the tenants they want to shape — just tenant names and rough per-tenant RPS / token budgets. No schema needed, pseudocode is fine.
+- SSH access to the inference box **or** readiness to screenshare with a terminal open. Either is fine.
+- Admin perms on the box (sudo or container exec) — the install writes one systemd unit or runs as a sidecar container.
+- 5 minutes of "real-ish" load they can replay or tail, so we can watch a before/after graph. If they don't have load, we'll synthesize it.
+
+If they don't have the endpoint URL by T-minus-5, start the call anyway — you can spend min 0-10 helping them locate it, that's still useful.
+
+---
+
+## Minute 0-5: intro
+
+- Who you are, one sentence: "I'm the founder. I built kvwarden because I watched my last team's inference bill get eaten by one noisy tenant starving everyone else."
+- What 30 minutes buys them: "By the end of this call, kvwarden is running against your engine with your tenants and you'll see whether it helps. If it doesn't, that's useful data for me and you've lost 30 minutes."
+- One question: "Before we go — what does a bad day look like in your current setup?" (This is the real discovery question. Write the answer down verbatim — it goes into `discovery-notes.md`.)
+
+---
+
+## Minute 5-15: diagnose
+
+- Have them run `kvwarden doctor` against their endpoint. This checks version, reachability, tenant detection heuristics, and flags anything weird (wrong vllm version, blocked port, whatever).
+- Pick the closest config template from `configs/` — most users land on one of:
+  - `configs/quickstart_fairness.yaml` — single engine, handful of tenants, no SLA tiers yet. Start here for most first-timers.
+  - `configs/gate2_fairness_token_bucket.yaml` — tenants with clear per-tenant RPS budgets; the reference fairness config from the launch hero.
+  - `configs/gate2_fairness_drr.yaml` — tenants with very different token-size profiles (short chat vs long RAG). DRR handles mixed sizes better than token-bucket.
+  - `configs/gate2_multi_tenant.yaml` — 6+ tenants, want hierarchical fairness.
+- Edit the template live with them — replace the example tenants with their real ones. Don't over-engineer; one per-tenant cap is enough for day one. They can tighten later.
+
+If `kvwarden doctor` flags something the playbook doesn't cover, capture it in `discovery-notes.md` as "Install blocker hit: yes" and either fix it in-call or promise a patch by next morning.
+
+---
+
+## Minute 15-25: stand up and watch
+
+- Start kvwarden as a sidecar to their engine (same box, same network namespace is easiest).
+- Point their client traffic at kvwarden's port instead of the engine's. If they're nervous, run both side-by-side with 10% mirrored traffic first.
+- Run a brief `reproduce-hero` equivalent — the `docs/reproduce_hero.md` script against their setup, scaled down if their hardware is smaller. Or just watch their real traffic tail for 3-5 minutes.
+- Pull up the Grafana dashboard (JSON in `docs/grafana/`) — the one they want to see is per-tenant p95 latency with the fairness toggle. When the graph moves, they'll notice before you point it out.
+
+If the graph doesn't move: their workload may not be saturated. That's fine — note it, promise a followup once they have real load, move on.
+
+---
+
+## Minute 25-30: capture and close
+
+- Lock the next check-in date. Default: 7-day check-in email + 14-day Zoom. Put it on the calendar live.
+- Ask for permission to quote them if they said something quotable. Exact phrasing: "Can I quote the thing you said about FIFO starvation, with your name and company?" Most say yes.
+- Confirm the testimonial ask explicitly — getting a "yes, you can ask me again in 30 days" is a real answer.
+- Thank them, end the call on time. Going over feels polite but the next call is in 30 min and you need write-up time.
+
+---
+
+## Post-call (next 24 hours)
+
+- Write the `docs/ops/discovery-notes.md` entry. Do this first, while the call is warm.
+- Update the matching row in `docs/ops/installs.csv` — set `onboarded_at`, `install_status`, `config_used`.
+- Send the followup email with whatever you promised (dashboard JSON, docs link, patch). Under-promise during the call, over-deliver in the email.
+- If a doc gap surfaced, file an issue. Don't fix it at 11pm.
+
+---
+
+## Red flags — abort the call politely
+
+Not every waitlist signup is a fit. The following mean kvwarden is the wrong tool and the founder should route them elsewhere and move on. Don't try to retrofit the pitch:
+
+- **"I want an OpenRouter-style hosted SaaS where I pay per token and don't run my own GPUs."** Route to OpenRouter / Together / Fireworks. kvwarden is self-hosted middleware; there's no hosted tier and won't be for the foreseeable future.
+- **"I want routing by cost across providers (GPT-4 vs Claude vs open-source)."** Route to LiteLLM or Portkey. kvwarden is about fairness inside a single engine, not cross-provider routing.
+- **"We have 100+ tenants on a multi-node Kubernetes cluster with autoscaling."** Route to llm-d or NVIDIA Dynamo. kvwarden's sweet spot is 1-10 boxes and <20 tenants; above that the datacenter tools are the right answer and you'll be fighting their strengths.
+- **"I just want a better load balancer across replicas."** Route to a plain nginx/envoy setup or the engine's built-in LB. kvwarden is per-tenant fairness, not replica balancing.
+
+Polite exit script: "Honestly, the tool for that is [X], not kvwarden. We're deliberately narrow — single-to-few-box fairness for teams with a handful of tenants. Happy to intro you to the [X] folks if useful." This protects both sides: they don't waste a week installing the wrong thing, and you don't get a bad 7-day check-in from someone who was never a fit.
+
+---
+
+The goal is 10 of these in W1. If you can't get to 10 because of inbound volume, run them sequentially and queue the rest for W2 — don't rush the quality of the first ones to chase the count.

--- a/docs/ops/weekly-retros.md
+++ b/docs/ops/weekly-retros.md
@@ -1,0 +1,63 @@
+# Weekly retros — kvwarden 90-day sprint
+
+One section per week, written every Friday EOD. The self-check line is the important one — it's the part of the ritual that stops activity theater from eating a week. Be honest with yourself, not performatively harsh.
+
+Rules:
+- Write it before you close the laptop Friday. Not Monday morning.
+- The "one sentence" line goes into the founder brain-dump doc; keep it short enough that future-you can skim 13 of them in one screen.
+- If "slipped" is empty every week, your plan is too conservative — name something.
+
+---
+
+## Week 1 (2026-04-27 → 2026-05-03)
+
+**Planned (from god-planner plan):**
+- 10 real installs of kvwarden surviving 7 days
+- All via 1:1 Zoom onboardings from the waitlist
+- Every call produces a `discovery-notes.md` entry + an `installs.csv` row
+
+**Shipped:**
+- (fill Friday 2026-05-03)
+
+**Slipped:**
+- (fill Friday 2026-05-03)
+
+**Installs this week:** _ new, _ surviving 7-day mark
+**Discovery calls:** _ conducted
+**Revenue conversations:** _
+**Activity theater self-check:** did I do anything that didn't trace to an install, a call, or a feature? If yes, what and why.
+
+**Next week's top 3:**
+1.
+2.
+3.
+
+**One sentence for the founder brain-dump:**
+
+---
+
+## Template (copy this for Week 2+)
+
+```markdown
+## Week N (2026-MM-DD → 2026-MM-DD)
+**Planned (from god-planner plan):**
+- ...
+
+**Shipped:**
+- ...
+
+**Slipped:**
+- ...
+
+**Installs this week:** N new, M surviving 7-day mark
+**Discovery calls:** N conducted
+**Revenue conversations:** N
+**Activity theater self-check:** did I do anything that didn't trace to an install, a call, or a feature? If yes, what and why.
+
+**Next week's top 3:**
+1.
+2.
+3.
+
+**One sentence for the founder brain-dump:**
+```


### PR DESCRIPTION
Four plain text files under docs/ops/ to run the W1 onboarding Zooms: installs.csv for the tracking spreadsheet, discovery-notes.md for 1:1 call notes, weekly-retros.md for the Friday retro ritual, and onboarding_playbook.md for the 30-min call structure including abort conditions.

All templates have seeded synthetic examples so the pattern is obvious on first read. Nothing here touches src/, configs/, or docs/launch/ — this is pure ops scaffolding.

Don't merge yet — review the playbook's red-flag section and the CSV columns first, those are the ones that'll be hardest to change once there's real data in them.