### PR TITLE
chore: post-T2-M1 cleanup — py3.13 CI + troubleshooting matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ First call returns `503` until vLLM finishes loading (30-90 s on A100 for an 8B)
 
 A Docker Compose bundle is not shipping yet — if you want one, [#109](https://github.com/coconut-labs/kvwarden/issues/109) is open as a good-first-issue.
 
+## When it breaks
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `kvwarden doctor` reports "SSL trust unavailable" | macOS stock Python venv missing CA roots | `pip install --upgrade certifi`, then re-run |
+| `/health` returns 503 right after `kvwarden serve` | vLLM JIT-compiling the model (30-90 s for an 8B on A100) | Wait, then `until curl -fs localhost:8000/health; do sleep 2; done` |
+| `/v1/completions` returns 401 | HuggingFace gated-model auth missing | `huggingface-cli login`, or `export HF_TOKEN=...` before `kvwarden serve` |
+| Quiet tenant still starved under flooder | `rate_limit_rpm` too high in config | Drop the per-tenant `rate_limit_rpm` in your config; the hero uses 600 with `rate_limit_burst: 10` |
+| All requests return 429 immediately | `rate_limit_burst` set tighter than your client's burst | Raise `rate_limit_burst` or unset it (default = `rate_limit_rpm`) |
+| vLLM subprocess crashes with CUDA OOM | `gpu_memory_utilization` too high for the loaded model + KV cache | Drop the model's `gpu_memory_utilization` to 0.40 (hero default) and retry |
+| `Address already in use` on port 8000 | Stale daemon or another local service | `kvwarden serve --port 8001`, or `lsof -i :8000` to find the holder |
+| `ModuleNotFoundError: kvwarden` after `pip install kvwarden` | venv mismatch — installed into the wrong interpreter | `python -c "import kvwarden; print(kvwarden.__version__)"` to confirm; reinstall in the venv that runs `kvwarden` |
+| Engine pre-load takes >5 min | First-time model download from HuggingFace | Pre-warm the cache: `huggingface-cli download <model_id>` before `kvwarden serve` |
+
+If your symptom is not in the table, file an issue with the output of `kvwarden doctor` and `kvwarden serve --log-level DEBUG`.
+
 ## Is this for me?
 
 | Tool | Orchestration | Tenant fairness | Engines | Target scale |


### PR DESCRIPTION
Closes #107. Closes #108.

## #107 — Python 3.13 in CI matrix

One-line: `python-version: ["3.11", "3.12", "3.13"]` in `.github/workflows/ci.yml`. The pyproject classifier already advertises 3.13 (added in commit `d3bf81b` after pre-launch QA confirmed install + import + doctor pass on macOS Python 3.13.7). CI was silently testing only 3.11 + 3.12.

## #108 — Troubleshooting matrix in README

9-row table inserted after the Quickstart paragraphs, before "Is this for me?". Covers the failure modes that came out of W1 onboarding QA + launch artifacts pre-flight:

- `doctor` reports SSL trust unavailable → `pip install --upgrade certifi`
- `/health` returns 503 right after `serve` → wait for vLLM JIT (30-90 s on A100 8B)
- `/v1/completions` returns 401 → HuggingFace gated-model auth (`huggingface-cli login` / `HF_TOKEN`)
- Quiet tenant still starved → `rate_limit_rpm` too high in config
- All 429s immediately → `rate_limit_burst` set tighter than client burst
- vLLM OOM → drop `gpu_memory_utilization` to 0.40 (hero default)
- Port 8000 in use → `--port 8001` or `lsof -i :8000`
- `ModuleNotFoundError: kvwarden` → venv mismatch
- Engine pre-load >5 min → first-time HF download; pre-warm with `huggingface-cli download <model_id>`

Footer line points users at `kvwarden doctor` + `--log-level DEBUG` for symptoms not in the table.

Verify: `ruff check src/ tests/` clean, `ruff format --check src/ tests/` clean. README is the only doc changed; no source touched.