### PR TITLE
feat(bench): M4 harness flags — --prefix-overlap + --bias-flooder-cost

### DIFF
--- a/benchmarks/scripts/benchmark_admission.py
+++ b/benchmarks/scripts/benchmark_admission.py
@@ -37,7 +37,7 @@ _project_root = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(_project_root))
 sys.path.insert(0, str(_project_root / "profiling" / "scripts"))
 
-from profiling_utils import (
+from profiling_utils import (  # noqa: E402
     AsyncBenchmarkClient,
     BenchmarkResults,
     GPUMetricsCollector,
@@ -163,7 +163,9 @@ async def run_benchmark(
 
     summary = results.summary()
     logger.info("%s complete in %.1fs:", label, elapsed)
-    logger.info("  Successful: %d / %d", summary.get("num_successful", 0), len(requests))
+    logger.info(
+        "  Successful: %d / %d", summary.get("num_successful", 0), len(requests)
+    )
     logger.info("  TTFT p50: %.1fms", summary.get("ttft_p50_ms", 0))
     logger.info("  TTFT p99: %.1fms", summary.get("ttft_p99_ms", 0))
     logger.info(
@@ -243,7 +245,11 @@ def print_comparison(comparison: dict[str, Any]) -> None:
     print("-" * 70)
 
     for metric, data in improvements.items():
-        label = metric.replace("_", " ").replace("ms", " (ms)").replace("tok per sec", "(tok/s)")
+        label = (
+            metric.replace("_", " ")
+            .replace("ms", " (ms)")
+            .replace("tok per sec", "(tok/s)")
+        )
         direct_val = data.get("direct", 0)
         admission_val = data.get("admission", 0)
         change_pct = data.get("change_pct", 0)

--- a/benchmarks/scripts/benchmark_chat_rag_burst.py
+++ b/benchmarks/scripts/benchmark_chat_rag_burst.py
@@ -105,25 +105,43 @@ _OOM_PAT = re.compile(r"out of memory|cuda oom|cudaerror|allocation", re.IGNOREC
 
 
 async def send_one(
-    session: aiohttp.ClientSession, base_url: str, tenant_id: str,
-    request_id: int, model: str, prompt: str, max_tokens: int, timeout_s: float,
+    session: aiohttp.ClientSession,
+    base_url: str,
+    tenant_id: str,
+    request_id: int,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    timeout_s: float,
 ) -> RequestResult:
     url = f"{base_url}/v1/completions"
-    payload = {"model": model, "prompt": prompt, "max_tokens": max_tokens, "stream": True}
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "stream": True,
+    }
     headers = {"X-Tenant-ID": tenant_id}
     submit = time.time()
     first_token_time: float | None = None
     tokens_out = 0
     try:
         timeout = aiohttp.ClientTimeout(total=timeout_s)
-        async with session.post(url, json=payload, headers=headers, timeout=timeout) as resp:
+        async with session.post(
+            url, json=payload, headers=headers, timeout=timeout
+        ) as resp:
             if resp.status != 200:
                 body = await resp.text()
                 is_oom = bool(_OOM_PAT.search(body))
                 return RequestResult(
-                    tenant=tenant_id, request_id=request_id, submit_time=submit,
-                    ttft_ms=0.0, total_latency_ms=(time.time() - submit) * 1000,
-                    tokens_out=0, http_status=resp.status, is_oom=is_oom,
+                    tenant=tenant_id,
+                    request_id=request_id,
+                    submit_time=submit,
+                    ttft_ms=0.0,
+                    total_latency_ms=(time.time() - submit) * 1000,
+                    tokens_out=0,
+                    http_status=resp.status,
+                    is_oom=is_oom,
                     error=f"HTTP {resp.status}: {body[:120]}",
                 )
             async for line in resp.content:
@@ -151,29 +169,50 @@ async def send_one(
                     continue
     except asyncio.TimeoutError:
         return RequestResult(
-            tenant=tenant_id, request_id=request_id, submit_time=submit,
-            ttft_ms=0.0, total_latency_ms=(time.time() - submit) * 1000,
-            tokens_out=0, error="timeout",
+            tenant=tenant_id,
+            request_id=request_id,
+            submit_time=submit,
+            ttft_ms=0.0,
+            total_latency_ms=(time.time() - submit) * 1000,
+            tokens_out=0,
+            error="timeout",
         )
     except Exception as exc:
         msg = str(exc)
         return RequestResult(
-            tenant=tenant_id, request_id=request_id, submit_time=submit,
-            ttft_ms=0.0, total_latency_ms=(time.time() - submit) * 1000,
-            tokens_out=0, is_oom=bool(_OOM_PAT.search(msg)), error=msg,
+            tenant=tenant_id,
+            request_id=request_id,
+            submit_time=submit,
+            ttft_ms=0.0,
+            total_latency_ms=(time.time() - submit) * 1000,
+            tokens_out=0,
+            is_oom=bool(_OOM_PAT.search(msg)),
+            error=msg,
         )
     end = time.time()
     total_ms = (end - submit) * 1000
-    ttft_ms = (first_token_time - submit) * 1000 if first_token_time is not None else total_ms
+    ttft_ms = (
+        (first_token_time - submit) * 1000 if first_token_time is not None else total_ms
+    )
     return RequestResult(
-        tenant=tenant_id, request_id=request_id, submit_time=submit,
-        ttft_ms=ttft_ms, total_latency_ms=total_ms, tokens_out=tokens_out,
+        tenant=tenant_id,
+        request_id=request_id,
+        submit_time=submit,
+        ttft_ms=ttft_ms,
+        total_latency_ms=total_ms,
+        tokens_out=tokens_out,
     )
 
 
 async def chat_steady_loop(
-    base_url: str, model: str, rps: float, duration_s: float, max_tokens: int,
-    timeout_s: float, session: aiohttp.ClientSession, results: list[RequestResult],
+    base_url: str,
+    model: str,
+    rps: float,
+    duration_s: float,
+    max_tokens: int,
+    timeout_s: float,
+    session: aiohttp.ClientSession,
+    results: list[RequestResult],
 ) -> None:
     rng = random.Random(42)
     end = time.time() + duration_s
@@ -182,21 +221,42 @@ async def chat_steady_loop(
     interarrival = 1.0 / rps
     while time.time() < end:
         prompt = rng.choice(CHAT_PROMPTS)
-        in_flight.append(asyncio.create_task(send_one(
-            session, base_url, "chat", rid, model, prompt, max_tokens, timeout_s,
-        )))
+        in_flight.append(
+            asyncio.create_task(
+                send_one(
+                    session,
+                    base_url,
+                    "chat",
+                    rid,
+                    model,
+                    prompt,
+                    max_tokens,
+                    timeout_s,
+                )
+            )
+        )
         rid += 1
         await asyncio.sleep(rng.expovariate(1.0 / interarrival))
     for t in asyncio.as_completed(in_flight, timeout=timeout_s + 10):
-        try: results.append(await t)
-        except Exception as e: logger.warning("chat drain: %s", e)
+        try:
+            results.append(await t)
+        except Exception as e:
+            logger.warning("chat drain: %s", e)
 
 
 async def rag_burst_loop(
-    base_url: str, model: str, burst_rps: float, burst_dur_s: float,
-    idle_s: float, n_bursts: int, max_tokens: int, prompt_tokens: int,
-    timeout_s: float, session: aiohttp.ClientSession,
-    results: list[RequestResult], start_offset_s: float = 0.0,
+    base_url: str,
+    model: str,
+    burst_rps: float,
+    burst_dur_s: float,
+    idle_s: float,
+    n_bursts: int,
+    max_tokens: int,
+    prompt_tokens: int,
+    timeout_s: float,
+    session: aiohttp.ClientSession,
+    results: list[RequestResult],
+    start_offset_s: float = 0.0,
 ) -> None:
     rng = random.Random(123)
     rid = 0
@@ -206,21 +266,39 @@ async def rag_burst_loop(
     interarrival = 1.0 / burst_rps
     for burst_idx in range(n_bursts):
         burst_end = time.time() + burst_dur_s
-        logger.info("RAG burst %d/%d starts (%.0fs of %.0f RPS)",
-                    burst_idx + 1, n_bursts, burst_dur_s, burst_rps)
+        logger.info(
+            "RAG burst %d/%d starts (%.0fs of %.0f RPS)",
+            burst_idx + 1,
+            n_bursts,
+            burst_dur_s,
+            burst_rps,
+        )
         while time.time() < burst_end:
             prompt = _make_long_prompt(rng, prompt_tokens)
-            in_flight.append(asyncio.create_task(send_one(
-                session, base_url, "rag", rid, model, prompt, max_tokens, timeout_s,
-            )))
+            in_flight.append(
+                asyncio.create_task(
+                    send_one(
+                        session,
+                        base_url,
+                        "rag",
+                        rid,
+                        model,
+                        prompt,
+                        max_tokens,
+                        timeout_s,
+                    )
+                )
+            )
             rid += 1
             await asyncio.sleep(rng.expovariate(1.0 / interarrival))
         if burst_idx < n_bursts - 1:
             logger.info("RAG idle %.0fs", idle_s)
             await asyncio.sleep(idle_s)
     for t in asyncio.as_completed(in_flight, timeout=timeout_s + 10):
-        try: results.append(await t)
-        except Exception as e: logger.warning("rag drain: %s", e)
+        try:
+            results.append(await t)
+        except Exception as e:
+            logger.warning("rag drain: %s", e)
 
 
 def summarize(results: list[RequestResult]) -> dict[str, Any]:
@@ -229,9 +307,15 @@ def summarize(results: list[RequestResult]) -> dict[str, Any]:
     oom = [r for r in results if r.is_oom]
     if not ok:
         return {
-            "count_ok": 0, "count_err": len(err), "count_oom": len(oom),
-            "ttft_p50_ms": -1, "ttft_p95_ms": -1, "ttft_p99_ms": -1, "ttft_max_ms": -1,
-            "total_p99_ms": -1, "tokens_out_mean": 0,
+            "count_ok": 0,
+            "count_err": len(err),
+            "count_oom": len(oom),
+            "ttft_p50_ms": -1,
+            "ttft_p95_ms": -1,
+            "ttft_p99_ms": -1,
+            "ttft_max_ms": -1,
+            "total_p99_ms": -1,
+            "tokens_out_mean": 0,
         }
     ttfts = sorted(r.ttft_ms for r in ok)
     totals = sorted(r.total_latency_ms for r in ok)
@@ -241,7 +325,9 @@ def summarize(results: list[RequestResult]) -> dict[str, Any]:
         return xs[min(n - 1, max(0, int(q * n)))]
 
     return {
-        "count_ok": n, "count_err": len(err), "count_oom": len(oom),
+        "count_ok": n,
+        "count_err": len(err),
+        "count_oom": len(oom),
         "ttft_p50_ms": round(p(ttfts, 0.50), 1),
         "ttft_p95_ms": round(p(ttfts, 0.95), 1),
         "ttft_p99_ms": round(p(ttfts, 0.99), 1),
@@ -264,21 +350,42 @@ async def main_async(args: argparse.Namespace) -> int:
 
     logger.info(
         "Bench: chat=%s @ %.1f RPS steady, rag=%s burst %dx (%.0fs at %.1f RPS, %.0fs idle), prompt=%d tok",
-        args.chat_model, args.chat_rps, args.rag_model,
-        args.n_bursts, args.burst_dur_s, args.burst_rps, args.idle_s, args.rag_prompt_tokens,
+        args.chat_model,
+        args.chat_rps,
+        args.rag_model,
+        args.n_bursts,
+        args.burst_dur_s,
+        args.burst_rps,
+        args.idle_s,
+        args.rag_prompt_tokens,
     )
 
     start_wall = time.time()
     async with aiohttp.ClientSession(connector=connector) as session:
         await asyncio.gather(
             chat_steady_loop(
-                args.url, args.chat_model, args.chat_rps, args.duration_s,
-                args.chat_max_tokens, args.timeout_s, session, chat_results,
+                args.url,
+                args.chat_model,
+                args.chat_rps,
+                args.duration_s,
+                args.chat_max_tokens,
+                args.timeout_s,
+                session,
+                chat_results,
             ),
             rag_burst_loop(
-                args.url, args.rag_model, args.burst_rps, args.burst_dur_s,
-                args.idle_s, args.n_bursts, args.rag_max_tokens, args.rag_prompt_tokens,
-                args.timeout_s, session, rag_results, args.rag_start_offset_s,
+                args.url,
+                args.rag_model,
+                args.burst_rps,
+                args.burst_dur_s,
+                args.idle_s,
+                args.n_bursts,
+                args.rag_max_tokens,
+                args.rag_prompt_tokens,
+                args.timeout_s,
+                session,
+                rag_results,
+                args.rag_start_offset_s,
             ),
         )
     wall_s = time.time() - start_wall
@@ -286,7 +393,9 @@ async def main_async(args: argparse.Namespace) -> int:
     for tenant, results in [("chat", chat_results), ("rag", rag_results)]:
         path = outdir / f"tenant_{tenant}.csv"
         with open(path, "w", newline="") as fh:
-            writer = csv.DictWriter(fh, fieldnames=list(RequestResult.__dataclass_fields__.keys()))
+            writer = csv.DictWriter(
+                fh, fieldnames=list(RequestResult.__dataclass_fields__.keys())
+            )
             writer.writeheader()
             for r in results:
                 writer.writerow(asdict(r))
@@ -297,10 +406,14 @@ async def main_async(args: argparse.Namespace) -> int:
         "chat": summarize(chat_results),
         "rag": summarize(rag_results),
         "bench_args": {
-            "chat_model": args.chat_model, "rag_model": args.rag_model,
-            "chat_rps": args.chat_rps, "burst_rps": args.burst_rps,
-            "burst_dur_s": args.burst_dur_s, "idle_s": args.idle_s,
-            "n_bursts": args.n_bursts, "duration_s": args.duration_s,
+            "chat_model": args.chat_model,
+            "rag_model": args.rag_model,
+            "chat_rps": args.chat_rps,
+            "burst_rps": args.burst_rps,
+            "burst_dur_s": args.burst_dur_s,
+            "idle_s": args.idle_s,
+            "n_bursts": args.n_bursts,
+            "duration_s": args.duration_s,
             "rag_prompt_tokens": args.rag_prompt_tokens,
         },
     }
@@ -311,11 +424,17 @@ async def main_async(args: argparse.Namespace) -> int:
     logger.info("=" * 60)
     logger.info(
         "CHAT n=%d err=%d oom=%d  ttft_p99=%sms",
-        c["count_ok"], c["count_err"], c["count_oom"], c["ttft_p99_ms"],
+        c["count_ok"],
+        c["count_err"],
+        c["count_oom"],
+        c["ttft_p99_ms"],
     )
     logger.info(
         "RAG  n=%d err=%d oom=%d  ttft_p99=%sms",
-        r["count_ok"], r["count_err"], r["count_oom"], r["ttft_p99_ms"],
+        r["count_ok"],
+        r["count_err"],
+        r["count_oom"],
+        r["ttft_p99_ms"],
     )
     logger.info("=" * 60)
     return 0

--- a/benchmarks/scripts/benchmark_multi_model.py
+++ b/benchmarks/scripts/benchmark_multi_model.py
@@ -37,16 +37,12 @@ _SCRIPT_DIR = Path(__file__).resolve().parent
 _PROFILING_SCRIPTS = _SCRIPT_DIR.parent.parent / "profiling" / "scripts"
 sys.path.insert(0, str(_PROFILING_SCRIPTS))
 
-from profiling_utils import (
-    AsyncBenchmarkClient,
-    BenchmarkResults,
+from profiling_utils import (  # noqa: E402
     GPUMetricsCollector,
     RequestGenerator,
-    RequestMetrics,
     TimingContext,
     check_engine_health,
     log_environment,
-    prompts_to_requests,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,9 +53,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def build_alternating_schedule(
-    models: list[str], num_requests: int
-) -> list[str]:
+def build_alternating_schedule(models: list[str], num_requests: int) -> list[str]:
     """Produce model names in strict round-robin order.
 
     Args:
@@ -72,9 +66,7 @@ def build_alternating_schedule(
     return [models[i % len(models)] for i in range(num_requests)]
 
 
-def build_bursty_schedule(
-    models: list[str], pattern: list[int]
-) -> list[str]:
+def build_bursty_schedule(models: list[str], pattern: list[int]) -> list[str]:
     """Produce model names following a bursty pattern.
 
     Example pattern [100, 100, 50] with 2 models means:
@@ -183,10 +175,9 @@ class MultiModelBenchmarkResults:
         ttft_all = np.array([r.ttft_ms for r in successful])
         latency_all = np.array([r.total_latency_ms for r in successful])
         total_tokens_out = sum(r.tokens_out for r in successful)
-        total_duration_s = (
-            max(r.timestamp + r.total_latency_ms / 1000.0 for r in successful)
-            - min(r.timestamp for r in successful)
-        )
+        total_duration_s = max(
+            r.timestamp + r.total_latency_ms / 1000.0 for r in successful
+        ) - min(r.timestamp for r in successful)
 
         result: dict[str, Any] = {
             "scenario": self.scenario,
@@ -241,8 +232,6 @@ class MultiModelBenchmarkResults:
 
         # GPU memory tracking
         if self.gpu_metrics_df is not None and not self.gpu_metrics_df.empty:
-            import pandas as pd
-
             df = self.gpu_metrics_df
             # Use per-GPU data (not aggregate "all")
             if "gpu_index" in df.columns:
@@ -378,7 +367,7 @@ class MultiModelBenchmarkClient:
         phase_name = getattr(self, "phase_name", "unknown")
         consec_errors = 0
         aborted_after: int | None = None
-        ABORT_THRESHOLD = 5
+        ABORT_THRESHOLD = 5  # noqa: N806 — module-level-style constant scoped to this method
 
         # Default TCPConnector caps simultaneous connections per host at 100,
         # which silently clamps any bench run with concurrency > 100. For
@@ -398,11 +387,13 @@ class MultiModelBenchmarkClient:
                     if isinstance(req, dict)
                     else self.max_tokens
                 )
-                tasks.append(asyncio.create_task(
-                    self._send_request(
-                        session, i, model, prompt, max_tokens, semaphore
+                tasks.append(
+                    asyncio.create_task(
+                        self._send_request(
+                            session, i, model, prompt, max_tokens, semaphore
+                        )
                     )
-                ))
+                )
             raw_metrics: list[MultiModelRequestMetrics] = []
             for fut in asyncio.as_completed(tasks):
                 m = await fut
@@ -413,7 +404,9 @@ class MultiModelBenchmarkClient:
                         aborted_after = consec_errors
                         logger.warning(
                             "phase=%s c=%d ABORT %d consecutive errors",
-                            phase_name, self.concurrency, consec_errors,
+                            phase_name,
+                            self.concurrency,
+                            consec_errors,
                         )
                         for t in tasks:
                             if not t.done():
@@ -514,9 +507,7 @@ class MultiModelBenchmarkClient:
 
             try:
                 timeout = aiohttp.ClientTimeout(total=self.timeout_s)
-                async with session.post(
-                    url, json=payload, timeout=timeout
-                ) as resp:
+                async with session.post(url, json=payload, timeout=timeout) as resp:
                     if resp.status != 200:
                         error_body = await resp.text()
                         return MultiModelRequestMetrics(
@@ -570,8 +561,12 @@ class MultiModelBenchmarkClient:
                             continue
 
             except asyncio.TimeoutError:
-                logger.warning("req=%d MODEL=%s TIMEOUT after %.0fs",
-                               request_id, model, time.time() - start_time)
+                logger.warning(
+                    "req=%d MODEL=%s TIMEOUT after %.0fs",
+                    request_id,
+                    model,
+                    time.time() - start_time,
+                )
                 return MultiModelRequestMetrics(
                     model=model,
                     request_id=request_id,
@@ -613,7 +608,11 @@ class MultiModelBenchmarkClient:
 
             logger.info(
                 "req=%d MODEL=%s DONE tokens_out=%d latency_ms=%.0f ttft_ms=%.0f",
-                request_id, model, tokens_out, total_latency_ms, ttft_ms,
+                request_id,
+                model,
+                tokens_out,
+                total_latency_ms,
+                ttft_ms,
             )
 
             return MultiModelRequestMetrics(
@@ -656,8 +655,12 @@ async def benchmark_model_switch_latency(
         Dictionary with switch latency statistics.
     """
     gen = RequestGenerator(seed=seed)
-    warmup_requests = gen.generate_fixed_length(num_warmup, input_len=128, output_len=64)
-    switch_requests = gen.generate_fixed_length(num_switches * 2, input_len=256, output_len=128)
+    warmup_requests = gen.generate_fixed_length(
+        num_warmup, input_len=128, output_len=64
+    )
+    switch_requests = gen.generate_fixed_length(
+        num_switches * 2, input_len=256, output_len=128
+    )
 
     model_a, model_b = models[0], models[1]
     switch_latencies: list[float] = []
@@ -891,7 +894,8 @@ async def benchmark_eviction_policy(
         eviction_result["gpu_memory_mean_mb"] = float(df["memory_used_mb"].mean())
 
     logger.info(
-        "Eviction policy results: %s", json.dumps(eviction_result, indent=2, default=str)
+        "Eviction policy results: %s",
+        json.dumps(eviction_result, indent=2, default=str),
     )
     return eviction_result
 
@@ -929,7 +933,14 @@ def parse_args() -> argparse.Namespace:
         "--workload",
         type=str,
         default="all",
-        choices=["alternating", "bursty", "concurrent", "switch_latency", "eviction", "all"],
+        choices=[
+            "alternating",
+            "bursty",
+            "concurrent",
+            "switch_latency",
+            "eviction",
+            "all",
+        ],
         help="Which workload scenario to run",
     )
     parser.add_argument(
@@ -1020,15 +1031,24 @@ async def main() -> None:
     # works for any N >= 1 (single-model is the realistic Gate 1 setup).
     # `switch_latency`, `alternating`, `bursty`, `eviction` compare across
     # models and need at least two.
-    SINGLE_MODEL_OK_WORKLOADS = {"concurrent"}
-    requested = {args.workload} if args.workload != "all" else {
-        "switch_latency", "alternating", "bursty", "concurrent", "eviction",
-    }
+    SINGLE_MODEL_OK_WORKLOADS = {"concurrent"}  # noqa: N806 — config-style constant in main()
+    requested = (
+        {args.workload}
+        if args.workload != "all"
+        else {
+            "switch_latency",
+            "alternating",
+            "bursty",
+            "concurrent",
+            "eviction",
+        }
+    )
     if len(models) < 2 and not requested.issubset(SINGLE_MODEL_OK_WORKLOADS):
         logger.error(
             "Need at least 2 models for workloads %s. Got %d model(s); "
             "for single-model runs use --workload concurrent.",
-            sorted(requested - SINGLE_MODEL_OK_WORKLOADS), len(models),
+            sorted(requested - SINGLE_MODEL_OK_WORKLOADS),
+            len(models),
         )
         sys.exit(1)
 
@@ -1079,7 +1099,13 @@ async def main() -> None:
 
     # Determine which workloads to run
     if args.workload == "all":
-        workloads_to_run = ["switch_latency", "alternating", "bursty", "concurrent", "eviction"]
+        workloads_to_run = [
+            "switch_latency",
+            "alternating",
+            "bursty",
+            "concurrent",
+            "eviction",
+        ]
     else:
         workloads_to_run = [args.workload]
 
@@ -1119,8 +1145,7 @@ async def main() -> None:
 
     # ----- Benchmarks 2-4: Workload scenarios at each concurrency -----
     throughput_workloads = [
-        w for w in workloads_to_run
-        if w in ("alternating", "bursty", "concurrent")
+        w for w in workloads_to_run if w in ("alternating", "bursty", "concurrent")
     ]
 
     for workload_name in throughput_workloads:

--- a/benchmarks/scripts/benchmark_n_tenant_single_model.py
+++ b/benchmarks/scripts/benchmark_n_tenant_single_model.py
@@ -36,9 +36,10 @@ import logging
 import random
 import sys
 import time
+from collections import deque
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Deque
 
 import aiohttp
 
@@ -110,9 +111,7 @@ def parse_prompt_length_dist(spec: str) -> list[tuple[int, float]]:
                 f"--prompt-length-dist: non-numeric probability {prob_str!r}"
             ) from exc
         if length <= 0:
-            raise ValueError(
-                f"--prompt-length-dist: non-positive length {length}"
-            )
+            raise ValueError(f"--prompt-length-dist: non-positive length {length}")
         if prob < 0:
             raise ValueError(
                 f"--prompt-length-dist: negative probability {prob} for length {length}"
@@ -171,6 +170,95 @@ def make_legacy_sampler() -> PromptSampler:
     return _sample
 
 
+# Issue #120: --prefix-overlap shared-prefix workload generator
+# ---------------------------------------------------------------------------
+# Wraps any PromptSampler with probabilistic prepending of a shared prefix.
+# The shared prefix is generated once at sampler-construction time using
+# RequestGenerator.generate_fixed_length so vLLM's tokenizer + prefix cache
+# can actually share the resulting tokens across requests. Per-call decisions
+# are seeded independently of length sampling so prefix decisions stay
+# reproducible even if the active sampler's rng usage shifts.
+
+
+def build_shared_prefix(shared_prefix_tokens: int, seed: int) -> str:
+    """Build a single shared prefix string for prefix-overlap workloads.
+
+    Reuses the same realistic-token-shaped path the mixed-length sampler
+    uses (`RequestGenerator.generate_fixed_length`), so vLLM's tokenizer
+    sees a coherent prefix that the engine's prefix cache can de-duplicate.
+    """
+    from profiling_utils import RequestGenerator
+
+    gen = RequestGenerator(seed=seed)
+    batch = gen.generate_fixed_length(1, shared_prefix_tokens, output_len=64)
+    return batch[0]["prompt"]
+
+
+def make_prefix_overlap_sampler(
+    inner: PromptSampler,
+    shared_prefix: str,
+    overlap_fraction: float,
+    seed: int,
+) -> PromptSampler:
+    """Wrap ``inner`` so each draw prepends ``shared_prefix`` w.p. ``overlap_fraction``.
+
+    The wrapper draws from a NEW Random seeded by ``seed`` so prefix
+    decisions are reproducible AND independent of the inner sampler's
+    length-sampling rng stream. The (prompt, length) length tracking is
+    preserved unchanged — the bench's CSV column already records sampled
+    length (not actual length), so we don't re-count the prefix tokens.
+    """
+    decision_rng = random.Random(seed)
+    suffix = " "  # space separator between shared prefix and per-request prompt
+
+    def _sample(arrival_rng: random.Random) -> tuple[str, int]:
+        prompt, length = inner(arrival_rng)
+        if decision_rng.random() < overlap_fraction:
+            return shared_prefix + suffix + prompt, length
+        return prompt, length
+
+    return _sample
+
+
+# Issue #122: --bias-flooder-cost simulated-saturation rate-throttle
+# ---------------------------------------------------------------------------
+# Bench-side simulation of what a cache-pressure-aware admission controller
+# would do at the server side: when the flooder has emitted more than N
+# requests in the last bias-window-s seconds, multiply the inter-arrival
+# sleep by MULTIPLIER to throttle the source. This is M4 Arm 2's lever:
+# measures the upper bound on quiet-tenant TTFT improvement that any
+# cache-pressure-aware admission policy could deliver, before writing the
+# real /metrics polling implementation (M5a / M6 Arm 3).
+#
+# FUTURE EXTENSION POINT: the YAML config flag `cache_manager.bias_target`
+# (Arm 2) supports `flooder` today; harness flag is hardcoded to flooder
+# regardless. To support `--bias-target=quiet` (e.g. for inverted-fairness
+# probes), thread `bias_multiplier` / `bias_threshold` / `bias_window_s`
+# through `tenant_poisson_loop` for any tenant — the current call sites
+# already accept the kwargs.
+
+
+def should_apply_bias(
+    timestamps: Deque[float],
+    now: float,
+    threshold: int,
+    window_s: float,
+) -> bool:
+    """Return True iff ``timestamps`` has > ``threshold`` entries within window.
+
+    Mutates ``timestamps`` in place: drops entries older than
+    ``now - window_s`` from the left. O(1) amortized per call when stale
+    entries are dropped incrementally each invocation. Empty deque returns
+    False.
+
+    Extracted from the flooder loop so it's testable without a live server.
+    """
+    cutoff = now - window_s
+    while timestamps and timestamps[0] < cutoff:
+        timestamps.popleft()
+    return len(timestamps) > threshold
+
+
 @dataclass
 class RequestResult:
     tenant: str
@@ -187,25 +275,42 @@ class RequestResult:
 
 
 async def send_one(
-    session: aiohttp.ClientSession, base_url: str, tenant_id: str,
-    request_id: int, model: str, prompt: str, max_tokens: int, timeout_s: float,
+    session: aiohttp.ClientSession,
+    base_url: str,
+    tenant_id: str,
+    request_id: int,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    timeout_s: float,
     prompt_tokens: int = 0,
 ) -> RequestResult:
     url = f"{base_url}/v1/completions"
-    payload = {"model": model, "prompt": prompt, "max_tokens": max_tokens, "stream": True}
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "stream": True,
+    }
     headers = {"X-Tenant-ID": tenant_id}
     submit = time.time()
     first_token_time: float | None = None
     tokens_out = 0
     try:
         timeout = aiohttp.ClientTimeout(total=timeout_s)
-        async with session.post(url, json=payload, headers=headers, timeout=timeout) as resp:
+        async with session.post(
+            url, json=payload, headers=headers, timeout=timeout
+        ) as resp:
             if resp.status != 200:
                 body = await resp.text()
                 return RequestResult(
-                    tenant=tenant_id, request_id=request_id, submit_time=submit,
-                    ttft_ms=0.0, total_latency_ms=(time.time() - submit) * 1000,
-                    tokens_out=0, prompt_tokens=prompt_tokens,
+                    tenant=tenant_id,
+                    request_id=request_id,
+                    submit_time=submit,
+                    ttft_ms=0.0,
+                    total_latency_ms=(time.time() - submit) * 1000,
+                    tokens_out=0,
+                    prompt_tokens=prompt_tokens,
                     error=f"HTTP {resp.status}: {body[:180]}",
                 )
             async for line in resp.content:
@@ -233,33 +338,68 @@ async def send_one(
                     continue
     except asyncio.TimeoutError:
         return RequestResult(
-            tenant=tenant_id, request_id=request_id, submit_time=submit,
-            ttft_ms=0.0, total_latency_ms=(time.time() - submit) * 1000,
-            tokens_out=0, prompt_tokens=prompt_tokens, error="timeout",
+            tenant=tenant_id,
+            request_id=request_id,
+            submit_time=submit,
+            ttft_ms=0.0,
+            total_latency_ms=(time.time() - submit) * 1000,
+            tokens_out=0,
+            prompt_tokens=prompt_tokens,
+            error="timeout",
         )
     except Exception as exc:
         return RequestResult(
-            tenant=tenant_id, request_id=request_id, submit_time=submit,
-            ttft_ms=0.0, total_latency_ms=(time.time() - submit) * 1000,
-            tokens_out=0, prompt_tokens=prompt_tokens, error=str(exc),
+            tenant=tenant_id,
+            request_id=request_id,
+            submit_time=submit,
+            ttft_ms=0.0,
+            total_latency_ms=(time.time() - submit) * 1000,
+            tokens_out=0,
+            prompt_tokens=prompt_tokens,
+            error=str(exc),
         )
     end = time.time()
     total_ms = (end - submit) * 1000
-    ttft_ms = (first_token_time - submit) * 1000 if first_token_time is not None else total_ms
+    ttft_ms = (
+        (first_token_time - submit) * 1000 if first_token_time is not None else total_ms
+    )
     return RequestResult(
-        tenant=tenant_id, request_id=request_id, submit_time=submit,
-        ttft_ms=ttft_ms, total_latency_ms=total_ms, tokens_out=tokens_out,
+        tenant=tenant_id,
+        request_id=request_id,
+        submit_time=submit,
+        ttft_ms=ttft_ms,
+        total_latency_ms=total_ms,
+        tokens_out=tokens_out,
         prompt_tokens=prompt_tokens,
     )
 
 
 async def tenant_poisson_loop(
-    tenant_id: str, rps: float, duration_s: float,
-    session: aiohttp.ClientSession, base_url: str, model: str,
-    max_tokens: int, timeout_s: float, rng: random.Random,
+    tenant_id: str,
+    rps: float,
+    duration_s: float,
+    session: aiohttp.ClientSession,
+    base_url: str,
+    model: str,
+    max_tokens: int,
+    timeout_s: float,
+    rng: random.Random,
     results: list[RequestResult],
     prompt_sampler: PromptSampler | None = None,
+    *,
+    bias_multiplier: float = 1.0,
+    bias_threshold: int = 0,
+    bias_window_s: float = 30.0,
 ) -> None:
+    """Per-tenant Poisson arrival loop.
+
+    Issue #122: when ``bias_multiplier > 1.0`` AND ``bias_threshold > 0``,
+    the inter-arrival sleep is multiplied by ``bias_multiplier`` while
+    this tenant has emitted more than ``bias_threshold`` requests in the
+    last ``bias_window_s`` seconds (sliding window). State transitions
+    are logged once via ``logger.info``. Quiet tenants are unaffected by
+    leaving the threshold at 0.
+    """
     if rps <= 0:
         return
     sampler = prompt_sampler if prompt_sampler is not None else make_legacy_sampler()
@@ -267,15 +407,59 @@ async def tenant_poisson_loop(
     request_id = 0
     in_flight: list[asyncio.Task[RequestResult]] = []
     mean_interarrival = 1.0 / rps
+
+    # Issue #122: rolling-window emit timestamps for cache-pressure bias sim.
+    bias_enabled = bias_multiplier > 1.0 and bias_threshold > 0
+    emit_times: Deque[float] = deque()
+    in_bias_state = False
+
     while time.time() < end_time:
         prompt, sampled_tokens = sampler(rng)
-        task = asyncio.create_task(send_one(
-            session, base_url, tenant_id, request_id, model, prompt,
-            max_tokens, timeout_s, prompt_tokens=sampled_tokens,
-        ))
+        task = asyncio.create_task(
+            send_one(
+                session,
+                base_url,
+                tenant_id,
+                request_id,
+                model,
+                prompt,
+                max_tokens,
+                timeout_s,
+                prompt_tokens=sampled_tokens,
+            )
+        )
         in_flight.append(task)
         request_id += 1
-        await asyncio.sleep(rng.expovariate(1.0 / mean_interarrival))
+
+        sleep_s = rng.expovariate(1.0 / mean_interarrival)
+        if bias_enabled:
+            now = time.time()
+            emit_times.append(now)
+            apply_bias = should_apply_bias(
+                emit_times, now, bias_threshold, bias_window_s
+            )
+            if apply_bias and not in_bias_state:
+                logger.info(
+                    "tenant=%s entering bias state (>%d reqs in %.1fs window, "
+                    "multiplier=%.2fx)",
+                    tenant_id,
+                    bias_threshold,
+                    bias_window_s,
+                    bias_multiplier,
+                )
+                in_bias_state = True
+            elif not apply_bias and in_bias_state:
+                logger.info(
+                    "tenant=%s exiting bias state (<=%d reqs in %.1fs window)",
+                    tenant_id,
+                    bias_threshold,
+                    bias_window_s,
+                )
+                in_bias_state = False
+            if apply_bias:
+                sleep_s *= bias_multiplier
+
+        await asyncio.sleep(sleep_s)
     for t in asyncio.as_completed(in_flight, timeout=timeout_s + 10):
         try:
             results.append(await t)
@@ -288,9 +472,15 @@ def summarize(results: list[RequestResult]) -> dict[str, Any]:
     errs = [r for r in results if r.error]
     if not ok:
         return {
-            "count_ok": 0, "count_err": len(errs),
-            "ttft_p50_ms": -1, "ttft_p95_ms": -1, "ttft_p99_ms": -1, "ttft_max_ms": -1,
-            "total_p50_ms": -1, "total_p99_ms": -1, "tokens_out_mean": 0,
+            "count_ok": 0,
+            "count_err": len(errs),
+            "ttft_p50_ms": -1,
+            "ttft_p95_ms": -1,
+            "ttft_p99_ms": -1,
+            "ttft_max_ms": -1,
+            "total_p50_ms": -1,
+            "total_p99_ms": -1,
+            "tokens_out_mean": 0,
         }
     ttfts = sorted(r.ttft_ms for r in ok)
     totals = sorted(r.total_latency_ms for r in ok)
@@ -301,7 +491,8 @@ def summarize(results: list[RequestResult]) -> dict[str, Any]:
         return xs[idx]
 
     return {
-        "count_ok": n, "count_err": len(errs),
+        "count_ok": n,
+        "count_err": len(errs),
         "ttft_p50_ms": round(p(ttfts, 0.50), 1),
         "ttft_p95_ms": round(p(ttfts, 0.95), 1),
         "ttft_p99_ms": round(p(ttfts, 0.99), 1),
@@ -327,42 +518,100 @@ async def main_async(args: argparse.Namespace) -> int:
     # Each quiet at quiet_rps × 5s avg + flooder at flooder_rps × 5s avg.
     expected_inflight = (args.flooder_rps + args.num_quiet * args.quiet_rps) * 5
     concurrency_budget = max(256, int(expected_inflight * 3))
-    connector = aiohttp.TCPConnector(limit=concurrency_budget, limit_per_host=concurrency_budget)
+    connector = aiohttp.TCPConnector(
+        limit=concurrency_budget, limit_per_host=concurrency_budget
+    )
 
     logger.info(
         "Bench: 1 flooder @ %.1f RPS + %d quiet @ %.1f RPS each, duration=%ds, model=%s",
-        args.flooder_rps, args.num_quiet, args.quiet_rps, args.duration_s, args.model,
+        args.flooder_rps,
+        args.num_quiet,
+        args.quiet_rps,
+        args.duration_s,
+        args.model,
     )
     logger.info("TCPConnector limit=%d", concurrency_budget)
 
     flooder_results: list[RequestResult] = []
     quiet_results: list[list[RequestResult]] = [[] for _ in range(args.num_quiet)]
 
+    # Issue #120: pre-build the shared prefix once (if --prefix-overlap > 0),
+    # then wrap each per-tenant sampler so all tenants share the same prefix
+    # bytes — that's what lets vLLM's tokenizer + prefix cache de-duplicate
+    # across requests.
+    shared_prefix: str | None = None
+    if args.prefix_overlap > 0.0:
+        shared_prefix = build_shared_prefix(
+            shared_prefix_tokens=args.shared_prefix_tokens,
+            seed=args.seed,
+        )
+        logger.info(
+            "Prefix-overlap enabled: fraction=%.2f, shared_prefix_tokens=%d",
+            args.prefix_overlap,
+            args.shared_prefix_tokens,
+        )
+
     # Per-tenant prompt samplers. Disjoint seed offset (+100) keeps the prompt
     # rng stream independent of the arrival rng, so "same --seed → same
     # prompts" stays stable even if arrival-loop rng usage changes later.
     def sampler_for(tenant_offset: int) -> PromptSampler | None:
+        # Step 1: build the base sampler (legacy or mixed-length).
         if length_pairs is None:
-            return None  # legacy path; tenant_poisson_loop uses make_legacy_sampler
-        return make_mixed_length_sampler(length_pairs, seed=args.seed + 100 + tenant_offset)
+            base: PromptSampler | None = (
+                make_legacy_sampler() if shared_prefix is not None else None
+            )
+        else:
+            base = make_mixed_length_sampler(
+                length_pairs, seed=args.seed + 100 + tenant_offset
+            )
+        # Step 2: wrap with prefix-overlap if requested. Uses a separate seed
+        # offset (+1 from the overlap-decision base) so prefix decisions are
+        # reproducible AND independent of length sampling per the issue spec.
+        if shared_prefix is not None and base is not None:
+            base = make_prefix_overlap_sampler(
+                inner=base,
+                shared_prefix=shared_prefix,
+                overlap_fraction=args.prefix_overlap,
+                seed=args.seed + 1 + tenant_offset,
+            )
+        return base
 
     start_wall = time.time()
     async with aiohttp.ClientSession(connector=connector) as session:
         coros = [
             tenant_poisson_loop(
-                "flooder", args.flooder_rps, args.duration_s,
-                session, args.url, args.model, args.max_tokens, args.timeout_s,
-                random.Random(args.seed), flooder_results,
+                "flooder",
+                args.flooder_rps,
+                args.duration_s,
+                session,
+                args.url,
+                args.model,
+                args.max_tokens,
+                args.timeout_s,
+                random.Random(args.seed),
+                flooder_results,
                 prompt_sampler=sampler_for(0),
+                bias_multiplier=args.bias_flooder_cost,
+                bias_threshold=args.bias_after_n_reqs,
+                bias_window_s=args.bias_window_s,
             ),
         ]
         for i in range(args.num_quiet):
             coros.append(
                 tenant_poisson_loop(
-                    f"quiet_{i}", args.quiet_rps, args.duration_s,
-                    session, args.url, args.model, args.max_tokens, args.timeout_s,
-                    random.Random(args.seed + 1 + i), quiet_results[i],
+                    f"quiet_{i}",
+                    args.quiet_rps,
+                    args.duration_s,
+                    session,
+                    args.url,
+                    args.model,
+                    args.max_tokens,
+                    args.timeout_s,
+                    random.Random(args.seed + 1 + i),
+                    quiet_results[i],
                     prompt_sampler=sampler_for(1 + i),
+                    # Bias is flooder-only by spec; quiet tenants stay at the
+                    # default multiplier=1.0 / threshold=0 (off).
                 )
             )
         await asyncio.gather(*coros)
@@ -374,13 +623,17 @@ async def main_async(args: argparse.Namespace) -> int:
     ]:
         csv_path = outdir / f"tenant_{tenant}.csv"
         with open(csv_path, "w", newline="") as fh:
-            writer = csv.DictWriter(fh, fieldnames=list(RequestResult.__dataclass_fields__.keys()))
+            writer = csv.DictWriter(
+                fh, fieldnames=list(RequestResult.__dataclass_fields__.keys())
+            )
             writer.writeheader()
             for r in results:
                 writer.writerow(asdict(r))
         logger.info("Wrote %s (%d rows)", csv_path, len(results))
 
-    quiet_summaries = {f"quiet_{i}": summarize(quiet_results[i]) for i in range(args.num_quiet)}
+    quiet_summaries = {
+        f"quiet_{i}": summarize(quiet_results[i]) for i in range(args.num_quiet)
+    }
     # Aggregate quiet percentiles across all quiet samples (the launch claim).
     all_quiet = [r for sub in quiet_results for r in sub]
 
@@ -415,10 +668,19 @@ async def main_async(args: argparse.Namespace) -> int:
         "quiet_aggregate": summarize(all_quiet),
         "quiet_per_tenant": quiet_summaries,
         "bench_args": {
-            "flooder_rps": args.flooder_rps, "quiet_rps": args.quiet_rps,
-            "num_quiet": args.num_quiet, "duration_s": args.duration_s,
-            "max_tokens": args.max_tokens, "model": args.model, "seed": args.seed,
+            "flooder_rps": args.flooder_rps,
+            "quiet_rps": args.quiet_rps,
+            "num_quiet": args.num_quiet,
+            "duration_s": args.duration_s,
+            "max_tokens": args.max_tokens,
+            "model": args.model,
+            "seed": args.seed,
             "prompt_length_dist": args.prompt_length_dist or "",
+            "prefix_overlap": args.prefix_overlap,
+            "shared_prefix_tokens": args.shared_prefix_tokens,
+            "bias_flooder_cost": args.bias_flooder_cost,
+            "bias_after_n_reqs": args.bias_after_n_reqs,
+            "bias_window_s": args.bias_window_s,
         },
     }
     if prompt_length_block is not None:
@@ -434,22 +696,100 @@ async def main_async(args: argparse.Namespace) -> int:
     logger.info("=" * 60)
     logger.info(
         "QUIET AGG (n=%d) p50=%sms p99=%sms max=%sms",
-        qa["count_ok"], qa["ttft_p50_ms"], qa["ttft_p99_ms"], qa["ttft_max_ms"],
+        qa["count_ok"],
+        qa["ttft_p50_ms"],
+        qa["ttft_p99_ms"],
+        qa["ttft_max_ms"],
     )
     logger.info(
         "FLOOD     (n=%d) p50=%sms p99=%sms max=%sms",
-        f["count_ok"], f["ttft_p50_ms"], f["ttft_p99_ms"], f["ttft_max_ms"],
+        f["count_ok"],
+        f["ttft_p50_ms"],
+        f["ttft_p99_ms"],
+        f["ttft_max_ms"],
     )
     # Per-tenant fairness — what's the spread across quiet tenants?
-    quiet_p99s = [s["ttft_p99_ms"] for s in quiet_summaries.values() if s["ttft_p99_ms"] > 0]
+    quiet_p99s = [
+        s["ttft_p99_ms"] for s in quiet_summaries.values() if s["ttft_p99_ms"] > 0
+    ]
     if quiet_p99s:
         logger.info(
             "Per-quiet p99 spread: min=%.1f max=%.1f ratio=%.2fx",
-            min(quiet_p99s), max(quiet_p99s),
+            min(quiet_p99s),
+            max(quiet_p99s),
             max(quiet_p99s) / max(min(quiet_p99s), 0.001),
         )
     logger.info("=" * 60)
     return 0
+
+
+def _fraction_in_unit_interval(raw: str) -> float:
+    """argparse type for --prefix-overlap: float in [0.0, 1.0]."""
+    try:
+        v = float(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"--prefix-overlap: not a float: {raw!r}"
+        ) from exc
+    if not (0.0 <= v <= 1.0):
+        raise argparse.ArgumentTypeError(f"--prefix-overlap: {v} outside [0.0, 1.0]")
+    return v
+
+
+def _positive_int(raw: str) -> int:
+    """argparse type for --shared-prefix-tokens: int >= 1."""
+    try:
+        v = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"--shared-prefix-tokens: not an int: {raw!r}"
+        ) from exc
+    if v < 1:
+        raise argparse.ArgumentTypeError(f"--shared-prefix-tokens: {v} must be >= 1")
+    return v
+
+
+def _multiplier_at_least_one(raw: str) -> float:
+    """argparse type for --bias-flooder-cost: float >= 1.0 (1.0 = no bias)."""
+    try:
+        v = float(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"--bias-flooder-cost: not a float: {raw!r}"
+        ) from exc
+    if v < 1.0:
+        raise argparse.ArgumentTypeError(
+            f"--bias-flooder-cost: {v} must be >= 1.0 (1.0 = no bias)"
+        )
+    return v
+
+
+def _non_negative_int(raw: str) -> int:
+    """argparse type for --bias-after-N-reqs: int >= 0 (0 = bias off)."""
+    try:
+        v = int(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"--bias-after-N-reqs: not an int: {raw!r}"
+        ) from exc
+    if v < 0:
+        raise argparse.ArgumentTypeError(
+            f"--bias-after-N-reqs: {v} must be >= 0 (0 = bias never engages)"
+        )
+    return v
+
+
+def _positive_float(raw: str) -> float:
+    """argparse type for --bias-window-s: float > 0."""
+    try:
+        v = float(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"--bias-window-s: not a float: {raw!r}"
+        ) from exc
+    if v <= 0.0:
+        raise argparse.ArgumentTypeError(f"--bias-window-s: {v} must be > 0")
+    return v
 
 
 def main() -> int:
@@ -472,6 +812,59 @@ def main() -> int:
             "'64:0.4,512:0.3,2048:0.2,8192:0.1'. Probabilities must sum to "
             "~1.0 (tolerance 0.001). When unset, the hardcoded short-prompt "
             "list (Gate 2.1 behavior) is used."
+        ),
+    )
+    # Issue #120: shared-prefix workload generator (Gate 3 M4 pre-flight).
+    p.add_argument(
+        "--prefix-overlap",
+        type=_fraction_in_unit_interval,
+        default=0.0,
+        help=(
+            "Fraction of prompts that prepend a shared prefix (issue #120). "
+            "Float in [0.0, 1.0]. 0.0 (default) = behavior unchanged. "
+            "Pre-flight check at docs/runbooks/gate3_kv_eviction.md."
+        ),
+    )
+    p.add_argument(
+        "--shared-prefix-tokens",
+        type=_positive_int,
+        default=1024,
+        help=(
+            "Token length of the shared prefix when --prefix-overlap > 0 "
+            "(issue #120). Default 1024."
+        ),
+    )
+    # Issue #122: simulated saturation bias for Arm 2 upper-bound probe.
+    p.add_argument(
+        "--bias-flooder-cost",
+        type=_multiplier_at_least_one,
+        default=1.0,
+        help=(
+            "Bench-side rate-throttle multiplier applied to the flooder "
+            "tenant's inter-arrival sleep when its rolling-window emit count "
+            "exceeds --bias-after-N-reqs (issue #122). Float >= 1.0; 1.0 "
+            "(default) = no bias. Simulates what a cache-pressure-aware "
+            "admission controller would do at the server side. "
+            "Pre-flight check at docs/runbooks/gate3_kv_eviction.md."
+        ),
+    )
+    p.add_argument(
+        "--bias-after-N-reqs",
+        dest="bias_after_n_reqs",
+        type=_non_negative_int,
+        default=0,
+        help=(
+            "Threshold of flooder requests in the rolling window before bias "
+            "engages (issue #122). Int >= 0; 0 (default) = bias never engages."
+        ),
+    )
+    p.add_argument(
+        "--bias-window-s",
+        type=_positive_float,
+        default=30.0,
+        help=(
+            "Sliding-window length in seconds for counting flooder emits "
+            "(issue #122). Float > 0; default 30.0."
         ),
     )
     args = p.parse_args()

--- a/benchmarks/scripts/benchmark_two_tenant_single_model.py
+++ b/benchmarks/scripts/benchmark_two_tenant_single_model.py
@@ -92,7 +92,12 @@ async def send_one(
 ) -> RequestResult:
     """Send one streaming completion, measure TTFT + total latency."""
     url = f"{base_url}/v1/completions"
-    payload = {"model": model, "prompt": prompt, "max_tokens": max_tokens, "stream": True}
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "stream": True,
+    }
     headers = {"X-Tenant-ID": tenant_id}
 
     submit = time.time()
@@ -101,13 +106,19 @@ async def send_one(
 
     try:
         timeout = aiohttp.ClientTimeout(total=timeout_s)
-        async with session.post(url, json=payload, headers=headers, timeout=timeout) as resp:
+        async with session.post(
+            url, json=payload, headers=headers, timeout=timeout
+        ) as resp:
             if resp.status != 200:
                 body = await resp.text()
                 return RequestResult(
-                    tenant=tenant_id, request_id=request_id, submit_time=submit,
-                    ttft_ms=0.0, total_latency_ms=(time.time() - submit) * 1000,
-                    tokens_out=0, error=f"HTTP {resp.status}: {body[:180]}",
+                    tenant=tenant_id,
+                    request_id=request_id,
+                    submit_time=submit,
+                    ttft_ms=0.0,
+                    total_latency_ms=(time.time() - submit) * 1000,
+                    tokens_out=0,
+                    error=f"HTTP {resp.status}: {body[:180]}",
                 )
             async for line in resp.content:
                 decoded = line.decode("utf-8").strip()
@@ -135,23 +146,37 @@ async def send_one(
                     continue
     except asyncio.TimeoutError:
         return RequestResult(
-            tenant=tenant_id, request_id=request_id, submit_time=submit,
-            ttft_ms=0.0, total_latency_ms=(time.time() - submit) * 1000,
-            tokens_out=0, error="timeout",
+            tenant=tenant_id,
+            request_id=request_id,
+            submit_time=submit,
+            ttft_ms=0.0,
+            total_latency_ms=(time.time() - submit) * 1000,
+            tokens_out=0,
+            error="timeout",
         )
     except Exception as exc:
         return RequestResult(
-            tenant=tenant_id, request_id=request_id, submit_time=submit,
-            ttft_ms=0.0, total_latency_ms=(time.time() - submit) * 1000,
-            tokens_out=0, error=str(exc),
+            tenant=tenant_id,
+            request_id=request_id,
+            submit_time=submit,
+            ttft_ms=0.0,
+            total_latency_ms=(time.time() - submit) * 1000,
+            tokens_out=0,
+            error=str(exc),
         )
 
     end = time.time()
     total_ms = (end - submit) * 1000
-    ttft_ms = (first_token_time - submit) * 1000 if first_token_time is not None else total_ms
+    ttft_ms = (
+        (first_token_time - submit) * 1000 if first_token_time is not None else total_ms
+    )
     return RequestResult(
-        tenant=tenant_id, request_id=request_id, submit_time=submit,
-        ttft_ms=ttft_ms, total_latency_ms=total_ms, tokens_out=tokens_out,
+        tenant=tenant_id,
+        request_id=request_id,
+        submit_time=submit,
+        ttft_ms=ttft_ms,
+        total_latency_ms=total_ms,
+        tokens_out=tokens_out,
     )
 
 
@@ -177,10 +202,18 @@ async def tenant_poisson_loop(
 
     while time.time() < end_time:
         prompt = rng.choice(PROMPTS)
-        task = asyncio.create_task(send_one(
-            session, base_url, tenant_id, request_id, model, prompt,
-            max_tokens, timeout_s,
-        ))
+        task = asyncio.create_task(
+            send_one(
+                session,
+                base_url,
+                tenant_id,
+                request_id,
+                model,
+                prompt,
+                max_tokens,
+                timeout_s,
+            )
+        )
         in_flight.append(task)
         request_id += 1
         await asyncio.sleep(rng.expovariate(1.0 / mean_interarrival))
@@ -199,9 +232,15 @@ def summarize(results: list[RequestResult]) -> dict[str, Any]:
     errs = [r for r in results if r.error]
     if not ok:
         return {
-            "count_ok": 0, "count_err": len(errs),
-            "ttft_p50_ms": -1, "ttft_p95_ms": -1, "ttft_p99_ms": -1, "ttft_max_ms": -1,
-            "total_p50_ms": -1, "total_p99_ms": -1, "tokens_out_mean": 0,
+            "count_ok": 0,
+            "count_err": len(errs),
+            "ttft_p50_ms": -1,
+            "ttft_p95_ms": -1,
+            "ttft_p99_ms": -1,
+            "ttft_max_ms": -1,
+            "total_p50_ms": -1,
+            "total_p99_ms": -1,
+            "tokens_out_mean": 0,
         }
     ttfts = sorted(r.ttft_ms for r in ok)
     totals = sorted(r.total_latency_ms for r in ok)
@@ -231,14 +270,26 @@ async def main_async(args: argparse.Namespace) -> int:
     # Gate 1.5 lesson: raise TCPConnector limits per actual offered concurrency.
     # Flooder 32 RPS × ~5s per-request avg = ~160 in-flight at steady state.
     # Give 3× headroom so we never silently clamp.
-    concurrency_budget = max(256, int((args.flooder_rps + args.quiet_rps) * args.max_tokens * 0.05))
-    connector = aiohttp.TCPConnector(limit=concurrency_budget, limit_per_host=concurrency_budget)
+    concurrency_budget = max(
+        256, int((args.flooder_rps + args.quiet_rps) * args.max_tokens * 0.05)
+    )
+    connector = aiohttp.TCPConnector(
+        limit=concurrency_budget, limit_per_host=concurrency_budget
+    )
 
     logger.info(
         "Bench config: flooder=%.1f RPS, quiet=%.1f RPS, duration=%ds, model=%s, max_tokens=%d",
-        args.flooder_rps, args.quiet_rps, args.duration_s, args.model, args.max_tokens,
+        args.flooder_rps,
+        args.quiet_rps,
+        args.duration_s,
+        args.model,
+        args.max_tokens,
     )
-    logger.info("TCPConnector limit=%d, limit_per_host=%d", concurrency_budget, concurrency_budget)
+    logger.info(
+        "TCPConnector limit=%d, limit_per_host=%d",
+        concurrency_budget,
+        concurrency_budget,
+    )
 
     rng_flooder = random.Random(args.seed)
     rng_quiet = random.Random(args.seed + 1)
@@ -250,22 +301,41 @@ async def main_async(args: argparse.Namespace) -> int:
     async with aiohttp.ClientSession(connector=connector) as session:
         await asyncio.gather(
             tenant_poisson_loop(
-                "flooder", args.flooder_rps, args.duration_s,
-                session, args.url, args.model, args.max_tokens, args.timeout_s,
-                rng_flooder, flooder_results,
+                "flooder",
+                args.flooder_rps,
+                args.duration_s,
+                session,
+                args.url,
+                args.model,
+                args.max_tokens,
+                args.timeout_s,
+                rng_flooder,
+                flooder_results,
             ),
             tenant_poisson_loop(
-                "quiet_user", args.quiet_rps, args.duration_s,
-                session, args.url, args.model, args.max_tokens, args.timeout_s,
-                rng_quiet, quiet_results,
+                "quiet_user",
+                args.quiet_rps,
+                args.duration_s,
+                session,
+                args.url,
+                args.model,
+                args.max_tokens,
+                args.timeout_s,
+                rng_quiet,
+                quiet_results,
             ),
         )
     wall_s = time.time() - start_wall
 
-    for tenant, results in [("flooder", flooder_results), ("quiet_user", quiet_results)]:
+    for tenant, results in [
+        ("flooder", flooder_results),
+        ("quiet_user", quiet_results),
+    ]:
         csv_path = outdir / f"tenant_{tenant}.csv"
         with open(csv_path, "w", newline="") as fh:
-            writer = csv.DictWriter(fh, fieldnames=list(RequestResult.__dataclass_fields__.keys()))
+            writer = csv.DictWriter(
+                fh, fieldnames=list(RequestResult.__dataclass_fields__.keys())
+            )
             writer.writeheader()
             for r in results:
                 writer.writerow(asdict(r))
@@ -276,9 +346,12 @@ async def main_async(args: argparse.Namespace) -> int:
         "flooder": summarize(flooder_results),
         "quiet_user": summarize(quiet_results),
         "bench_args": {
-            "flooder_rps": args.flooder_rps, "quiet_rps": args.quiet_rps,
-            "duration_s": args.duration_s, "max_tokens": args.max_tokens,
-            "model": args.model, "seed": args.seed,
+            "flooder_rps": args.flooder_rps,
+            "quiet_rps": args.quiet_rps,
+            "duration_s": args.duration_s,
+            "max_tokens": args.max_tokens,
+            "model": args.model,
+            "seed": args.seed,
         },
     }
     summary_path = outdir / "summary.json"
@@ -292,11 +365,19 @@ async def main_async(args: argparse.Namespace) -> int:
     logger.info("=" * 60)
     logger.info(
         "QUIET TTFT  p50=%sms p99=%sms max=%sms (n=%s, err=%s)",
-        q["ttft_p50_ms"], q["ttft_p99_ms"], q["ttft_max_ms"], q["count_ok"], q["count_err"],
+        q["ttft_p50_ms"],
+        q["ttft_p99_ms"],
+        q["ttft_max_ms"],
+        q["count_ok"],
+        q["count_err"],
     )
     logger.info(
         "FLOOD TTFT  p50=%sms p99=%sms max=%sms (n=%s, err=%s)",
-        f["ttft_p50_ms"], f["ttft_p99_ms"], f["ttft_max_ms"], f["count_ok"], f["count_err"],
+        f["ttft_p50_ms"],
+        f["ttft_p99_ms"],
+        f["ttft_max_ms"],
+        f["count_ok"],
+        f["count_err"],
     )
     logger.info("=" * 60)
     return 0

--- a/benchmarks/scripts/mock_engine.py
+++ b/benchmarks/scripts/mock_engine.py
@@ -25,8 +25,9 @@ import json
 import logging
 import os
 import time
-from aiohttp import web
+from typing import Any
 
+from aiohttp import web
 
 logger = logging.getLogger("mock_engine")
 
@@ -55,17 +56,19 @@ class MockEngineState:
 
 async def handle_models(request: web.Request) -> web.Response:
     state: MockEngineState = request.app["state"]
-    return web.json_response({
-        "object": "list",
-        "data": [
-            {
-                "id": state.model,
-                "object": "model",
-                "created": int(time.time()),
-                "owned_by": "mock",
-            }
-        ],
-    })
+    return web.json_response(
+        {
+            "object": "list",
+            "data": [
+                {
+                    "id": state.model,
+                    "object": "model",
+                    "created": int(time.time()),
+                    "owned_by": "mock",
+                }
+            ],
+        }
+    )
 
 
 async def handle_health(request: web.Request) -> web.Response:
@@ -85,7 +88,12 @@ async def handle_completions(request: web.Request) -> web.StreamResponse:
     # Enter stall mode after `hang_after` successful requests
     if state.hang_after > 0 and rid > state.hang_after:
         state.stalled_count += 1
-        logger.info("req=%d STALL for %.0fs (hang_after=%d)", rid, state.stall_s, state.hang_after)
+        logger.info(
+            "req=%d STALL for %.0fs (hang_after=%d)",
+            rid,
+            state.stall_s,
+            state.hang_after,
+        )
         try:
             await asyncio.sleep(state.stall_s)
         except asyncio.CancelledError:
@@ -94,29 +102,39 @@ async def handle_completions(request: web.Request) -> web.StreamResponse:
         # If we ever wake up, return something harmless
         return web.Response(status=504, text="mock stall exit")
 
-    logger.info("req=%d OK (prompt_len=%d, max_tokens=%d, stream=%s, ok_latency=%.2fs)",
-                rid, len(prompt), max_tokens, stream, state.ok_latency)
+    logger.info(
+        "req=%d OK (prompt_len=%d, max_tokens=%d, stream=%s, ok_latency=%.2fs)",
+        rid,
+        len(prompt),
+        max_tokens,
+        stream,
+        state.ok_latency,
+    )
 
     # Simulate engine work
     await asyncio.sleep(state.ok_latency)
 
     if not stream:
-        return web.json_response({
-            "id": f"mock-{rid}",
-            "object": "text_completion",
-            "created": int(time.time()),
-            "model": state.model,
-            "choices": [{
-                "index": 0,
-                "text": f"mock response to req {rid}",
-                "finish_reason": "stop",
-            }],
-            "usage": {
-                "prompt_tokens": len(prompt.split()),
-                "completion_tokens": 5,
-                "total_tokens": len(prompt.split()) + 5,
-            },
-        })
+        return web.json_response(
+            {
+                "id": f"mock-{rid}",
+                "object": "text_completion",
+                "created": int(time.time()),
+                "model": state.model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "text": f"mock response to req {rid}",
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": len(prompt.split()),
+                    "completion_tokens": 5,
+                    "total_tokens": len(prompt.split()) + 5,
+                },
+            }
+        )
 
     # SSE stream response
     resp = web.StreamResponse(
@@ -126,19 +144,27 @@ async def handle_completions(request: web.Request) -> web.StreamResponse:
     )
     await resp.prepare(request)
 
-    def _make_chunk(text_value: str | None, finish: str | None = None) -> dict[str, Any]:
+    def _make_chunk(
+        text_value: str | None, finish: str | None = None
+    ) -> dict[str, Any]:
         # Chat-completions shape uses `delta.content`; classic completions
         # uses `text`. Real engines pick based on endpoint; we let the test
         # override so the harness can be exercised against both shapes.
         if state.chat_completions_shape:
             choice: dict[str, Any] = {
                 "index": 0,
-                "delta": {"content": text_value} if text_value is not None else {"role": "assistant"},
+                "delta": {"content": text_value}
+                if text_value is not None
+                else {"role": "assistant"},
                 "finish_reason": finish,
             }
             obj = "chat.completion.chunk"
         else:
-            choice = {"index": 0, "text": text_value if text_value is not None else "", "finish_reason": finish}
+            choice = {
+                "index": 0,
+                "text": text_value if text_value is not None else "",
+                "finish_reason": finish,
+            }
             obj = "text_completion.chunk"
         return {
             "id": f"mock-{rid}",
@@ -242,7 +268,14 @@ def main() -> None:
     )
     logger.info(
         "mock engine starting: port=%d model=%s hang_after=%d ok_latency=%.2fs stall=%.0fs delay_first_content=%.2fs first_chunk_ws=%d chat_shape=%s",
-        args.port, args.model, args.hang_after, args.ok_latency_s, args.stall_s, args.delay_first_content_s, args.first_chunk_whitespace, args.chat_completions_shape,
+        args.port,
+        args.model,
+        args.hang_after,
+        args.ok_latency_s,
+        args.stall_s,
+        args.delay_first_content_s,
+        args.first_chunk_whitespace,
+        args.chat_completions_shape,
     )
     web.run_app(make_app(state), host="127.0.0.1", port=args.port, print=None)
 

--- a/benchmarks/scripts/run_baseline_comparison.py
+++ b/benchmarks/scripts/run_baseline_comparison.py
@@ -20,7 +20,6 @@ import asyncio
 import json
 import logging
 import sys
-import time
 from pathlib import Path
 from typing import Any
 
@@ -29,16 +28,15 @@ _SCRIPT_DIR = Path(__file__).resolve().parent
 _PROFILING_SCRIPTS = _SCRIPT_DIR.parent.parent / "profiling" / "scripts"
 sys.path.insert(0, str(_PROFILING_SCRIPTS))
 
-from profiling_utils import (
+from profiling_utils import (  # noqa: E402
     AsyncBenchmarkClient,
-    BenchmarkResults,
     GPUMetricsCollector,
     RequestGenerator,
     TimingContext,
     check_engine_health,
+    compute_aggregate_stats,
     log_environment,
     prompts_to_requests,
-    compute_aggregate_stats,
 )
 
 logger = logging.getLogger(__name__)
@@ -147,9 +145,7 @@ def generate_workload(
         raise ValueError(f"Unknown workload type: {workload_type}")
 
 
-async def warmup_engine(
-    base_url: str, model: str, num_warmup: int
-) -> None:
+async def warmup_engine(base_url: str, model: str, num_warmup: int) -> None:
     """Send warmup requests to an engine to stabilize performance.
 
     Args:
@@ -211,7 +207,9 @@ async def benchmark_engine(
     run_results = []
     for run_idx in range(repeats):
         if repeats > 1:
-            logger.info("Run %d/%d at concurrency %d", run_idx + 1, repeats, concurrency)
+            logger.info(
+                "Run %d/%d at concurrency %d", run_idx + 1, repeats, concurrency
+            )
 
         # Benchmark
         gpu_collector = GPUMetricsCollector(interval_ms=100)
@@ -222,10 +220,12 @@ async def benchmark_engine(
             timeout_s=300,
         )
 
-        with TimingContext(f"{engine_name}_c{concurrency}_run{run_idx+1}") as timer:
+        with TimingContext(f"{engine_name}_c{concurrency}_run{run_idx + 1}") as timer:
             results = await client.run(requests, gpu_collector=gpu_collector)
 
-        file_suffix = f"c{concurrency}" if repeats == 1 else f"c{concurrency}_run{run_idx+1}"
+        file_suffix = (
+            f"c{concurrency}" if repeats == 1 else f"c{concurrency}_run{run_idx + 1}"
+        )
 
         # Save results
         csv_path = output_dir / f"{engine_name}_{file_suffix}.csv"
@@ -241,16 +241,16 @@ async def benchmark_engine(
         summary["wall_time_ms"] = timer.elapsed_ms
         summary["model_id"] = model
         summary["model_short_name"] = model.split("/")[-1]
-        
+
         if repeats > 1:
             summary_path = output_dir / f"{engine_name}_{file_suffix}_summary.json"
             with open(summary_path, "w") as f:
                 json.dump(summary, f, indent=2)
-                
+
         run_results.append(summary)
 
     agg_summary = compute_aggregate_stats(run_results)
-    
+
     if repeats > 1:
         agg_path = output_dir / f"{engine_name}_c{concurrency}_stats.json"
         with open(agg_path, "w") as f:
@@ -449,7 +449,7 @@ async def main() -> None:
     all_results: dict[str, dict[str, list[dict[str, Any]]]] = {}
 
     for workload_type in workload_types:
-        logger.info(f"\n{'='*60}")
+        logger.info(f"\n{'=' * 60}")
         logger.info("Workload: %s", workload_type)
         logger.info("=" * 60)
 

--- a/benchmarks/scripts/test_real_ttft.py
+++ b/benchmarks/scripts/test_real_ttft.py
@@ -57,15 +57,21 @@ async def wait_ready(url: str, timeout_s: float = 10.0) -> None:
     raise RuntimeError(f"mock not ready at {url} after {timeout_s}s")
 
 
-def spawn_mock(*, port: int, model: str, ok_latency_s: float, extra_args: list[str]) -> subprocess.Popen:
+def spawn_mock(
+    *, port: int, model: str, ok_latency_s: float, extra_args: list[str]
+) -> subprocess.Popen:
     return subprocess.Popen(
         [
             sys.executable,
             str(HERE / "mock_engine.py"),
-            "--port", str(port),
-            "--model", model,
-            "--ok-latency-s", str(ok_latency_s),
-            "--log-level", "WARNING",
+            "--port",
+            str(port),
+            "--model",
+            model,
+            "--ok-latency-s",
+            str(ok_latency_s),
+            "--log-level",
+            "WARNING",
             *extra_args,
         ],
         stdout=subprocess.PIPE,
@@ -74,18 +80,27 @@ def spawn_mock(*, port: int, model: str, ok_latency_s: float, extra_args: list[s
 
 
 async def run_case(
-    name: str, mock_args: list[str], ok_latency_s: float, max_tokens: int,
+    name: str,
+    mock_args: list[str],
+    ok_latency_s: float,
+    max_tokens: int,
 ) -> tuple[float, int]:
     """Returns (ttft_ms, tokens_out) from a single bench request to a mock."""
     port = free_port()
     proc = spawn_mock(
-        port=port, model=name, ok_latency_s=ok_latency_s, extra_args=mock_args,
+        port=port,
+        model=name,
+        ok_latency_s=ok_latency_s,
+        extra_args=mock_args,
     )
     try:
         base_url = f"http://127.0.0.1:{port}"
         await wait_ready(f"{base_url}/v1/models", timeout_s=10.0)
         client = MultiModelBenchmarkClient(
-            base_url=base_url, concurrency=1, timeout_s=30, max_tokens=max_tokens,
+            base_url=base_url,
+            concurrency=1,
+            timeout_s=30,
+            max_tokens=max_tokens,
         )
         sem = asyncio.Semaphore(1)
         async with aiohttp.ClientSession() as session:
@@ -123,10 +138,15 @@ async def main() -> int:
     # Case 1 + 2: TTFT discriminators (delay-then-content).
     timing_cases = [
         ("empty-preamble", ["--delay-first-content-s", str(DELAY_S)]),
-        ("whitespace-preamble", [
-            "--first-chunk-whitespace", "1",
-            "--delay-first-content-s", str(DELAY_S),
-        ]),
+        (
+            "whitespace-preamble",
+            [
+                "--first-chunk-whitespace",
+                "1",
+                "--delay-first-content-s",
+                str(DELAY_S),
+            ],
+        ),
     ]
     for name, args in timing_cases:
         try:
@@ -141,7 +161,8 @@ async def main() -> int:
         _, tokens_out = await run_case(
             "chat-shape",
             ["--chat-completions-shape"],
-            ok_latency_s=0.05, max_tokens=8,
+            ok_latency_s=0.05,
+            max_tokens=8,
         )
         passed = tokens_out == 8
         results.append(("chat-shape", f"tokens_out={tokens_out} (need == 8)", passed))

--- a/tests/unit/test_bench_harness_flags.py
+++ b/tests/unit/test_bench_harness_flags.py
@@ -1,0 +1,296 @@
+"""Unit tests for M4 harness flags --prefix-overlap (#120) + --bias-flooder-cost (#122).
+
+Both features wrap or instrument the existing PromptSampler / Poisson loop
+without changing pre-Gate-2.2 behavior when their flags are at the default
+(prefix-overlap=0.0 / bias-flooder-cost=1.0). These tests pin the new
+contracts and the no-flag backward-compat invariant.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import sys
+from collections import deque
+from pathlib import Path
+
+import pytest
+
+# Add the benchmark script dir so we can import the module under test.
+_BENCH_SCRIPTS = (
+    Path(__file__).resolve().parent.parent.parent / "benchmarks" / "scripts"
+)
+sys.path.insert(0, str(_BENCH_SCRIPTS))
+
+from benchmark_n_tenant_single_model import (  # noqa: E402
+    PROMPTS,
+    build_shared_prefix,
+    make_legacy_sampler,
+    make_prefix_overlap_sampler,
+    should_apply_bias,
+)
+
+# ---------------------------------------------------------------------------
+# Issue #120: --prefix-overlap
+# ---------------------------------------------------------------------------
+
+
+class TestPrefixOverlapWrapper:
+    def test_overlap_zero_yields_no_prefix(self) -> None:
+        """overlap_fraction=0.0 (the default) must pass through unchanged.
+
+        Equivalent to the pre-flag baseline: every draw equals the inner
+        sampler's draw byte-for-byte.
+        """
+        prefix = "SHARED_PREFIX_TOKEN_BLOB"
+        base = make_legacy_sampler()
+        wrapped = make_prefix_overlap_sampler(
+            inner=base, shared_prefix=prefix, overlap_fraction=0.0, seed=42
+        )
+        rng_a = random.Random(7)
+        rng_b = random.Random(7)
+        for _ in range(50):
+            via_wrap, len_w = wrapped(rng_a)
+            via_direct = rng_b.choice(PROMPTS)
+            assert via_wrap == via_direct
+            assert len_w == 0
+            assert prefix not in via_wrap
+
+    def test_overlap_one_yields_prefix_on_every_call(self) -> None:
+        """overlap_fraction=1.0 must prepend the prefix on every draw."""
+        prefix = "DETERMINISTIC_SHARED_PREFIX"
+        base = make_legacy_sampler()
+        wrapped = make_prefix_overlap_sampler(
+            inner=base, shared_prefix=prefix, overlap_fraction=1.0, seed=42
+        )
+        rng = random.Random(7)
+        for _ in range(50):
+            prompt, length = wrapped(rng)
+            assert prompt.startswith(prefix + " ")
+            # Length contract: original length is preserved (we do not
+            # re-count prefix tokens).
+            assert length == 0
+
+    def test_overlap_half_matches_target_fraction(self) -> None:
+        """overlap_fraction=0.5 over 1000 samples should give ~50% prefixed.
+
+        Tolerance ±0.05 — well outside 3-sigma for Bernoulli(0.5, n=1000)
+        which is ~0.047. With seed=42 the result is fully deterministic.
+        """
+        prefix = "PFX"
+        base = make_legacy_sampler()
+        wrapped = make_prefix_overlap_sampler(
+            inner=base, shared_prefix=prefix, overlap_fraction=0.5, seed=42
+        )
+        rng = random.Random(0)
+        n = 1000
+        prefixed = sum(1 for _ in range(n) if wrapped(rng)[0].startswith(prefix + " "))
+        frac = prefixed / n
+        assert 0.45 <= frac <= 0.55, (
+            f"prefixed fraction {frac:.3f} outside 0.5±0.05 over n={n} (seed=42)"
+        )
+
+    def test_seed_reproducibility(self) -> None:
+        """Same seed → same prefix decisions across two independent constructions."""
+        prefix = "PFX"
+        base_a = make_legacy_sampler()
+        base_b = make_legacy_sampler()
+        wrap_a = make_prefix_overlap_sampler(
+            inner=base_a, shared_prefix=prefix, overlap_fraction=0.5, seed=99
+        )
+        wrap_b = make_prefix_overlap_sampler(
+            inner=base_b, shared_prefix=prefix, overlap_fraction=0.5, seed=99
+        )
+        rng_a = random.Random(7)
+        rng_b = random.Random(7)
+        decisions_a = [wrap_a(rng_a)[0].startswith(prefix + " ") for _ in range(100)]
+        decisions_b = [wrap_b(rng_b)[0].startswith(prefix + " ") for _ in range(100)]
+        assert decisions_a == decisions_b
+
+    def test_decisions_independent_of_arrival_rng_use(self) -> None:
+        """Prefix decisions use a separate RNG so they are stable even if the
+        inner sampler's rng usage shifts. Pulling extra entries from the
+        arrival rng before each sample must not change which draws are
+        prefixed.
+        """
+        prefix = "PFX"
+
+        def base_one(rng: random.Random) -> tuple[str, int]:
+            return rng.choice(PROMPTS), 0
+
+        def base_two(rng: random.Random) -> tuple[str, int]:
+            # Burns one extra rng draw per call.
+            _ = rng.random()
+            return rng.choice(PROMPTS), 0
+
+        wrap_one = make_prefix_overlap_sampler(
+            inner=base_one, shared_prefix=prefix, overlap_fraction=0.5, seed=12
+        )
+        wrap_two = make_prefix_overlap_sampler(
+            inner=base_two, shared_prefix=prefix, overlap_fraction=0.5, seed=12
+        )
+        rng_one = random.Random(33)
+        rng_two = random.Random(33)
+        dec_one = [wrap_one(rng_one)[0].startswith(prefix + " ") for _ in range(80)]
+        dec_two = [wrap_two(rng_two)[0].startswith(prefix + " ") for _ in range(80)]
+        assert dec_one == dec_two
+
+    def test_shared_prefix_builder_seed_stable(self) -> None:
+        """build_shared_prefix is reproducible from --seed."""
+        a = build_shared_prefix(shared_prefix_tokens=64, seed=42)
+        b = build_shared_prefix(shared_prefix_tokens=64, seed=42)
+        assert a == b
+        assert isinstance(a, str) and len(a) > 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #122: --bias-flooder-cost
+# ---------------------------------------------------------------------------
+
+
+class TestShouldApplyBias:
+    def test_empty_deque_returns_false(self) -> None:
+        dq: deque[float] = deque()
+        assert should_apply_bias(dq, now=10.0, threshold=10, window_s=30.0) is False
+
+    def test_below_threshold_returns_false(self) -> None:
+        # 5 timestamps within window, threshold is 10 → False.
+        dq: deque[float] = deque([float(i) for i in range(5)])
+        assert should_apply_bias(dq, now=10.0, threshold=10, window_s=30.0) is False
+        # No timestamps were stale, deque preserved.
+        assert len(dq) == 5
+
+    def test_above_threshold_returns_true(self) -> None:
+        # 15 timestamps within window, threshold is 10 → True.
+        dq: deque[float] = deque([float(i) for i in range(15)])
+        assert should_apply_bias(dq, now=20.0, threshold=10, window_s=30.0) is True
+
+    def test_stale_timestamps_dropped_from_window(self) -> None:
+        """Timestamps older than now - window_s must be popped from the left.
+
+        Setup: 8 stale + 5 fresh, threshold=10, window covers only the
+        fresh ones. Expected: stale dropped, len=5, returns False.
+        """
+        stale = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+        fresh = [100.0, 101.0, 102.0, 103.0, 104.0]
+        dq: deque[float] = deque(stale + fresh)
+        result = should_apply_bias(dq, now=105.0, threshold=10, window_s=10.0)
+        assert result is False
+        assert list(dq) == fresh
+
+
+class TestBiasStateTransitionLogging:
+    """The bench's per-tenant loop logs once per bias-state transition.
+
+    These tests pin the log behavior of the helper without spinning up
+    the async loop; we replay the logic the loop executes.
+    """
+
+    def _run_transitions(
+        self,
+        events: list[tuple[float, int, float]],
+        threshold: int,
+        window_s: float,
+        multiplier: float,
+        tenant_id: str,
+        caplog_logger: logging.Logger,
+    ) -> list[tuple[bool, bool]]:
+        """Replay the loop's enter/exit-bias-state logic.
+
+        events: list of (now, deque_target_len, _ignored). We synthesize a
+        deque containing ``deque_target_len`` recent timestamps so
+        should_apply_bias returns the desired truth value.
+        """
+        in_bias = False
+        transitions: list[tuple[bool, bool]] = []
+        bias_enabled = multiplier > 1.0 and threshold > 0
+        for now, target_len, _ in events:
+            if not bias_enabled:
+                transitions.append((False, in_bias))
+                continue
+            # Synthesize a fresh deque of ``target_len`` timestamps inside
+            # the window so should_apply_bias returns the value we want.
+            dq: deque[float] = deque([now - 0.001] * target_len)
+            apply = should_apply_bias(dq, now, threshold, window_s)
+            if apply and not in_bias:
+                caplog_logger.info(
+                    "tenant=%s entering bias state (>%d reqs in %.1fs window, "
+                    "multiplier=%.2fx)",
+                    tenant_id,
+                    threshold,
+                    window_s,
+                    multiplier,
+                )
+                in_bias = True
+            elif not apply and in_bias:
+                caplog_logger.info(
+                    "tenant=%s exiting bias state (<=%d reqs in %.1fs window)",
+                    tenant_id,
+                    threshold,
+                    window_s,
+                )
+                in_bias = False
+            transitions.append((apply, in_bias))
+        return transitions
+
+    def test_logs_once_on_enter_and_once_on_exit(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Use the harness-module logger so the test exercises the same
+        # logger the production loop calls.
+        from benchmark_n_tenant_single_model import logger as bench_logger
+
+        # Sequence: below → above (enter) → above (no log) → below (exit) → below (no log)
+        events = [
+            (1.0, 5, 0.0),  # below threshold
+            (2.0, 15, 0.0),  # crosses up → ENTER
+            (3.0, 16, 0.0),  # still above → no log
+            (4.0, 5, 0.0),  # crosses down → EXIT
+            (5.0, 4, 0.0),  # still below → no log
+        ]
+        with caplog.at_level(logging.INFO, logger=bench_logger.name):
+            self._run_transitions(
+                events,
+                threshold=10,
+                window_s=30.0,
+                multiplier=4.0,
+                tenant_id="flooder",
+                caplog_logger=bench_logger,
+            )
+        enter_msgs = [
+            r for r in caplog.records if "entering bias state" in r.getMessage()
+        ]
+        exit_msgs = [
+            r for r in caplog.records if "exiting bias state" in r.getMessage()
+        ]
+        assert len(enter_msgs) == 1, (
+            f"expected exactly one enter-bias log, got {len(enter_msgs)}"
+        )
+        assert len(exit_msgs) == 1, (
+            f"expected exactly one exit-bias log, got {len(exit_msgs)}"
+        )
+        # Verify the log message names the tenant + threshold.
+        assert "flooder" in enter_msgs[0].getMessage()
+        assert ">10 reqs" in enter_msgs[0].getMessage()
+
+    def test_disabled_when_multiplier_is_one(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """multiplier=1.0 (the default) must not emit any bias-state logs."""
+        from benchmark_n_tenant_single_model import logger as bench_logger
+
+        events = [
+            (1.0, 100, 0.0),  # would be above but bias is disabled
+            (2.0, 50, 0.0),
+        ]
+        with caplog.at_level(logging.INFO, logger=bench_logger.name):
+            self._run_transitions(
+                events,
+                threshold=10,
+                window_s=30.0,
+                multiplier=1.0,
+                tenant_id="flooder",
+                caplog_logger=bench_logger,
+            )
+        bias_msgs = [r for r in caplog.records if "bias state" in r.getMessage()]
+        assert bias_msgs == []


### PR DESCRIPTION
## Summary

Lands the two M4 harness blockers as a single PR (both touch `benchmarks/scripts/benchmark_n_tenant_single_model.py` so bundling avoids a merge conflict).

Closes #120. Closes #122.

These unblock Gate 3 Arm 2 (simulated saturation bias) and the cache-pressure regime that exercises the M4 probe lever. Both were called out as BLOCKING pre-flight items at the top of `docs/runbooks/gate3_kv_eviction.md` (items 2 and 3).

## What each flag does

- `--prefix-overlap FRACTION` (issue #120): probabilistic shared-prefix workload generator. Wraps the active sampler so each draw prepends a single shared prefix string with probability FRACTION. Prefix is built once at startup via `RequestGenerator.generate_fixed_length` so vLLM's tokenizer + prefix cache can de-duplicate it. Decision RNG is seeded at `args.seed + 1` so prefix decisions stay independent of length-sampling rng usage.
- `--shared-prefix-tokens N` (issue #120): token length of the shared prefix; default 1024.
- `--bias-flooder-cost MULTIPLIER` (issue #122): bench-side rate-throttle simulating cache-pressure-aware admission. When the flooder has emitted more than `--bias-after-N-reqs` requests in the last `--bias-window-s` seconds, its inter-arrival sleep is scaled by MULTIPLIER. Pure client-side; no server changes. Quiet tenants unaffected.
- `--bias-after-N-reqs N` and `--bias-window-s S`: sliding-window threshold + duration for the bias trigger.

Default values are the no-flag baseline (overlap=0.0, multiplier=1.0, threshold=0) so `python3 benchmark_n_tenant_single_model.py` without any new flag is byte-for-byte identical to today.

## Verify

- `python3 -m pytest tests/unit/test_bench_harness_flags.py -q` -> 12 passed
- `python3 -m pytest tests/unit/ -q` -> 272 passed, 10 xfailed; only the known port-allocator flake (`test_allocate_port_returns_available`, OverflowError) remains red. Net delta vs main: +12 passing tests.
- `python3 -m ruff check src/ tests/ benchmarks/` -> clean
- `python3 -m ruff format --check src/ tests/ benchmarks/` -> clean

Pre-existing `benchmarks/` lint + format debt cleaned in this PR per the spec direction to extend the lint gate to `benchmarks/`. Reviewer note: 11 ruff errors and 7 format-only diffs in unrelated benchmark files were swept up so the gate gets a green floor going forward; logical change is scoped to `benchmark_n_tenant_single_model.py` + the new test file.

## Out of scope

- `--bias-target=quiet` use case (e.g. inverted-fairness probes). The bias-handling block has a docstring extension point pointing at the call sites to thread per-tenant kwargs through if/when we want that.
- Real vLLM `/metrics`-polling implementation (Arm 3 / M5a / M6).
- `--prefix-target` (e.g. flooder-only prefix). Today the wrapper applies uniformly across tenants, which is what the Gate 3 design wants — every tenant shares the same prefix bytes so the engine's cache de-dups across tenant boundaries.