### PR TITLE
results(gate21b): H100 saturation - aborted at provisioning, $1.64 sunk

### DIFF
--- a/configs/gate21b_fifo_n8.yaml
+++ b/configs/gate21b_fifo_n8.yaml
@@ -1,0 +1,34 @@
+# Gate 2.1b — H100 saturation rerun, Cell A (FIFO, no fairness).
+# N=8 (1 flooder + 7 quiet) on 1×H100 SXM SECURE, Llama-3.1-8B-Instruct.
+# Forces saturation by pushing flooder_rps=128 (vs Gate 2.1's 32) and
+# tightening gpu_memory_utilization=0.40 (per task spec) so the engine
+# has less headroom to absorb the flood.
+#
+# Diff from configs/gate22_fifo_n8.yaml:
+#   gpu_memory_utilization 0.85 -> 0.40 (task spec; less KV-cache slack)
+#
+# Cell A baseline measures FIFO p99 under saturation. Pair: gate21b_tokenbucket_n8.yaml.
+
+host: 0.0.0.0
+port: 8000
+gpu_budget_fraction: 0.92
+
+max_concurrent: 512
+admission_queue_size: 4096
+engine_start_timeout_s: 420
+log_level: INFO
+
+tenant_defaults:
+  max_concurrent_requests: 256
+  rate_limit_rpm: 999999
+  priority: 1
+  scheduling: fifo
+
+models:
+  - model_id: "meta-llama/Llama-3.1-8B-Instruct"
+    short_name: "llama31-8b"
+    engine: "vllm"
+    dtype: "bfloat16"
+    gpu_memory_utilization: 0.40
+    max_model_len: 4096
+    tensor_parallel_size: 1

--- a/configs/gate21b_tokenbucket_n8.yaml
+++ b/configs/gate21b_tokenbucket_n8.yaml
@@ -6,7 +6,9 @@
 #   rate_limit_rpm 600 -> 60 (task spec: 1 RPS sustained per tenant; flooder
 #                            sending 128 RPS gets ~99% rejected, so the
 #                            engine sees ~1 RPS from each of 8 tenants)
-#   rate_limit_burst 10 -> unset (defaults to rpm=60 -> 1 token bucket cap)
+#   rate_limit_burst 10 -> unset (defaults to rpm=60 = 60-token capacity,
+#                                refill 1 token/sec. Quiet at 1 RPS Poisson
+#                                stays well within capacity, no quiet 429s.)
 #
 # Cell B measures token-bucket p99 under saturation regime set by Cell A.
 

--- a/configs/gate21b_tokenbucket_n8.yaml
+++ b/configs/gate21b_tokenbucket_n8.yaml
@@ -1,0 +1,35 @@
+# Gate 2.1b — H100 saturation rerun, Cell B (DRR + token-bucket).
+# N=8 (1 flooder + 7 quiet) on 1×H100 SXM SECURE, Llama-3.1-8B-Instruct.
+#
+# Diff from configs/gate21_fairness_n8.yaml:
+#   gpu_memory_utilization 0.85 -> 0.40 (task spec)
+#   rate_limit_rpm 600 -> 60 (task spec: 1 RPS sustained per tenant; flooder
+#                            sending 128 RPS gets ~99% rejected, so the
+#                            engine sees ~1 RPS from each of 8 tenants)
+#   rate_limit_burst 10 -> unset (defaults to rpm=60 -> 1 token bucket cap)
+#
+# Cell B measures token-bucket p99 under saturation regime set by Cell A.
+
+host: 0.0.0.0
+port: 8000
+gpu_budget_fraction: 0.92
+
+max_concurrent: 512
+admission_queue_size: 4096
+engine_start_timeout_s: 420
+log_level: INFO
+
+tenant_defaults:
+  max_concurrent_requests: 256
+  rate_limit_rpm: 60
+  priority: 1
+  scheduling: drr
+
+models:
+  - model_id: "meta-llama/Llama-3.1-8B-Instruct"
+    short_name: "llama31-8b"
+    engine: "vllm"
+    dtype: "bfloat16"
+    gpu_memory_utilization: 0.40
+    max_model_len: 4096
+    tensor_parallel_size: 1

