### PR TITLE
feat(cache): T2 signature stub — TenantPolicy + tenant_id surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: pytest tests/unit/
         run: pytest tests/unit/ -v --tb=short
 
+      - name: pytest tests/integration/
+        run: pytest tests/integration/ -v --tb=short
+
   lint:
     name: lint (ruff)
     runs-on: ubuntu-latest

--- a/src/kvwarden/cache/__init__.py
+++ b/src/kvwarden/cache/__init__.py
@@ -1,5 +1,5 @@
 """KVWarden KV cache management with tiered eviction."""
 
-from kvwarden.cache.manager import CacheBlock, CacheManager, TierStats
+from kvwarden.cache.manager import CacheBlock, CacheManager, TenantPolicy, TierStats
 
-__all__ = ["CacheBlock", "CacheManager", "TierStats"]
+__all__ = ["CacheBlock", "CacheManager", "TenantPolicy", "TierStats"]

--- a/src/kvwarden/cache/manager.py
+++ b/src/kvwarden/cache/manager.py
@@ -24,6 +24,23 @@ TIER_ORDER: list[str] = ["gpu", "cpu", "ssd"]
 
 
 @dataclass
+class TenantPolicy:
+    """Tenant-weight policy for KV eviction (T2 — issue #103).
+
+    Currently a no-op surface — the API is reserved so test fixtures and the
+    Gate 3 bench config can be written before the W4-W6 implementation lands.
+    See `docs/rfcs/T2-tenant-aware-eviction.md` for the locked semantics.
+
+    `tenant_weights` will eventually scale a block's `reuse_score` by the
+    block's `tenant_id` weight (default 1.0 for unknown tenants), so a flooder
+    tenant's blocks score down under eviction pressure. Default empty dict =
+    LRU-equivalent behavior; passing `None` to `reuse_score` does the same.
+    """
+
+    tenant_weights: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
 class CacheBlock:
     """Metadata for a single KV cache block.
 
@@ -36,6 +53,7 @@ class CacheBlock:
         access_count: Total number of accesses.
         last_access_time: Monotonic timestamp of last access.
         created_time: Monotonic timestamp of creation.
+        tenant_id: Originating tenant (T2 — None until the hot path tags blocks).
     """
 
     block_id: str
@@ -46,6 +64,7 @@ class CacheBlock:
     access_count: int = 1
     last_access_time: float = field(default_factory=time.monotonic)
     created_time: float = field(default_factory=time.monotonic)
+    tenant_id: str | None = None
 
     def reuse_score(
         self,
@@ -53,20 +72,28 @@ class CacheBlock:
         freq_weight: float = 0.7,
         recency_weight: float = 0.3,
         decay_half_life_s: float = 300.0,
+        *,
+        policy: TenantPolicy | None = None,
     ) -> float:
         """Compute predicted reuse score (higher = more likely to be reused).
 
         Uses frequency * exponential-decay(recency) rather than naive LRU.
+
+        T2 (issue #103): `policy` is the surface for tenant-weighted eviction.
+        Currently ignored — the implementation lands W4-W6 after the RFC closes.
+        Callers passing `policy=None` get the legacy behavior.
 
         Args:
             now: Current monotonic time.
             freq_weight: Weight for the frequency component.
             recency_weight: Weight for the recency component.
             decay_half_life_s: Half-life in seconds for the recency decay.
+            policy: Tenant-weight policy (T2 — reserved, no-op until W4).
 
         Returns:
             Non-negative score; higher means keep longer.
         """
+        del policy  # T2 — ignored until W4-W6.
         age_s = max(now - self.last_access_time, 0.001)
         decay = math.exp(-math.log(2) * age_s / decay_half_life_s)
 
@@ -160,6 +187,8 @@ class CacheManager:
         request_id: str,
         num_tokens: int,
         tier: str = "gpu",
