### PR TITLE
feat(docker): minimal Compose bundle for one-command eval

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,59 @@
+# Keep the Docker build context small. Anything not needed for
+# `pip install -e .` (pyproject.toml + README.md + src/) should be
+# excluded so docker build doesn't ship the whole repo to the daemon.
+
+.git
+.github
+.gitignore
+.gitattributes
+
+# Tests + bench artifacts — installed package doesn't ship these.
+tests
+benchmarks
+results
+profiling
+dashboards
+telemetry-worker
+docs
+
+# Docs + dot-files
+*.md
+!README.md
+LICENSE
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+SECURITY.md
+PROGRESS.md
+research_roadmap.md
+
+# Compose-bundle artifacts and tarballs
+*.tar.gz
+infergrid_*.tar.gz
+kvwarden_*.tar.gz
+
+# Python / venv
+__pycache__
+*.py[cod]
+*.egg-info
+dist
+build
+.venv
+venv
+.pytest_cache
+.ruff_cache
+.mypy_cache
+
+# Editor + OS
+.idea
+.vscode
+*.swp
+*.swo
+.DS_Store
+
+# Worktrees + agent state
+.claude
+worktree-agent-*
+
+# Misc
+.checkpoints
+.ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -50,7 +50,19 @@ curl localhost:8000/metrics | grep -E "tenant_rejected|admission_queue_depth"
 
 First call returns `503` until vLLM finishes loading (30-90 s on A100 for an 8B). The config at [`configs/quickstart_fairness.yaml`](configs/quickstart_fairness.yaml) is heavily commented; every knob traces back to a specific experiment.
 