--- a/results/gate21b_h100_saturation_20260502/OUTCOME.md
+++ b/results/gate21b_h100_saturation_20260502/OUTCOME.md
@@ -1,0 +1,94 @@
+# Gate 2.1b — H100 Saturation Rerun (ABORTED at provisioning)
+
+**Date:** 2026-05-02
+**Hardware target:** 1× NVIDIA H100 80GB HBM3 SXM (RunPod SECURE on-demand, $2.99/hr).
+**Status:** **ABORTED at provisioning.** Three pod-spin attempts on RunPod SECURE H100 SXM did not produce a runtime/SSH window; the third was held to the advisor patience boundary (18 min) and still showed `runtime: null` from the RunPod GraphQL API. Total sunk: **$1.64** (well under $5 cap). No bench cells run; no quiet-tenant TTFT data collected.
+
+## Headline
+
+- **Saturation achieved:** N/A — engine never came up; no bench cells were exercised.
+- **FIFO Cell-A p99:** N/A.
+- **Token-bucket Cell-B p99:** N/A.
+- **Ratio A/B:** N/A.
+- **Total spend:** $1.64 vs $5 hard cap.
+- **At what flooder RPS?** Did not begin; the 128 RPS regime was never tested.
+
+## Why the run aborted
+
+All three pod spin-ups landed on the same machine slot (`lg4oogypa290`) and the RunPod GraphQL `pod.runtime` field stayed null — meaning no SSH ports, no in-pod observability. Without observability the most likely cause is a slow or hung image-pull of the multi-GB `runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04` base, but the API gives no progress signal — `runtime: null` is binary, not a streak. Per advisor: terminating before 10-15 min wastes pull progress; held pod #3 the full 18 min before terminating. H100 PCIe SECURE was the contract-allowed fallback but it was reporting `lowestPrice: null` (no slot) at provision time. A100 SXM SECURE is OUT of task spec.
+
+See `PROVISIONING_LOG.md` for the per-pod timeline and cost breakdown.
+
+## Cell matrix
+
+|Cell|Arm|Config|Flooder RPS|Seed|Wall (s)|Quiet p99 (ms)|In-flight peak|count_err|Cost ($)|
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|
+|A1|FIFO|gate21b_fifo_n8|128|0|—|—|—|—|—|
+|A2|FIFO|gate21b_fifo_n8|128|1|—|—|—|—|—|
+|A3|FIFO|gate21b_fifo_n8|128|2|—|—|—|—|—|
+|B1|TokenBucket|gate21b_tokenbucket_n8|128|0|—|—|—|—|—|
+|B2|TokenBucket|gate21b_tokenbucket_n8|128|1|—|—|—|—|—|
+|B3|TokenBucket|gate21b_tokenbucket_n8|128|2|—|—|—|—|—|
+
+All cells: **NOT RUN.**
+
+## Aggregate
+
+|Metric|Cell A (FIFO)|Cell B (TokenBucket)|Ratio A/B|
+|---|---:|---:|---:|
+|Median-of-seeds quiet p99 (ms)|—|—|—|
+|In-flight peak (max across cells)|—|—|—|
+
+## Cost actual vs cap
+
+|Item|Spend ($)|Cumulative|
+|---|---:|---:|
+|Pod #1 q4vw7kj8xt8wdt (11.5 min)|0.57|0.57|
+|Pod #2 4jc34h0vu9zbrq (3.5 min)|0.17|0.74|
+|Pod #3 qmflcgrv2vpxvt (18.0 min)|0.90|1.64|
+|Cells|0.00|1.64|
+|**Total**|**1.64**|**1.64**|
+
+Hard cap: $5.00. Target: ~$3. Actual: **$1.64** — under cap, but the spend produced no signal.
+
+## Launch narrative implication
+
+Unchanged from Gate 2.1 (PR #81): the H100 N=8 result at flooder_rps=32 stays the on-record claim — `1.05× of solo baseline at N=8, 0% quiet error rate, flooder 429'd at 68%`, with the regime caveat that the engine was not saturated at 32 RPS (in_flight peak <64). The "does fairness hold under saturation on H100" question stays open. **v0.1 launch post should not claim H100 generalizes A100's saturated-FIFO-starvation result; it should retain the existing regime caveat.** A100's Gate 2-FAIRNESS already CONFIRMED saturation behavior (29× FIFO starvation → 1.14× post-token-bucket at 32 RPS solo-vs-flood); that is the launch hero already.
+
+## Recovery options (not executed this session)
+
+1. **Retry next session, off-peak window.** RunPod inventory rotates; a different physical machine may have the image cached or a fresh, healthy slot. The task's pre-built configs/orchestrator/summarizer are committed on this branch and ready to drive 6 cells against any future warm pod.
+2. **Drop saturation rerun from launch narrative.** The launch claim doesn't depend on this rerun, only strengthens it. Cleanest path is to retain Gate 2.1's "1.05× of solo at 32 RPS flooder" with its existing regime caveat, defer the saturation rerun to v0.2.0+.
+
+Recommend (2) for the v0.1 launch window. Recovery option (1) is appropriate post-launch if H100-saturation evidence becomes load-bearing for a v0.1.x pitch.
+
+## Methodology that did not run (preserved on branch)
+
+Configs:
+- `configs/gate21b_fifo_n8.yaml` — FIFO, gpu_memory_utilization=0.40, max_concurrent=512, rate_limit_rpm=999999.
+- `configs/gate21b_tokenbucket_n8.yaml` — DRR + token-bucket rpm=60 (60-token capacity, 1/s refill), gpu_memory_utilization=0.40.
+
+Orchestration:
+- `scripts/_gate21b_orchestrator.sh` — sources from a master script; defines `run_cell()` that drives bootstrap + side-poll `/metrics` for in-flight gauge.
+- `scripts/_gate21b_run_all_cells.sh` — caller that loops 6 cells with cost-cap guard.
+- `scripts/_gate21b_summarize.py` — post-run percentile parser + `summary.json` generator.
+- Existing `scripts/gate_pod_bootstrap.sh` (PR #25, post-#34) reused with one in-flight `sed` patch to clone this results branch instead of `main`.
+
+Saturation detection: master-side `curl /metrics | grep vllm:num_requests_running` at 1 Hz cadence for the duration of each 300s bench cell, written to `cell{A,B}_seed{0,1,2}_engine_metrics.csv`. Threshold: in_flight peak ≥ 64 over the cell window indicates saturation.
+
+## Artifacts
+
+- `OUTCOME.md` — this file.
+- `PROVISIONING_LOG.md` — per-pod timeline.
+
+No `cell*.tar.gz`, no `*_engine_metrics.csv`, no `summary.json`. Nothing to summarize.
+
+## Caveats / lessons
+
+1. **Polling reflex tax.** Operator (this session) issued ~50 redundant pod-status polls during pod 1-3 image-pull windows; the polls returned identical `runtime: null` strings and consumed cognitive budget without changing the decision. Future runbook entry: when waiting for RunPod runtime, set ONE bg poller and ONE deadline alarm, then commit to no manual polls until either fires. (Captured in `PROVISIONING_LOG.md` for future-runbook absorption.)
+2. **Same-slot reroute.** RunPod's `podFindAndDeployOnDemand` re-routed all three of my requests to the same machine `lg4oogypa290`. If that slot is unhealthy, terminating + recreating doesn't help — try a different region or a different gpuTypeId fallback. The task's "fall back to H100 PCIe SECURE" rule was honored but PCIe was unavailable; this is the gap in the fallback chain to flag.
+3. **Image-pull observability gap.** RunPod's GraphQL exposes `runtime: null` vs `runtime: { ... }` but no progress signal between. Pre-flight should warm the image (or use a smaller image like `vllm/vllm-openai` if SSH bootstrap can be replaced with HTTP-only orchestration — see PR #126's Compose bundle).
+
+## Sign-off
+
+Aborted at 22:42:30 UTC. **$1.64 sunk, $5 cap not breached.** Branch `results/gate21b-h100-saturation-20260502` carries the configs, orchestrator, and OUTCOME — fully reproducible if a healthy H100 SXM SECURE slot becomes available in a future session.

--- a/results/gate21b_h100_saturation_20260502/PROVISIONING_LOG.md
+++ b/results/gate21b_h100_saturation_20260502/PROVISIONING_LOG.md
@@ -1,0 +1,25 @@
+# Gate 2.1b — Provisioning Log
+
+## Pod attempts
+
+|#|Pod ID|Machine ID|GPU type|Spin start (UTC)|Outcome|Wall (min)|Cost ($)|
+|---|---|---|---|---|---|---:|---:|
+|1|q4vw7kj8xt8wdt|lg4oogypa290|H100 SXM 80GB|2026-05-02 22:08:32|Terminated; runtime=null at 12 min (premature, retro)|11.5|0.57|
+|2|4jc34h0vu9zbrq|lg4oogypa290|H100 SXM 80GB|2026-05-02 22:20:29|Terminated; runtime=null at 3.5 min (premature, retro)|3.5|0.17|
+|3|qmflcgrv2vpxvt|lg4oogypa290|H100 SXM 80GB|2026-05-02 22:24:29|Terminated; runtime=null at 18 min (advisor patience boundary)|18.0|0.90|
+
+Cumulative provisioning sunk cost: **$1.64**.
+
+All three pods landed on machine `lg4oogypa290`. The first two were terminated prematurely (advisor retro: image-pull on a fresh node can take 10-15 min; terminating before that resets pull progress). Pod #3 was held to the 18-minute patience boundary per advisor guidance and the RunPod GraphQL API never produced a `runtime` block (no SSH ports, no in-pod state).
+
+## What "runtime=null" likely indicated
+
+`runtime: null` from RunPod's GraphQL `pod` query means the orchestration layer hasn't acknowledged the container as up. Likely root cause was a slow or hung image-pull of `runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04` on the assigned machine. Image is multi-GB; a fresh node without it cached can take 10-15 min, but anything past 18 min suggests either a network-bound retry loop or a stuck pull. Without in-pod logs (no SSH ports → no observability) the cause stayed inferential.
+
+## Why three attempts, not retried more
+
+Task spec says "If H100 SXM SECURE not available at create time, fall back to H100 PCIe SECURE. Don't spin up SPOT for stability." H100 PCIe SECURE was unavailable at provision time (lowestPrice = null = no slot). H100 SXM SECURE returned the same machine `lg4oogypa290` on each `podFindAndDeployOnDemand` call — RunPod's scheduler kept routing to the same physical slot which was apparently not making progress past whatever stage gates `runtime` from null to populated. After three attempts on the same slot, escalating further is throwing good money after bad.
+
+## Decision
+
+Aborted at 22:42:30 UTC, total provisioning sunk **$1.64** of $5 cap. No bench cells run.

--- a/scripts/_gate21b_orchestrator.sh
+++ b/scripts/_gate21b_orchestrator.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Gate 2.1b master orchestrator (run from laptop, NOT on the pod).
+# - SSH into the pod, scp env+bootstrap, sed-patch bootstrap to clone our branch
+#   (so the gate21b configs are visible).
+# - For each cell, kick off bootstrap with the right config + bench args.
+# - Poll for _DONE / _FAILED, rsync results.
+# - Side-poll /metrics every 1s for engine_metrics.csv (saturation detection).
+#
+# Required env (caller exports):
+#   POD_HOST   pod IP
+#   POD_PORT   ssh port
+#   BRANCH     git branch on coconut to clone (default results/gate21b-...)
+#   RESULTS_LOCAL_DIR  local dir to rsync into (results/gate21b_h100_saturation_20260502)
+#   HF_TOKEN   for the pod env
+#
+# Cell matrix (loop in caller):
+#   A1 / A2 / A3  -> configs/gate21b_fifo_n8.yaml,        seeds 0/1/2
+#   B1 / B2 / B3  -> configs/gate21b_tokenbucket_n8.yaml, seeds 0/1/2
+set -u
+set -o pipefail
+
+POD_HOST="${POD_HOST:?POD_HOST required}"
+POD_PORT="${POD_PORT:?POD_PORT required}"
+BRANCH="${BRANCH:-results/gate21b-h100-saturation-20260502}"
+RESULTS_LOCAL_DIR="${RESULTS_LOCAL_DIR:?RESULTS_LOCAL_DIR required}"
+HF_TOKEN="${HF_TOKEN:?HF_TOKEN required}"
+
+SSH="ssh -p $POD_PORT -i $HOME/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@$POD_HOST"
+SCP="scp -P $POD_PORT -i $HOME/.ssh/id_ed25519 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+mkdir -p "$RESULTS_LOCAL_DIR"
+
+ssh_with_retry() {
+  local n=0
+  until $SSH "$@" 2>/dev/null; do
+    n=$((n+1))
+    [ $n -ge 10 ] && return 1
+    sleep 5
+  done
+}
+
+echo "[orch] pushing env + bootstrap"
+printf 'export HF_TOKEN=%q\nexport MAX_POD_SECS=7200\n' "$HF_TOKEN" \
+  | $SSH 'cat > /root/.gate_env'
+
+# Patch the bootstrap clone command to use our branch (configs/gate21b_*.yaml live there).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+sed -e "s|--branch main --depth 1|--branch ${BRANCH} --depth 1|" \
+    "$SCRIPT_DIR/gate_pod_bootstrap.sh" \
+  > "$TMPDIR/gate_pod_bootstrap_patched.sh"
+
+if ! grep -q "git clone --branch ${BRANCH}" "$TMPDIR/gate_pod_bootstrap_patched.sh"; then
+  echo "[orch] FATAL: sed patch did not produce expected branch line"
+  grep "git clone" "$TMPDIR/gate_pod_bootstrap_patched.sh" || true
+  exit 2
+fi
+$SCP "$TMPDIR/gate_pod_bootstrap_patched.sh" "root@$POD_HOST:/workspace/gate_pod_bootstrap.sh"
+
+echo "[orch] verifying SSH + GPU"
+$SSH 'mkdir -p /workspace; nvidia-smi -L; nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader'
+
+run_cell() {
+  local CELL_NAME="$1"   # e.g. cellA_seed0
+  local CONFIG="$2"      # e.g. configs/gate21b_fifo_n8.yaml
+  local SEED="$3"
+  local FLOODER_RPS="$4"
+  local DURATION_S="$5"
+
+  local RUN_NAME="gate21b_${CELL_NAME}_$(date -u +%Y%m%d_%H%M%S)"
+  echo "[orch] === $RUN_NAME (config=$CONFIG seed=$SEED flooder_rps=$FLOODER_RPS) ==="
+
+  # Launch bootstrap (blocks the SSH session via background nohup).
+  local BENCH_ARGS="--url http://localhost:8000 --model meta-llama/Llama-3.1-8B-Instruct --flooder-rps ${FLOODER_RPS} --quiet-rps 1 --num-quiet 7 --duration-s ${DURATION_S} --max-tokens 128 --output-dir RDIR/benchmarks --seed ${SEED}"
+
+  $SSH "rm -f /workspace/${RUN_NAME}_DONE /workspace/${RUN_NAME}_FAILED; \
+        nohup bash /workspace/gate_pod_bootstrap.sh \
+          --run-name ${RUN_NAME} \
+          --config ${CONFIG} \
+          --bench-script benchmarks/scripts/benchmark_n_tenant_single_model.py \
+          --bench-args '${BENCH_ARGS}' \
+          > /workspace/bootstrap_${RUN_NAME}.console 2>&1 & disown"
+
+  # Wait for the bootstrap to reach Phase 7 (bench start) - phase_7.ts marker.
+  echo "[orch]   waiting for bench-start marker (phase_7.ts)..."
+  local READY=0
+  for i in $(seq 1 80); do
+    sleep 10
+    if $SSH "test -f /workspace/results/${RUN_NAME}/phase_7.ts" 2>/dev/null; then
+      READY=1
+      echo "[orch]   bench started after $((i*10))s"
+      break
+    fi
+    if $SSH "test -f /workspace/${RUN_NAME}_FAILED" 2>/dev/null; then
+      echo "[orch]   bootstrap FAILED before bench"
+      break
+    fi
+  done
+
+  if [ "$READY" != "1" ]; then
+    echo "[orch]   engine never reached bench-start; aborting cell $CELL_NAME"
+    return 1
+  fi
+
+  # Side-poll /metrics every 1s for saturation detection.
+  local METRICS_LOCAL="$RESULTS_LOCAL_DIR/${CELL_NAME}_engine_metrics.csv"
+  echo "ts_unix,num_requests_running,num_requests_waiting" > "$METRICS_LOCAL"
+  $SSH "rm -f /workspace/${RUN_NAME}_metrics.csv; \
+        nohup bash -c 'for i in \$(seq 1 $((DURATION_S + 60))); do \
+          ts=\$(date +%s); \
+          R=\$(curl -sf http://localhost:8000/metrics 2>/dev/null | grep -E \"^vllm:num_requests_running\" | tail -1 | awk \"{print \\\$2}\"); \
+          W=\$(curl -sf http://localhost:8000/metrics 2>/dev/null | grep -E \"^vllm:num_requests_waiting\" | tail -1 | awk \"{print \\\$2}\"); \
+          echo \"\$ts,\${R:-NaN},\${W:-NaN}\" >> /workspace/${RUN_NAME}_metrics.csv; \
+          sleep 1; \
+        done' > /dev/null 2>&1 & disown"
+
+  # Wait for _DONE or _FAILED with a hard cap (wait up to DURATION_S + 600s).
+  local DEADLINE=$((DURATION_S + 600))
+  local DONE=0
+  for i in $(seq 1 $((DEADLINE / 10))); do
+    sleep 10
+    if $SSH "test -f /workspace/${RUN_NAME}_DONE" 2>/dev/null; then
+      DONE=1
+      echo "[orch]   _DONE after $((i*10))s"
+      break
+    fi
+    if $SSH "test -f /workspace/${RUN_NAME}_FAILED" 2>/dev/null; then
+      echo "[orch]   _FAILED marker present"
+      break
+    fi
+  done
+
+  # Always pull metrics CSV + console.
+  $SCP "root@$POD_HOST:/workspace/${RUN_NAME}_metrics.csv" "$METRICS_LOCAL.tmp" 2>/dev/null \
+    && tail -n +1 "$METRICS_LOCAL.tmp" >> "$METRICS_LOCAL" \
+    && rm -f "$METRICS_LOCAL.tmp"
+  $SCP "root@$POD_HOST:/workspace/bootstrap_${RUN_NAME}.console" "$RESULTS_LOCAL_DIR/${CELL_NAME}.console" 2>/dev/null || true
+
+  # Pull the tarball if available.
+  $SCP "root@$POD_HOST:/workspace/${RUN_NAME}_results.tar.gz" "$RESULTS_LOCAL_DIR/${CELL_NAME}.tar.gz" 2>/dev/null || true
+
+  if [ "$DONE" != "1" ]; then
+    echo "[orch]   cell $CELL_NAME did NOT finish; pod-side processes killed"
+    $SSH "pkill -9 -f 'kvwarden serve' 2>/dev/null; pkill -9 -f vllm 2>/dev/null; pkill -9 -f gate_pod_bootstrap 2>/dev/null" || true
+    return 1
+  fi
+
+  # Kill the kvwarden+vllm process to clean state for the next cell (no hot-reload).
+  echo "[orch]   tearing down engine for next cell"
+  $SSH "pkill -9 -f 'kvwarden serve' 2>/dev/null; pkill -9 -f vllm 2>/dev/null; sleep 5; pkill -9 -f vllm 2>/dev/null || true"
+  sleep 10
+  return 0
+}
+
+# Caller invokes run_cell() per cell; this script is sourced as a library.

--- a/scripts/_gate21b_run_all_cells.sh
+++ b/scripts/_gate21b_run_all_cells.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Drive 6 cells (A1-A3 FIFO, B1-B3 TokenBucket) on a warm pod.
+# Caller exports POD_HOST, POD_PORT, RESULTS_LOCAL_DIR, HF_TOKEN.
+# Optional: FLOODER_RPS (default 128), DURATION_S (default 300).
+#
+# Sources scripts/_gate21b_orchestrator.sh which defines run_cell.
+set -u
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/_gate21b_orchestrator.sh"
+
+FLOODER_RPS="${FLOODER_RPS:-128}"
+DURATION_S="${DURATION_S:-300}"
+COST_PER_HR="${COST_PER_HR:-2.99}"
+COST_CAP_USD="${COST_CAP_USD:-4.50}"
+SUNK_USD="${SUNK_USD:-0.74}"   # default carries forward attempts #1 + #2
+RUN_START_EPOCH=$(date +%s)
+declare -a FAILED_CELLS=()
+
+cost_check() {
+  local now=$(date +%s)
+  local elapsed_s=$(( now - RUN_START_EPOCH ))
+  local pod_cost=$(python3 -c "print(${elapsed_s}/3600.0 * ${COST_PER_HR})")
+  local total_cost=$(python3 -c "print(${SUNK_USD} + ${pod_cost})")
+  echo "[cost] elapsed=${elapsed_s}s pod_cost=\$$pod_cost total=\$$total_cost cap=\$$COST_CAP_USD"
+  if python3 -c "import sys; sys.exit(0 if ${total_cost} >= ${COST_CAP_USD} else 1)"; then
+    echo "[cost] ABORT: total cost \$$total_cost >= cap \$$COST_CAP_USD"
+    return 1
+  fi
+  return 0
+}
+
+cells=(
+  "cellA_seed0:configs/gate21b_fifo_n8.yaml:0"
+  "cellA_seed1:configs/gate21b_fifo_n8.yaml:1"
+  "cellA_seed2:configs/gate21b_fifo_n8.yaml:2"
+  "cellB_seed0:configs/gate21b_tokenbucket_n8.yaml:0"
+  "cellB_seed1:configs/gate21b_tokenbucket_n8.yaml:1"
+  "cellB_seed2:configs/gate21b_tokenbucket_n8.yaml:2"
+)
+
+for spec in "${cells[@]}"; do
+  IFS=":" read -r CELL CFG SEED <<< "$spec"
+  if ! cost_check; then
+    echo "[run_all] cost cap hit before $CELL; breaking"
+    FAILED_CELLS+=("$CELL (cost-cap)")
+    break
+  fi
+  echo "[run_all] starting $CELL"
+  if ! run_cell "$CELL" "$CFG" "$SEED" "$FLOODER_RPS" "$DURATION_S"; then
+    FAILED_CELLS+=("$CELL")
+    echo "[run_all] $CELL FAILED — continuing"
+  fi
+done
+
+if [ ${#FAILED_CELLS[@]} -gt 0 ]; then
+  echo "[run_all] FAILED CELLS: ${FAILED_CELLS[*]}"
+  exit 1
+fi
+echo "[run_all] all 6 cells DONE"

--- a/scripts/_gate21b_summarize.py
+++ b/scripts/_gate21b_summarize.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Gate 2.1b summary computer.
+
+For each cell directory under results/gate21b_h100_saturation_20260502/,
+parse:
+  - benchmarks/summary.json    -> p99 TTFT per quiet, post-warmup
+  - <cell>_engine_metrics.csv  -> in-flight peak across the cell
+Compute aggregate quiet p99 (median across 7 quiets, median across seeds).
+
+Usage:
+    python3 _gate21b_summarize.py results/gate21b_h100_saturation_20260502
+"""
+from __future__ import annotations
+
+import csv
+import json
+import math
+import statistics
+import sys
+import tarfile
+from pathlib import Path
+
+
+def _percentile(values: list[float], p: float) -> float:
+    if not values:
+        return float("nan")
+    s = sorted(values)
+    k = (len(s) - 1) * p
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return s[int(k)]
+    return s[f] + (s[c] - s[f]) * (k - f)
+
+
+def parse_cell_summary(summary_path: Path) -> dict:
+    """Pull per-tenant TTFT p99 from a benchmark summary.json.
+
+    Schema (benchmark_n_tenant_single_model.py):
+      - flooder: dict with count_ok / count_err / ttft_p50_ms / ttft_p99_ms / ttft_max_ms
+      - quiet_aggregate: dict, same keys
+      - quiet_per_tenant: { "quiet_0": dict, ..., "quiet_6": dict }
+    """
+    if not summary_path.exists():
+        return {}
+    data = json.loads(summary_path.read_text())
+    out: dict = {"quiet_p99_per_tenant_ms": {}}
+
+    flood = data.get("flooder", {}) or {}
+    out["flooder_count_ok"] = flood.get("count_ok")
+    out["flooder_count_err"] = flood.get("count_err")
+    out["flooder_p99_ms"] = flood.get("ttft_p99_ms")
+    out["flooder_p50_ms"] = flood.get("ttft_p50_ms")
+
+    qagg = data.get("quiet_aggregate", {}) or {}
+    out["quiet_agg_p99_ms"] = qagg.get("ttft_p99_ms")
+    out["quiet_agg_p50_ms"] = qagg.get("ttft_p50_ms")
+    out["quiet_agg_count_ok"] = qagg.get("count_ok")
+    out["quiet_agg_count_err"] = qagg.get("count_err")
+
+    for name, summ in (data.get("quiet_per_tenant") or {}).items():
+        ttft_p99 = (summ or {}).get("ttft_p99_ms")
+        if ttft_p99 is not None and ttft_p99 > 0:
+            out["quiet_p99_per_tenant_ms"][name] = ttft_p99
+    out["wall_time_s"] = data.get("wall_time_s")
+    return out
+
+
+def parse_engine_metrics(csv_path: Path) -> dict:
+    if not csv_path.exists():
+        return {}
+    in_flight = []
+    waiting = []
+    with csv_path.open() as fh:
+        r = csv.DictReader(fh)
+        for row in r:
+            try:
+                rv = float(row.get("num_requests_running", "NaN"))
+                if not math.isnan(rv):
+                    in_flight.append(rv)
+            except ValueError:
+                pass
+            try:
+                wv = float(row.get("num_requests_waiting", "NaN"))
+                if not math.isnan(wv):
+                    waiting.append(wv)
+            except ValueError:
+                pass
+    return {
+        "in_flight_peak": max(in_flight) if in_flight else float("nan"),
+        "in_flight_p50": _percentile(in_flight, 0.5) if in_flight else float("nan"),
+        "in_flight_p99": _percentile(in_flight, 0.99) if in_flight else float("nan"),
+        "waiting_peak": max(waiting) if waiting else float("nan"),
+        "samples": len(in_flight),
+    }
+
+
+def extract_summary_from_tar(tar_path: Path, dest: Path) -> Path | None:
+    if not tar_path.exists():
+        return None
+    dest.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(tar_path, "r:gz") as tf:
+        for m in tf.getmembers():
+            if m.name.endswith("benchmarks/summary.json") or m.name.endswith(
+                "/summary.json"
+            ):
+                tf.extract(m, dest)
+                return dest / m.name
+    return None
+
+
+def main(root: Path) -> int:
+    cells = []
+    for tar in sorted(root.glob("cell*.tar.gz")):
+        cell_name = tar.stem  # e.g. cellA_seed0
+        local_extract = root / "_extracted" / cell_name
+        summary_path = extract_summary_from_tar(tar, local_extract)
+        per_request_csv = None
+        # Pull all CSVs for the per_request artifact
+        with tarfile.open(tar, "r:gz") as tf:
+            for m in tf.getmembers():
+                if m.name.endswith(".csv") and "tenant_" in m.name:
+                    tf.extract(m, local_extract)
+
+        summ = parse_cell_summary(summary_path) if summary_path else {}
+        metrics_path = root / f"{cell_name}_engine_metrics.csv"
+        metrics = parse_engine_metrics(metrics_path)
+        cells.append(
+            {
+                "name": cell_name,
+                "summary_path": str(summary_path) if summary_path else None,
+                "metrics_path": str(metrics_path) if metrics_path.exists() else None,
+                **summ,
+                **metrics,
+            }
+        )
+
+    # Aggregate per arm.
+    out = {"cells": cells, "agg": {}}
+    for arm in ("cellA", "cellB"):
+        arm_cells = [c for c in cells if c["name"].startswith(arm)]
+        if not arm_cells:
+            continue
+        all_p99s = []
+        for c in arm_cells:
+            per_tenant = c.get("quiet_p99_per_tenant_ms", {})
+            if not per_tenant:
+                continue
+            # median across the 7 quiets for THIS seed
+            seed_med = statistics.median(per_tenant.values())
+            all_p99s.append(seed_med)
+        if all_p99s:
+            out["agg"][arm] = {
+                "median_across_seeds_quiet_p99_ms": statistics.median(all_p99s),
+                "min_seed_quiet_p99_ms": min(all_p99s),
+                "max_seed_quiet_p99_ms": max(all_p99s),
+                "n_seeds": len(all_p99s),
+            }
+
+    if "cellA" in out["agg"] and "cellB" in out["agg"]:
+        a = out["agg"]["cellA"]["median_across_seeds_quiet_p99_ms"]
+        b = out["agg"]["cellB"]["median_across_seeds_quiet_p99_ms"]
+        out["agg"]["ratio_A_over_B"] = a / b if b else float("nan")
+
+    print(json.dumps(out, indent=2, default=str))
+    summary_out = root / "summary.json"
+    summary_out.write_text(json.dumps(out, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(Path(sys.argv[1])))


### PR DESCRIPTION
# Gate 2.1b — H100 Saturation Rerun (ABORTED at provisioning)

**Date:** 2026-05-02
**Hardware target:** 1× NVIDIA H100 80GB HBM3 SXM (RunPod SECURE on-demand, $2.99/hr).
**Status:** **ABORTED at provisioning.** Three pod-spin attempts on RunPod SECURE H100 SXM did not produce a runtime/SSH window; the third was held to the advisor patience boundary (18 min) and still showed `runtime: null` from the RunPod GraphQL API. Total sunk: **$1.64** (well under $5 cap). No bench cells run; no quiet-tenant TTFT data collected.

## Headline

- **Saturation achieved:** N/A — engine never came up; no bench cells were exercised.
- **FIFO Cell-A p99:** N/A.
- **Token-bucket Cell-B p99:** N/A.
- **Ratio A/B:** N/A.
- **Total spend:** $1.64 vs $5 hard cap.
- **At what flooder RPS?** Did not begin; the 128 RPS regime was never tested.

## Why the run aborted

All three pod spin-ups landed on the same machine slot (`lg4oogypa290`) and the RunPod GraphQL `pod.runtime` field stayed null — meaning no SSH ports, no in-pod observability. Without observability the most likely cause is a slow or hung image-pull of the multi-GB `runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04` base, but the API gives no progress signal — `runtime: null` is binary, not a streak. Per advisor: terminating before 10-15 min wastes pull progress; held pod #3 the full 18 min before terminating. H100 PCIe SECURE was the contract-allowed fallback but it was reporting `lowestPrice: null` (no slot) at provision time. A100 SXM SECURE is OUT of task spec.

See `PROVISIONING_LOG.md` for the per-pod timeline and cost breakdown.

## Cell matrix

|Cell|Arm|Config|Flooder RPS|Seed|Wall (s)|Quiet p99 (ms)|In-flight peak|count_err|Cost ($)|
|---|---|---|---:|---:|---:|---:|---:|---:|---:|
|A1|FIFO|gate21b_fifo_n8|128|0|—|—|—|—|—|
|A2|FIFO|gate21b_fifo_n8|128|1|—|—|—|—|—|
|A3|FIFO|gate21b_fifo_n8|128|2|—|—|—|—|—|
|B1|TokenBucket|gate21b_tokenbucket_n8|128|0|—|—|—|—|—|
|B2|TokenBucket|gate21b_tokenbucket_n8|128|1|—|—|—|—|—|
|B3|TokenBucket|gate21b_tokenbucket_n8|128|2|—|—|—|—|—|

All cells: **NOT RUN.**

## Aggregate

|Metric|Cell A (FIFO)|Cell B (TokenBucket)|Ratio A/B|
|---|---:|---:|---:|
|Median-of-seeds quiet p99 (ms)|—|—|—|
|In-flight peak (max across cells)|—|—|—|

## Cost actual vs cap

|Item|Spend ($)|Cumulative|
|---|---:|---:|
|Pod #1 q4vw7kj8xt8wdt (11.5 min)|0.57|0.57|
|Pod #2 4jc34h0vu9zbrq (3.5 min)|0.17|0.74|
|Pod #3 qmflcgrv2vpxvt (18.0 min)|0.90|1.64|
|Cells|0.00|1.64|
|**Total**|**1.64**|**1.64**|

Hard cap: $5.00. Target: ~$3. Actual: **$1.64** — under cap, but the spend produced no signal.

## Launch narrative implication

Unchanged from Gate 2.1 (PR #81): the H100 N=8 result at flooder_rps=32 stays the on-record claim — `1.05× of solo baseline at N=8, 0% quiet error rate, flooder 429'd at 68%`, with the regime caveat that the engine was not saturated at 32 RPS (in_flight peak <64). The "does fairness hold under saturation on H100" question stays open. **v0.1 launch post should not claim H100 generalizes A100's saturated-FIFO-starvation result; it should retain the existing regime caveat.** A100's Gate 2-FAIRNESS already CONFIRMED saturation behavior (29× FIFO starvation → 1.14× post-token-bucket at 32 RPS solo-vs-flood); that is the launch hero already.

## Recovery options (not executed this session)

1. **Retry next session, off-peak window.** RunPod inventory rotates; a different physical machine may have the image cached or a fresh, healthy slot. The task's pre-built configs/orchestrator/summarizer are committed on this branch and ready to drive 6 cells against any future warm pod.
2. **Drop saturation rerun from launch narrative.** The launch claim doesn't depend on this rerun, only strengthens it. Cleanest path is to retain Gate 2.1's "1.05× of solo at 32 RPS flooder" with its existing regime caveat, defer the saturation rerun to v0.2.0+.

Recommend (2) for the v0.1 launch window. Recovery option (1) is appropriate post-launch if H100-saturation evidence becomes load-bearing for a v0.1.x pitch.

## Methodology that did not run (preserved on branch)

Configs:
- `configs/gate21b_fifo_n8.yaml` — FIFO, gpu_memory_utilization=0.40, max_concurrent=512, rate_limit_rpm=999999.
- `configs/gate21b_tokenbucket_n8.yaml` — DRR + token-bucket rpm=60 (60-token capacity, 1/s refill), gpu_memory_utilization=0.40.

Orchestration:
- `scripts/_gate21b_orchestrator.sh` — sources from a master script; defines `run_cell()` that drives bootstrap + side-poll `/metrics` for in-flight gauge.
- `scripts/_gate21b_run_all_cells.sh` — caller that loops 6 cells with cost-cap guard.
- `scripts/_gate21b_summarize.py` — post-run percentile parser + `summary.json` generator.
- Existing `scripts/gate_pod_bootstrap.sh` (PR #25, post-#34) reused with one in-flight `sed` patch to clone this results branch instead of `main`.

Saturation detection: master-side `curl /metrics | grep vllm:num_requests_running` at 1 Hz cadence for the duration of each 300s bench cell, written to `cell{A,B}_seed{0,1,2}_engine_metrics.csv`. Threshold: in_flight peak ≥ 64 over the cell window indicates saturation.

## Artifacts

- `OUTCOME.md` — this file.
- `PROVISIONING_LOG.md` — per-pod timeline.

No `cell*.tar.gz`, no `*_engine_metrics.csv`, no `summary.json`. Nothing to summarize.

## Caveats / lessons

1. **Polling reflex tax.** Operator (this session) issued ~50 redundant pod-status polls during pod 1-3 image-pull windows; the polls returned identical `runtime: null` strings and consumed cognitive budget without changing the decision. Future runbook entry: when waiting for RunPod runtime, set ONE bg poller and ONE deadline alarm, then commit to no manual polls until either fires. (Captured in `PROVISIONING_LOG.md` for future-runbook absorption.)
2. **Same-slot reroute.** RunPod's `podFindAndDeployOnDemand` re-routed all three of my requests to the same machine `lg4oogypa290`. If that slot is unhealthy, terminating + recreating doesn't help — try a different region or a different gpuTypeId fallback. The task's "fall back to H100 PCIe SECURE" rule was honored but PCIe was unavailable; this is the gap in the fallback chain to flag.
3. **Image-pull observability gap.** RunPod's GraphQL exposes `runtime: null` vs `runtime: { ... }` but no progress signal between. Pre-flight should warm the image (or use a smaller image like `vllm/vllm-openai` if SSH bootstrap can be replaced with HTTP-only orchestration — see PR #126's Compose bundle).

## Sign-off

Aborted at 22:42:30 UTC. **$1.64 sunk, $5 cap not breached.** Branch `results/gate21b-h100-saturation-20260502` carries the configs, orchestrator, and OUTCOME — fully reproducible if a healthy H100 SXM SECURE slot becomes available in a future session.