+        *,
+        tenant_id: str | None = None,
     ) -> CacheBlock | None:
         """Allocate a new cache block in the specified tier.
 
@@ -173,6 +202,8 @@ class CacheManager:
             request_id: Originating request ID.
             num_tokens: Tokens to store.
             tier: Preferred tier ("gpu", "cpu", "ssd").
+            tenant_id: Originating tenant (T2 — currently optional; the hot
+                path will start tagging blocks in W4-W6).
 
         Returns:
             The allocated CacheBlock, or None if no tier has space.
@@ -183,12 +214,16 @@ class CacheManager:
         tier_idx = TIER_ORDER.index(tier) if tier in TIER_ORDER else 0
         for t in TIER_ORDER[tier_idx:]:
             if self._tier_used_gb(t) + needed_gb <= self._capacities.get(t, 0):
-                return self._place_block(block_id, model_id, request_id, num_tokens, t)
+                return self._place_block(
+                    block_id, model_id, request_id, num_tokens, t, tenant_id=tenant_id
+                )
 
             # Try evicting from this tier
             evicted = self._evict_from_tier(t, needed_gb)
             if evicted:
-                return self._place_block(block_id, model_id, request_id, num_tokens, t)
+                return self._place_block(
+                    block_id, model_id, request_id, num_tokens, t, tenant_id=tenant_id
+                )
 
         logger.warning(
             "No tier has space for block %s (%d tokens)", block_id, num_tokens
@@ -326,7 +361,13 @@ class CacheManager:
     # Eviction
     # ------------------------------------------------------------------
 
-    def _evict_from_tier(self, tier: str, needed_gb: float) -> bool:
+    def _evict_from_tier(
+        self,
+        tier: str,
+        needed_gb: float,
+        *,
+        policy: TenantPolicy | None = None,
+    ) -> bool:
         """Evict lowest-scored blocks from a tier to free space.
 
         Evicted blocks are demoted to the next-lower tier if possible,
@@ -335,6 +376,8 @@ class CacheManager:
         Args:
             tier: Tier to evict from.
             needed_gb: Space needed in GB.
+            policy: Tenant-weight policy passed through to `reuse_score`
+                (T2 — currently a no-op; the W4-W6 implementation will use it).
 
         Returns:
             True if enough space was freed.
@@ -348,7 +391,10 @@ class CacheManager:
         scored = sorted(
             tier_block_ids,
             key=lambda bid: self._blocks[bid].reuse_score(
-                now, self._freq_weight, self._recency_weight
+                now,
+                self._freq_weight,
+                self._recency_weight,
+                policy=policy,
             ),
         )
 
@@ -470,6 +516,8 @@ class CacheManager:
         request_id: str,
         num_tokens: int,
         tier: str,
+        *,
+        tenant_id: str | None = None,
     ) -> CacheBlock:
         """Place a block in a tier (internal helper, no capacity check)."""
         now = time.monotonic()
@@ -482,6 +530,7 @@ class CacheManager:
             access_count=1,
             last_access_time=now,
             created_time=now,
+            tenant_id=tenant_id,
         )
         self._blocks[block_id] = block
         self._tier_blocks[tier].add(block_id)

--- a/src/kvwarden/cache/manager.py
+++ b/src/kvwarden/cache/manager.py
@@ -25,16 +25,21 @@ TIER_ORDER: list[str] = ["gpu", "cpu", "ssd"]
 
 @dataclass
 class TenantPolicy:
