### PR TITLE
chore: tighten tautological docstrings (#106, #110)

### DIFF
--- a/src/kvwarden/cache/manager.py
+++ b/src/kvwarden/cache/manager.py
@@ -88,7 +88,12 @@ class TierStats:
 
     @property
     def utilization(self) -> float:
-        """Fraction of tier capacity in use."""
+        """Fraction of tier capacity in use, in [0.0, 1.0].
+
+        Clamps to 1.0 if `used_gb > capacity_gb` (transient over-allocation
+        during eviction). Returns 0.0 when `capacity_gb <= 0` to avoid
+        ZeroDivisionError on disabled tiers.
+        """
         if self.capacity_gb <= 0:
             return 0.0
         return min(self.used_gb / self.capacity_gb, 1.0)
@@ -408,7 +413,6 @@ class CacheManager:
         return counts
 
     def total_blocks(self) -> int:
-        """Return total number of tracked cache blocks."""
         return len(self._blocks)
 
     def hit_rate(self) -> float:
@@ -455,7 +459,6 @@ class CacheManager:
         return (num_tokens * self._bytes_per_token) / (1024**3)
 
     def _tier_used_gb(self, tier: str) -> float:
-        """Compute current usage in GB for a tier."""
         total_tokens = sum(
             self._blocks[bid].num_tokens
             for bid in self._tier_blocks.get(tier, set())

--- a/src/kvwarden/router/router.py
+++ b/src/kvwarden/router/router.py
@@ -118,7 +118,10 @@ class ModelState:
 
     @property
     def avg_latency_s(self) -> float:
-        """Average request latency in seconds."""
+        """Lifetime mean request latency in seconds. 0.0 before any request completes.
+
+        Cumulative — not a rolling window. Resets only when the model is unloaded.
+        """
         if self.request_count == 0:
             return 0.0
         return self.total_latency_s / self.request_count
@@ -962,14 +965,15 @@ class WorkloadRouter:
     # ------------------------------------------------------------------
 
     def loaded_models(self) -> list[str]:
-        """Return list of currently loaded model IDs."""
         return list(self._models.keys())
 
     def model_stats(self) -> dict[str, dict[str, Any]]:
-        """Return per-model statistics.
+        """Per-model snapshot used by `kvwarden status` and the /status endpoint.
 
-        Returns:
-            Dictionary mapping model_id to stats dict.
+        Each value carries: engine, port, request_count, avg_latency_s (rounded
+        to 4dp), eviction_score (frequency × recency-decay), healthy bit, and
+        uptime_s since the model was loaded. Snapshot is taken at call time,
+        not streamed — repeat calls are independent.
         """
         now = time.monotonic()
         stats: dict[str, dict[str, Any]] = {}
@@ -986,10 +990,13 @@ class WorkloadRouter:
         return stats
 
     def queue_depths(self) -> dict[str, int]:
-        """Return current queue depths per bucket.
+        """Pending-request count per scheduling bucket.
 
-        Returns:
-            Dictionary mapping bucket name to queue size.
+        Buckets are length-bucketed asyncio queues — short prompts and long
+        prompts are scheduled separately so a long-prompt backlog doesn't
+        block short-prompt latency. Bucket names are the keys configured in
+        `WorkloadRouter._queues`. Returns sizes from `Queue.qsize()`, which
+        is approximate under concurrent enqueue/dequeue.
         """
         return {name: q.qsize() for name, q in self._queues.items()}
 


### PR DESCRIPTION
Closes #106. Closes #110.

7 sites total — bundled both issues since they're identical patterns in different files. No code refactoring.

**router.py**
- `avg_latency_s` — rewrite. Calls out cumulative-not-rolling and the 0.0 sentinel.
- `loaded_models` — dropped. Name + return type cover it.
- `model_stats` — rewrite. Lists the actual fields the dict carries (engine, port, request_count, avg_latency_s, eviction_score, healthy, uptime_s) and snapshot semantics.
- `queue_depths` — rewrite. Explains length-bucketed scheduling (the only non-obvious thing here) and the `qsize()` approximate-under-concurrency caveat.

**cache/manager.py**
- `TierStats.utilization` — rewrite. Documents the `[0.0, 1.0]` clamp and the `capacity_gb <= 0` → 0.0 guard.
- `total_blocks` — dropped. Pure accessor.
- `_tier_used_gb` — dropped. Internal helper, signature speaks.

## Verify

- `ruff check` + `ruff format --check` clean on both files.
- `pytest` deltas relative to `main`: zero. Same 2 pre-existing failures (`test_allocate_port_returns_available` port>65535 OverflowError, `test_benchmark_client.py` aiohttp setup errors) on both `main` and this branch — both unrelated to docstrings.