### PR TITLE
docs: P1 pre-flight follow-ups — RFC label-set + runbook base image

### DIFF
--- a/docs/rfcs/T2-cache-pressure-admission.md
+++ b/docs/rfcs/T2-cache-pressure-admission.md
@@ -49,14 +49,14 @@ vLLM exposes `vllm:kv_cache_usage_perc` as a Prometheus `Gauge` on the engine's 
 
 Two properties of the gauge are load-bearing:
 
-1. **Instance-level.** The only label is `model_name`. There is no per-tenant, per-request, or per-block label. Cache pressure as kvwarden sees it is global to the engine instance.
+1. **Instance-level.** Labels are `engine` (instance index — `engine="0"` on a single-engine pod, increments for multi-engine deployments) and `model_name`. There is no per-tenant, per-request, or per-block label. Cache pressure as kvwarden sees it is global per engine instance.
 2. **Range [0.0, 1.0].** Composes cleanly with a unitless scaling function. No magnitude calibration across hardware.
 
 The first property means tenant fairness in v0.2 comes from kvwarden's existing per-tenant signal (DRR deficit, tenant_manager state) composed with the engine's global pressure. We do not claim per-tenant cache visibility. The composition is honest: cache pressure is engine state, tenant attribution is orchestration state, and admission combines them.
 
 Adjacent histograms exist (`vllm:kv_block_lifetime_seconds`, `vllm:kv_block_idle_before_evict_seconds`, `vllm:kv_block_reuse_gap_seconds`) for v0.3+ adaptive thresholding. Out of scope for v0.2.
 
-Refresh tempo is a verifiable property of the gauge, not a documented one. M1 pre-flight scrapes `/metrics` against the existing test vLLM container to measure the update cadence and confirm the gauge is reachable without auth. Per R5 in the persisted plan, if vLLM updates the gauge slower than ~1 Hz, the poller caches the last value with a TTL bounded by the observed update rate; admission still composes against a stale-but-bounded reading rather than blocking on a fresh poll.
+**Refresh tempo verified (P1 pre-flight, 2026-05-02):** vLLM 0.19.1 on A100, 4 RPS small-completion load — `vllm:kv_cache_usage_perc` distinct-value updates at p50 0.25 s, well above the 1 Hz threshold. The 250 ms poller cadence locked in §Architecture is sufficient; the staleness-bounded fallback path documented in R5 of the persisted plan is not load-bearing for v0.2. Findings: `results/p1_gauge_preflight_20260502/GAUGE_FINDINGS.md`.
 
 ### Architecture
 

--- a/docs/runbooks/gate3_kv_eviction.md
+++ b/docs/runbooks/gate3_kv_eviction.md
@@ -74,13 +74,15 @@ Stage 2 (M6, Arm 3 vs Arm 1, same threshold table). Arm 3 must track Arm 2 withi
 runpodctl create pod \
   --name "kvwarden-gate3-cache-pressure-admission" \
   --gpu-type "A100 SXM4 80GB" \
-  --image vllm/vllm-openai:0.19.1 \
+  --image runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 \
   --cloud-type SECURE \
   --container-disk-gb 80 \
   --ports "22/tcp,8000/http" \
   --env "HF_TOKEN=$HF_TOKEN" \
   --env "MAX_POD_SECS=21600"
 ```
+
+**Why `runpod/pytorch` not `vllm/vllm-openai` (P1 finding 2026-05-02):** the `vllm/vllm-openai` image runs vLLM as PID 1 with no sshd. Bench orchestration here SSHes in, runs `gate_pod_bootstrap.sh` to pip-install vLLM, then launches engines as subprocesses. The pytorch base gives sshd + room for `pip install vllm==0.19.1` during bootstrap. The Compose bundle (#126) uses `vllm/vllm-openai` because it talks to the engine over HTTP only, no SSH needed.
 
 (MAX_POD_SECS=21600 = 6h, above 4.5h compute budget. In-pod self-destruct is best-effort; the operator's calendar alarm is the actual ceiling.)
 


### PR DESCRIPTION
P1 pre-flight (2026-05-02, $0.24, see #128) surfaced two doc-grade fixes that need to land before M3 Show HN locks the launch narrative.

## RFC §Design

`vllm:kv_cache_usage_perc` labels are `engine` (instance index) **and** `model_name`, not `model_name` alone. The `engine` label is an instance index (`engine="0"` on a single-engine pod), not per-tenant — so the load-bearing inference (no per-tenant attribution from the engine) survives. Also pinned the verified 0.25 s p50 cadence and the implication: the 250 ms poller cadence in §Architecture is sufficient and the staleness-bounded fallback path is not load-bearing for v0.2.

## Gate 3 runbook

Swap base image from `vllm/vllm-openai:0.19.1` → `runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04`. The vllm-openai image runs vLLM as PID 1 with no sshd — breaks the SSH-coupled bench orchestrator that `gate_pod_bootstrap.sh` relies on. Bootstrap now pip-installs vLLM during setup.

Compose bundle (#126) keeps `vllm/vllm-openai` — that path talks to the engine over HTTP only, no SSH needed.

## Verify

RFC + runbook only; no source. ruff not relevant. The fixes were drafted from the P1 agent's `results/p1_gauge_preflight_20260502/GAUGE_FINDINGS.md` evidence (landed in #128).

Refs #103.