-    """Tenant-weight policy for KV eviction (T2 — issue #103).
+    """Tenant-weight policy for cache-pressure admission (T2 — issue #103).
 
-    Currently a no-op surface — the API is reserved so test fixtures and the
-    Gate 3 bench config can be written before the W4-W6 implementation lands.
-    See `docs/rfcs/T2-tenant-aware-eviction.md` for the locked semantics.
+    No-op surface today. PR #115 reserves the shape so the RFC, test skeleton,
+    and Gate 3 bench config can land in parallel ahead of the W4-W6 wiring.
 
-    `tenant_weights` will eventually scale a block's `reuse_score` by the
-    block's `tenant_id` weight (default 1.0 for unknown tenants), so a flooder
-    tenant's blocks score down under eviction pressure. Default empty dict =
-    LRU-equivalent behavior; passing `None` to `reuse_score` does the same.
+    Semantics (locked by `docs/rfcs/T2-cache-pressure-admission.md`):
+    `tenant_weights` will multiply per-tenant admission priority **under cache
+    pressure** — NOT eviction order. The earlier eviction framing was wrong:
+    `CacheManager` is a shadow ledger, so block-level reuse_score reordering
+    has no observable effect. Instead, the lever fires when vLLM's
+    `vllm:kv_cache_usage_perc` p99 climbs to ~0.7, at which point the
+    admission gate scales tenant deficit by the per-tenant weight.
+
+    Default empty dict = no scaling = legacy LRU + frequency-decay behavior.
+    `tenant_id` not present in the dict defaults to weight 1.0.
     """
 
     tenant_weights: dict[str, float] = field(default_factory=dict)
@@ -53,7 +58,10 @@ class CacheBlock:
         access_count: Total number of accesses.
         last_access_time: Monotonic timestamp of last access.
         created_time: Monotonic timestamp of creation.
-        tenant_id: Originating tenant (T2 — None until the hot path tags blocks).
+        tenant_id: Originating tenant. Reserved for v0.3 trace-replay
+            analysis; no semantic role in T2's admission-side mechanism
+            (T2 reads the global vLLM cache-usage gauge, not per-block
+            tenant tracking). Field stays for v0.3 utility.
     """
 
     block_id: str
@@ -79,16 +87,18 @@ class CacheBlock:
 
         Uses frequency * exponential-decay(recency) rather than naive LRU.
 
-        T2 (issue #103): `policy` is the surface for tenant-weighted eviction.
-        Currently ignored — the implementation lands W4-W6 after the RFC closes.
-        Callers passing `policy=None` get the legacy behavior.
+        T2 (issue #103): `policy` is a reserved API surface with no semantics
+        in the cache-pressure-admission design — T2's lever lives at the
+        admission gate, not in eviction ordering. Kept on this method for
+        backward compatibility and possible v0.3 use; passing `policy` does
+        nothing today and will continue to do nothing in v0.2.0.
 
         Args:
             now: Current monotonic time.
             freq_weight: Weight for the frequency component.
             recency_weight: Weight for the recency component.
             decay_half_life_s: Half-life in seconds for the recency decay.
-            policy: Tenant-weight policy (T2 — reserved, no-op until W4).
+            policy: Reserved API surface; no-op in T2 (v0.2.0).
 
         Returns:
             Non-negative score; higher means keep longer.
@@ -202,8 +212,9 @@ class CacheManager:
             request_id: Originating request ID.
             num_tokens: Tokens to store.
             tier: Preferred tier ("gpu", "cpu", "ssd").
-            tenant_id: Originating tenant (T2 — currently optional; the hot
-                path will start tagging blocks in W4-W6).
+            tenant_id: Tags blocks for v0.3 per-tenant trace replay. T2's
+                mechanism does NOT read this — admission decisions use the
+                global vLLM cache-usage gauge, not per-block tenant tracking.
 
         Returns:
             The allocated CacheBlock, or None if no tier has space.
@@ -376,8 +387,8 @@ class CacheManager:
         Args:
             tier: Tier to evict from.
             needed_gb: Space needed in GB.
-            policy: Tenant-weight policy passed through to `reuse_score`
-                (T2 — currently a no-op; the W4-W6 implementation will use it).
+            policy: Plumbed through to `reuse_score` for forward-compat.
+                T2 ships no eviction-policy semantics; v0.2.0 leaves this no-op.
 
         Returns:
             True if enough space was freed.


### PR DESCRIPTION
Refs #103.

Reserves the API surface for tenant-aware KV eviction so the RFC, test skeleton, and Gate 3 bench config can land in parallel without merge conflicts. Zero behavior change — `policy=None` and `tenant_id=None` defaults preserve the legacy LRU+frequency-decay path.

## Surface

- New `TenantPolicy` dataclass — `tenant_weights: dict[str, float]`, no-op until W4-W6.
- `CacheBlock.tenant_id: str | None = None`.
- `CacheBlock.reuse_score(*, policy=...)` accepts and ignores the policy (`del policy` annotation in body — explicit no-op until W4).
- `CacheManager.allocate_block(*, tenant_id=...)` tags the block.
- `CacheManager._place_block` plumbs `tenant_id` into the dataclass.
- `CacheManager._evict_from_tier(*, policy=...)` passes policy through to `reuse_score`.
- `kvwarden.cache.__init__` re-exports `TenantPolicy`.

## Why this lands first

Unblocks three parallel sub-agents with disjoint write surfaces:
- **R** writes `docs/rfcs/T2-tenant-aware-eviction.md` (semantics)
- **T** writes `tests/unit/test_tenant_aware_reuse_score.py` + `tests/unit/test_tenant_policy.py` + `tests/integration/test_cache_manager_hot_path.py` against the API in this PR (semantic tests `xfail` until W4, wiring tests `skip` until W4)
- **B** writes `configs/gate3_kv_eviction.yaml` + `docs/runbooks/gate3_kv_eviction.md`

Without this stub, all three agents would touch overlapping signatures and produce merge conflicts.

## CI integration-tests gate

Also adds `pytest tests/integration/` to the CI test job. The integration tests are currently macOS-local-fail (sandbox blocks `socket.bind('127.0.0.1', 0)` — `aiohttp_server` fixture can't allocate a port), but pass on the GitHub Linux runners. Closes the silent-skip credibility gap surfaced during today's audit.

## Verify

- `ruff check` + `ruff format --check` clean.
- 251/252 unit tests pass on this branch. The one failure (`test_allocate_port_returns_available` port>65535 OverflowError) is pre-existing on `main` and unrelated to this change — flagged separately as a side-quest.

## Out of scope

No semantics. The `policy` kwarg is `del`'d in the body. The hot-path wiring (router → cache_manager.allocate_block per request) lands in W4-W6 alongside the policy implementation.