-A Docker Compose bundle is not shipping yet — if you want one, [#109](https://github.com/coconut-labs/kvwarden/issues/109) is open as a good-first-issue.
+## Docker Compose
+
+A two-service compose bundle brings up vLLM + kvwarden with one command. Requires a Linux GPU host with the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html); CPU-only and Apple Silicon hosts cannot run this end-to-end (vLLM needs CUDA).
+
+```bash
+export HF_TOKEN=hf_...                      # gated Llama-3.1-8B model
+docker compose -f docker/docker-compose.yml up
+# in another shell, once both services report healthy (~3 min cold):
+curl localhost:8000/v1/completions -H 'X-Tenant-ID: quiet' \
+  -d '{"model":"llama31-8b","prompt":"Hello","max_tokens":32}'
+```
+
+Compose pins `vllm/vllm-openai:v0.19.1` (the image the hero number was measured against) and serves the bundled [`docker/quickstart-compose.yaml`](docker/quickstart-compose.yaml) — same two-tenant token-bucket shape as `configs/quickstart_fairness.yaml`, port-pinned for the bundle.
 
 ## When it breaks
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,85 @@
+# kvwarden Dockerfile — multistage, slim base.
+#
+# Builder stage installs the package + dev extras into a venv, runtime
+# stage copies just the venv and the kvwarden console script. The runtime
+# image stays small (no compilers, no build deps) and runs as a non-root
+# user. curl is kept for the HEALTHCHECK probe.
+#
+# Build:
+#   docker build -f docker/Dockerfile -t kvwarden:local .
+#
+# Run (standalone — assumes vLLM reachable on localhost:8001 and a config
+# in /etc/kvwarden/config.yaml; the compose bundle wires this up):
+#   docker run --rm -p 8000:8000 \
+#     -v $(pwd)/docker/quickstart-compose.yaml:/etc/kvwarden/config.yaml:ro \
+#     kvwarden:local serve --config /etc/kvwarden/config.yaml
+
+# ── Builder ───────────────────────────────────────────────────────────
+FROM python:3.12-slim AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    VIRTUAL_ENV=/opt/venv \
+    PATH=/opt/venv/bin:$PATH
+
+# build-essential covers compiled wheels (numpy, pandas, aiohttp) when no
+# manylinux wheel exists for the python+platform combination.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m venv /opt/venv
+
+WORKDIR /src
+
+# Copy only what's needed for `pip install`. Source goes in last so a
+# code-only edit doesn't bust the dep-install layer.
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+# `[dev]` is the broadest non-vllm extra (pytest, ruff, etc.). vLLM is
+# NOT installed in the kvwarden image — it lives in the vllm/vllm-openai
+# service in the compose bundle, and the kvwarden container reaches it
+# via the shared network namespace. See docker-compose.yml for the wiring.
+RUN pip install --upgrade pip && pip install -e ".[dev]"
+
+# ── Runtime ───────────────────────────────────────────────────────────
+FROM python:3.12-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    VIRTUAL_ENV=/opt/venv \
+    PATH=/opt/venv/bin:$PATH
+
+# curl for HEALTHCHECK; tini for proper signal handling under PID 1.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+        tini \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system --gid 1001 kvwarden \
+    && useradd  --system --uid 1001 --gid kvwarden --home-dir /app --shell /usr/sbin/nologin kvwarden
+
+# Pull the venv (binaries + site-packages + entry-point script) from the
+# builder. The kvwarden console script lives at /opt/venv/bin/kvwarden
+# because pip installs editable extras' scripts there.
+COPY --from=builder /opt/venv /opt/venv
+# Copy package source so the editable install resolves at runtime.
+COPY --from=builder /src /src
+
+WORKDIR /app
+RUN chown -R kvwarden:kvwarden /app
+USER kvwarden
+
+EXPOSE 8000
+
+# /health returns 200 once all engines have warmed up; 503 with a
+# {missing_models: [...]} body until then. The healthcheck loop is the
+# same one the README quickstart uses.
+HEALTHCHECK --interval=10s --timeout=5s --start-period=120s --retries=12 \
+    CMD curl -fs http://localhost:8000/health || exit 1
+
+ENTRYPOINT ["/usr/bin/tini", "--", "kvwarden"]
+CMD ["serve", "--config", "/etc/kvwarden/config.yaml"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,11 +1,33 @@
-# KVWarden benchmark environment
-# Usage: docker compose -f docker/docker-compose.yml up vllm-server
-
-version: "3.8"
+# kvwarden compose bundle — one-command local eval (closes #109).
+#
+# Usage:
+#   export HF_TOKEN=hf_...                    # gated Llama-3.1-8B model
+#   docker compose -f docker/docker-compose.yml up
+#   # in another shell, once both services are healthy (~3 min cold):
+#   curl localhost:8000/v1/completions -H 'X-Tenant-ID: quiet' \
+#     -d '{"model":"llama31-8b","prompt":"Hello","max_tokens":32}'
+#
+# Architecture note: the kvwarden engine adapter currently spawns vLLM as
+# a subprocess and reaches it on localhost:{port}. A two-process compose
+# split with service-name DNS would need an `engine_endpoint` config knob
+# kvwarden does not have today. As a workaround, the kvwarden service
+# joins the vllm service's network namespace (`network_mode: service:vllm`)
+# and runs with KVWARDEN_DEV_SKIP_ENGINE_LAUNCH=1 so the adapter attaches
+# to the existing vllm process on localhost:8001. Both ports (8000 for
+# kvwarden, 8001 for vllm) are exposed on the vllm service since it owns
+# the netns. Followup to ship a real `engine_endpoint` field is out of
+# scope for #109.
+#
+# Requires a Linux GPU host with the NVIDIA Container Toolkit installed.
+# Apple Silicon and CPU-only hosts cannot run this — vLLM needs CUDA.
 
 services:
-  vllm-server:
-    image: vllm/vllm-openai:latest
+  vllm:
+    image: vllm/vllm-openai:v0.19.1
+    # GPU reservation. Modern Compose (v2+) reads `deploy.resources`;
+    # older Compose v1 uses `runtime: nvidia`. Pick whichever your daemon
+    # accepts — uncomment the runtime line if the deploy form is ignored.
+    # runtime: nvidia
     deploy:
       resources:
         reservations:
@@ -13,33 +35,57 @@ services:
             - driver: nvidia
               count: 1
               capabilities: [gpu]
+    environment:
+      HF_TOKEN: ${HF_TOKEN:?HF_TOKEN must be set in your shell — gated model auth}
+      HUGGING_FACE_HUB_TOKEN: ${HF_TOKEN}
+    # Only kvwarden's port 8000 is published to the host. Port 8001
+    # (vLLM) is reachable from kvwarden via the shared netns at
+    # localhost:8001 but stays unpublished — exposing it would bypass
+    # kvwarden's tenant-fairness admission gate entirely.
     ports:
       - "8000:8000"
-    command: >
-      --model meta-llama/Llama-3.1-8B-Instruct
-      --dtype bfloat16
-      --gpu-memory-utilization 0.8
     volumes:
-      - huggingface-cache:/root/.cache/huggingface
+      - hf-cache:/root/.cache/huggingface
+    command:
+      - --model
+      - meta-llama/Llama-3.1-8B-Instruct
+      - --gpu-memory-utilization
+      - "0.40"
+      - --max-model-len
+      - "4096"
+      - --port
+      - "8001"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost:8001/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 60
+      start_period: 30s
 
-  sglang-server:
-    image: lmsysorg/sglang:latest
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
-    ports:
-      - "8001:30000"
-    command: >
-      python -m sglang.launch_server
-      --model meta-llama/Llama-3.1-8B-Instruct
-      --dtype bfloat16
-      --mem-fraction-static 0.8
+  kvwarden:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    # Share the vllm container's netns so the kvwarden adapter can reach
+    # vllm on localhost:8001 without an `engine_endpoint` config knob.
+    # Side-effect: this service has no `ports:` of its own — port 8000
+    # is exposed by the vllm service above.
+    network_mode: "service:vllm"
+    depends_on:
+      vllm:
+        condition: service_healthy
+    environment:
+      # Tells the engine adapter to attach to an already-running vllm on
+      # localhost:{model.port} instead of spawning its own subprocess.
+      KVWARDEN_DEV_SKIP_ENGINE_LAUNCH: "1"
     volumes:
-      - huggingface-cache:/root/.cache/huggingface
+      - ../configs:/configs:ro
+      - ../docker/quickstart-compose.yaml:/etc/kvwarden/config.yaml:ro
+    command:
+      - serve
+      - --config
+      - /etc/kvwarden/config.yaml
+    # Healthcheck inherited from the Dockerfile (curl /health on 8000).
 
 volumes:
-  huggingface-cache:
+  hf-cache:

--- a/docker/quickstart-compose.yaml
+++ b/docker/quickstart-compose.yaml
@@ -1,0 +1,41 @@
+# kvwarden compose-bundle config — mirrors configs/quickstart_fairness.yaml
+# but pinned to the layout the docker-compose bundle ships:
+#
+#   - vLLM runs in the `vllm` service on port 8001 (set in compose).
+#   - kvwarden joins that netns, attaches via KVWARDEN_DEV_SKIP_ENGINE_LAUNCH,
+#     and reaches vllm on localhost:8001.
+#   - kvwarden's own API binds 0.0.0.0:8000 inside the netns; the host
+#     reaches it via the vllm service's `ports:` mapping.
+#
+# Two tenants (`noisy`, `quiet`) with token-bucket rate-limiting on a
+# DRR-scheduled admission gate — same shape as the README hero number.
+# Tunable via the same knobs documented in configs/quickstart_fairness.yaml.
+
+host: 0.0.0.0
+port: 8000
+gpu_budget_fraction: 0.40    # matches the vllm service's --gpu-memory-utilization
+
+max_concurrent: 256
+admission_queue_size: 2048
+engine_start_timeout_s: 420
+log_level: INFO
+
+tenant_defaults:
+  max_concurrent_requests: 512
+  rate_limit_rpm: 600          # 10 RPS sustained per tenant
+  rate_limit_burst: 10         # 1 second of burst capacity
+  priority: 1
+  scheduling: drr
+
+models:
+  - model_id: "meta-llama/Llama-3.1-8B-Instruct"
+    short_name: "llama31-8b"
+    engine: "vllm"
+    dtype: "bfloat16"
+    gpu_memory_utilization: 0.40
+    max_model_len: 4096
+    tensor_parallel_size: 1
+    # Pinned: must match `--port 8001` in docker-compose.yml's vllm
+    # command. The KVWARDEN_DEV_SKIP_ENGINE_LAUNCH path attaches to
+    # localhost:{port} of the running engine.
+    port: 8001


### PR DESCRIPTION
Closes #109.

## What's in here

| File | Why |
|---|---|
| `docker/Dockerfile` | multistage `python:3.12-slim`, builder installs `pip install -e ".[dev]"`, runtime drops compilers, runs as non-root user `kvwarden:1001`, `curl` healthcheck on `/health`, `tini` for signal handling |
| `docker/docker-compose.yml` | `vllm/vllm-openai:v0.19.1` + kvwarden, GPU reservation, HF cache volume, kvwarden joins vllm's netns to bridge an architectural gap (see below) |
| `docker/quickstart-compose.yaml` | two tenants (`noisy`, `quiet`), token-bucket on DRR, port-pinned to 8001 to match the compose vllm service |
| `.dockerignore` | excludes `.git`, `tests/`, `benchmarks/`, `results/`, `docs/`, worktrees, caches |
| `README.md` | replaces the "not shipping yet" line with a real `## Docker Compose` section showing the user flow |

## User flow

```bash
export HF_TOKEN=hf_...                      # gated Llama-3.1-8B model
docker compose -f docker/docker-compose.yml up
# in another shell, once both services report healthy (~3 min cold):
curl localhost:8000/v1/completions -H 'X-Tenant-ID: quiet' \
  -d '{"model":"llama31-8b","prompt":"Hello","max_tokens":32}'
```

## Decisions worth surfacing

**Port 8000, not 8080.** Issue #109 body says 8080 but every shipped config (`configs/quickstart_fairness.yaml` line 48), the README quickstart, and `kvwarden serve` defaults use 8000. Treating the issue body as a typo.

**kvwarden joins vllm's netns.** The engine adapter currently spawns vLLM as a subprocess and reaches it on `localhost:{port}` (`src/kvwarden/engines/base.py:92`). A clean two-process split would need an `engine_endpoint` config knob the project does not have today. The bundle works around this with `network_mode: "service:vllm"` + `KVWARDEN_DEV_SKIP_ENGINE_LAUNCH=1` — kvwarden attaches to the running vllm on `localhost:8001` inside the shared netns. Followup to ship a real `engine_endpoint` is out of scope here.

**Only port 8000 published.** vllm:8001 stays inside the netns. Publishing it would let evaluators bypass the tenant-fairness admission gate — defeating the bundle's purpose.

## Sharp edges

- `KVWARDEN_DEV_SKIP_ENGINE_LAUNCH` is named "dev" because that's what it was originally for. The bundle relies on it as the only available "attach to existing engine" path. Should rename + promote to a first-class config option in a followup.
- The kvwarden image installs `[dev]` extras (pytest, ruff, etc.) — slightly heavier than strictly needed. A `[runtime]` extra would be cleaner.
- GPU-only: Apple Silicon and CPU-only hosts cannot run this end-to-end. Documented in the README section.

## Verification

Verified: YAML schemas parse. NOT smoke-tested end-to-end — sandbox has no Docker. Reviewer should run `docker compose up` on a GPU host with `HF_TOKEN` set; expected: vllm healthy in ~3 min, kvwarden healthy ~30 s after, `curl localhost:8000/health` returns 200.

What I did verify locally:
- `docker compose -f docker/docker-compose.yml config --quiet` parses with exit 0.
- `python3 -c "import yaml; yaml.safe_load(...)"` parses both YAML files.
- `python3 -m ruff check src/ tests/` clean (no source changes; sanity).

## Why ship this now

Labeled good-first-issue; pre-launch, this closes the friction window for HN-commenter evaluators. Aligns with the #102 onboarding-installs goal — `pip install` + `kvwarden serve` is four commands in three terminals; one `docker compose up` is one command. Slack between Show HN slip (2026-05-12) and pre-launch QA (#105) is the right time to land it.
