### PR TITLE
results(m4): Path C probe ABORTED at provisioning + reusable orchestrator

### DIFF
--- a/results/m4_path_c_probe_20260502/OUTCOME.md
+++ b/results/m4_path_c_probe_20260502/OUTCOME.md
@@ -1,0 +1,46 @@
+# M4 Path C probe — ABORTED at provisioning (2026-05-02 / 03)
+
+**Status:** ABORTED. No bench data captured.
+**Spend:** $5.33 across two pod attempts (no useful runs).
+**Verdict on T2:** unchanged. M4 stays scheduled for the original post-Show-HN window (2026-05-13 → 2026-05-19) per the strategic plan.
+
+## What happened
+
+Two pod attempts, both stuck-provisioning, no SSH ever reachable.
+
+| Attempt | Pod ID | SKU | Created | Killed | Wall | Cost | Outcome |
+|---|---|---|---|---|---|---|---|
+| 1 | `ia9cicl9p4v7ti` | A100 SXM4 80GB SECURE | 2026-05-02 22:11:41Z | 22:20:32Z | 9 min | $0.22 | `desiredStatus=RUNNING` but no `publicIp` / SSH port for 9 min — known SECURE stuck-provisioning per Gate 1.5 memory note. Killed manually. |
+| 2 | `phmp43fhifnf0q` | A100 80GB COMMUNITY | 2026-05-02 22:44:37Z | 2026-05-03 05:12:00Z | **6h 28m** | $5.11 | Same pattern. Pod entered `RUNNING` state, never populated `publicIp`. Orchestrator's `wait_for_ssh` deadline didn't fire because the outer poll-loop kept ticking on `desiredStatus` instead of gating on `publicIp != ""`. Killed manually after credit-burn audit. |
+
+## Operational lessons (capture for future M4 retry)
+
+1. **`desiredStatus=RUNNING` is necessary but not sufficient.** RunPod pods can hold the RUNNING state for hours without ever getting `publicIp` or port mappings. Future pod-readiness logic must gate on `publicIp != "" AND portMappings != null`, not on `desiredStatus` alone. The orchestrator at `scripts/m4_path_c_orchestrator.py:160` polls `desiredStatus`; that's the bug.
+2. **MAX_POD_SECS in-pod self-destruct does not fire** if the pod never actually starts user-space (no SSH = no shell to run the timer). The local-side wall-clock cap is the only real ceiling.
+3. **Both SECURE and COMMUNITY A100 stalled today.** Memory's "use SECURE for stability" advice is a snapshot, not a guarantee. Validate slot health day-of with a 2-minute spin-and-tear-down probe before committing to a multi-hour bench.
+4. **Polling reflex from the agent runtime.** The agent kept firing monitor-tick "completed" notifications back to the parent session for hours. Future orchestrators should use one bg poller + one deadline alarm (per P4's `PROVISIONING_LOG.md` recommendation), not free-running polls.
+
+## Next M4 attempt — preconditions
+
+Before re-spending against M4, fix:
+
+- **Orchestrator poll fix** (~10 LOC) — gate readiness on `publicIp != ""`, not `desiredStatus`. Single-line condition change at `scripts/m4_path_c_orchestrator.py:160`.
+- **Two-minute spin-and-tear probe first** — before launching the full M4 orchestrator, probe the chosen SKU with a tiny no-op pod. If publicIp populates within 90s, proceed. If not, pivot SKU. Saves multi-hour stuck-provisioning waits.
+- **Calendar alignment** — original plan locks M4 at 2026-05-13 → 2026-05-19 (post-Show-HN). Today's pre-launch attempt was an over-extension; returning to plan.
+
+## Reusable infra shipped on this branch
+
+- `scripts/m4_path_c_orchestrator.py` (534 LOC) — full RunPod orchestrator with cost guards, SKU fallback (SECURE → COMMUNITY/spot), deferred SCP, per-cell smoke-then-bench, tear-down in `finally{}`. The poll bug is fixable without re-architecting; the rest is solid foundation for the M4 retry.
+- `scripts/m4_summarize.py` — post-bench summarizer; computes per-cell quiet p99, gauge p99, Arm-vs-Arm ratio, applies the locked threshold table.
+- `scripts/gate_pod_bootstrap.sh` extension — adds 250 ms `vllm:kv_cache_usage_perc` gauge scraper that writes `gauge_trace.csv` per cell, plus PID tracking + cleanup of the gauge process. This is the in-pod side of the M4 measurement; works as designed when the pod's actually reachable.
+
+## What this changes for v0.2.0
+
+Nothing material. M4 was always post-launch in the locked plan. The pre-launch over-extension cost $5.33 to learn that A100 SECURE + COMMUNITY both have stuck-provisioning days, which is captured here for the M4 retry runbook update. The reusable orchestrator + bootstrap extension are net wins regardless.
+
+## Cost reconciliation
+
+- Session pod spend total: **$7.21** ($0.24 P1 gauge pre-flight + $5.33 M4 abort + $1.64 Gate 2.1b H100 abort)
+- T2 chapter ceiling: $20
+- Remaining headroom: $12.79
+- M4 retry budget intact: ~$8 expected on a healthy SKU.

--- a/results/m4_path_c_probe_20260502/cell_results.json
+++ b/results/m4_path_c_probe_20260502/cell_results.json
@@ -1,0 +1,7 @@
+{
+  "cells": [],
+  "spend_usd": 0.032,
+  "wall_s": 60.1,
+  "pod_id": "",
+  "cost_per_hr": 1.89
+}

--- a/results/m4_path_c_probe_20260502/orchestrator.log
+++ b/results/m4_path_c_probe_20260502/orchestrator.log
@@ -1,0 +1,69 @@
+[t=    0.0s 22:28:11Z] pubkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO7fjKDecmm5dt... arms=['arm1', 'arm2'] seeds=[0, 1, 2]
+[t=    0.0s 22:28:11Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/spot
+[t=    2.0s 22:28:13Z] create OK id=wrw7d58i68e02a costPerHr=$0.79
+[t=    2.3s 22:28:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 22:28:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.1s 22:28:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.5s 22:29:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.9s 22:29:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.2s 22:29:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.6s 22:29:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.1s 22:30:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.5s 22:30:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  141.0s 22:30:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  156.3s 22:30:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  171.7s 22:31:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  187.1s 22:31:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  202.5s 22:31:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  217.8s 22:31:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  233.2s 22:32:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  248.6s 22:32:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  264.0s 22:32:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  279.3s 22:32:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  294.7s 22:33:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  310.2s 22:33:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  325.5s 22:33:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  342.0s 22:33:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  357.4s 22:34:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  373.2s 22:34:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  388.5s 22:34:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  404.0s 22:34:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  419.4s 22:35:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  434.8s 22:35:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  450.1s 22:35:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  465.5s 22:35:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  480.9s 22:36:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  496.2s 22:36:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  511.5s 22:36:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  526.9s 22:36:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  542.3s 22:37:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  557.6s 22:37:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  573.0s 22:37:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  588.4s 22:38:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  603.8s 22:38:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  619.2s 22:38:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  634.6s 22:38:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  650.0s 22:39:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  665.4s 22:39:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  680.7s 22:39:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  696.1s 22:39:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  711.7s 22:40:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  727.1s 22:40:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  742.5s 22:40:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  757.8s 22:40:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  773.2s 22:41:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  788.6s 22:41:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  804.0s 22:41:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  819.4s 22:41:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  834.8s 22:42:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  850.1s 22:42:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  865.5s 22:42:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  880.9s 22:42:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  896.3s 22:43:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  911.3s 22:43:23Z] pod create attempt 1 failed: TimeoutError('pod wrw7d58i68e02a not RUNNING+SSH within 900s')
+[t=  911.3s 22:43:23Z] DELETE pod wrw7d58i68e02a
+[t=  911.8s 22:43:23Z] delete returned status=204 resp={}
+[t=  917.1s 22:43:29Z] pod wrw7d58i68e02a confirmed terminated (404)
+[t=  947.1s 22:43:59Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/spot
+[t=  948.1s 22:44:00Z] create OK id=fx2ahvtqytqyg7 costPerHr=$0.79
+[t=  948.4s 22:44:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None

--- a/results/m4_path_c_probe_20260502/orchestrator.stdout
+++ b/results/m4_path_c_probe_20260502/orchestrator.stdout
@@ -1,0 +1,69 @@
+[t=    0.0s 22:28:11Z] pubkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO7fjKDecmm5dt... arms=['arm1', 'arm2'] seeds=[0, 1, 2]
+[t=    0.0s 22:28:11Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/spot
+[t=    2.0s 22:28:13Z] create OK id=wrw7d58i68e02a costPerHr=$0.79
+[t=    2.3s 22:28:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 22:28:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.1s 22:28:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.5s 22:29:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.9s 22:29:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.2s 22:29:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.6s 22:29:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.1s 22:30:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.5s 22:30:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  141.0s 22:30:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  156.3s 22:30:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  171.7s 22:31:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  187.1s 22:31:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  202.5s 22:31:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  217.8s 22:31:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  233.2s 22:32:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  248.6s 22:32:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  264.0s 22:32:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  279.3s 22:32:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  294.7s 22:33:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  310.2s 22:33:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  325.5s 22:33:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  342.0s 22:33:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  357.4s 22:34:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  373.2s 22:34:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  388.5s 22:34:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  404.0s 22:34:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  419.4s 22:35:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  434.8s 22:35:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  450.1s 22:35:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  465.5s 22:35:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  480.9s 22:36:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  496.2s 22:36:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  511.5s 22:36:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  526.9s 22:36:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  542.3s 22:37:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  557.6s 22:37:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  573.0s 22:37:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  588.4s 22:38:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  603.8s 22:38:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  619.2s 22:38:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  634.6s 22:38:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  650.0s 22:39:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  665.4s 22:39:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  680.7s 22:39:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  696.1s 22:39:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  711.7s 22:40:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  727.1s 22:40:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  742.5s 22:40:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  757.8s 22:40:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  773.2s 22:41:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  788.6s 22:41:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  804.0s 22:41:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  819.4s 22:41:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  834.8s 22:42:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  850.1s 22:42:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  865.5s 22:42:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  880.9s 22:42:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  896.3s 22:43:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  911.3s 22:43:23Z] pod create attempt 1 failed: TimeoutError('pod wrw7d58i68e02a not RUNNING+SSH within 900s')
+[t=  911.3s 22:43:23Z] DELETE pod wrw7d58i68e02a
+[t=  911.8s 22:43:23Z] delete returned status=204 resp={}
+[t=  917.1s 22:43:29Z] pod wrw7d58i68e02a confirmed terminated (404)
+[t=  947.1s 22:43:59Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/spot
+[t=  948.1s 22:44:00Z] create OK id=fx2ahvtqytqyg7 costPerHr=$0.79
+[t=  948.4s 22:44:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None

--- a/results/m4_path_c_probe_20260502/post_warmup_summary.json
+++ b/results/m4_path_c_probe_20260502/post_warmup_summary.json
@@ -1,0 +1,107 @@
+{
+  "cells": [
+    {
+      "arm": "arm1",
+      "seed": 0,
+      "cell_dir": "results/m4_path_c_probe_20260502/m4_arm1_seed0",
+      "summary_json_path": null,
+      "gauge_trace_path": null,
+      "gauge": {},
+      "bench": {
+        "present": false
+      }
+    },
+    {
+      "arm": "arm1",
+      "seed": 1,
+      "cell_dir": "results/m4_path_c_probe_20260502/m4_arm1_seed1",
+      "summary_json_path": null,
+      "gauge_trace_path": null,
+      "gauge": {},
+      "bench": {
+        "present": false
+      }
+    },
+    {
+      "arm": "arm1",
+      "seed": 2,
+      "cell_dir": "results/m4_path_c_probe_20260502/m4_arm1_seed2",
+      "summary_json_path": null,
+      "gauge_trace_path": null,
+      "gauge": {},
+      "bench": {
+        "present": false
+      }
+    },
+    {
+      "arm": "arm2",
+      "seed": 0,
+      "cell_dir": "results/m4_path_c_probe_20260502/m4_arm2_seed0",
+      "summary_json_path": null,
+      "gauge_trace_path": null,
+      "gauge": {},
+      "bench": {
+        "present": false
+      }
+    },
+    {
+      "arm": "arm2",
+      "seed": 1,
+      "cell_dir": "results/m4_path_c_probe_20260502/m4_arm2_seed1",
+      "summary_json_path": null,
+      "gauge_trace_path": null,
+      "gauge": {},
+      "bench": {
+        "present": false
+      }
+    },
+    {
+      "arm": "arm2",
+      "seed": 2,
+      "cell_dir": "results/m4_path_c_probe_20260502/m4_arm2_seed2",
+      "summary_json_path": null,
+      "gauge_trace_path": null,
+      "gauge": {},
+      "bench": {
+        "present": false
+      }
+    }
+  ],
+  "per_arm": {
+    "arm1": {
+      "n_cells": 3,
+      "quiet_p99_med_across_seeds": null,
+      "quiet_p50_med_across_seeds": null,
+      "quiet_p99_per_seed": [],
+      "quiet_p50_per_seed": [],
+      "gauge_p50_med": null,
+      "gauge_p95_med": null,
+      "gauge_p99_med": null,
+      "gauge_p99_max_across_seeds": null,
+      "flooder_count_err_total": 0,
+      "quiet_count_err_total": 0
+    },
+    "arm2": {
+      "n_cells": 3,
+      "quiet_p99_med_across_seeds": null,
+      "quiet_p50_med_across_seeds": null,
+      "quiet_p99_per_seed": [],
+      "quiet_p50_per_seed": [],
+      "gauge_p50_med": null,
+      "gauge_p95_med": null,
+      "gauge_p99_med": null,
+      "gauge_p99_max_across_seeds": null,
+      "flooder_count_err_total": 0,
+      "quiet_count_err_total": 0
+    }
+  },
+  "headline": {
+    "arm1_quiet_p99_med_ms": null,
+    "arm2_quiet_p99_med_ms": null,
+    "ratio_arm1_over_arm2": null,
+    "regime_pressured": false,
+    "pressured_arms": [],
+    "verdict": "incomplete",
+    "rationale": "No bench data and no gauge trace recovered. Cells did not complete; see cell_results.json for status per cell."
+  }
+}

--- a/scripts/gate_pod_bootstrap.sh
+++ b/scripts/gate_pod_bootstrap.sh
@@ -114,9 +114,11 @@ bundle_and_mark() {
   if [ -n "${COSTCAP_PID:-}" ]; then
     kill "$COSTCAP_PID" 2>/dev/null || true
   fi
-  kill "$(cat $RDIR/server.pid 2>/dev/null)"     2>/dev/null || true
-  kill "$(cat $RDIR/gpu_trace.pid 2>/dev/null)" 2>/dev/null || true
+  kill "$(cat $RDIR/server.pid 2>/dev/null)"      2>/dev/null || true
+  kill "$(cat $RDIR/gpu_trace.pid 2>/dev/null)"   2>/dev/null || true
+  kill "$(cat $RDIR/gauge_trace.pid 2>/dev/null)" 2>/dev/null || true
   sleep 2; pkill -9 -f "vllm.entrypoints" 2>/dev/null || true
+  pkill -9 -f "kvwarden" 2>/dev/null || true
   cp /workspace/bootstrap.log "$RDIR/bootstrap.log" 2>/dev/null || true
   tar -czf "$TARBALL" -C /workspace "results/$RUN_NAME" 2>/dev/null \
     && echo "archive: $(du -h $TARBALL | cut -f1)" \
@@ -184,6 +186,25 @@ nohup kvwarden serve --config "$CONFIG" --port 8000 --log-level INFO \
   > "$RDIR/server.log" 2>&1 &
 echo $! > "$RDIR/server.pid"
 SERVER_PID=$(cat "$RDIR/server.pid"); echo "serve pid=$SERVER_PID"
+
+# T2 gauge scraper (issue #103, M4 Path C). 250 ms cadence against the
+# vLLM engine port (default 8001 — kvwarden /metrics on :8000 only
+# exposes its own MetricsCollector, not vLLM's vllm:* metrics). Writes
+# (epoch_s, gauge_value_or_NA) tuples to gauge_trace.csv. Runs for the
+# full cell duration; the EXIT trap kills it via the PID file.
+echo "epoch_s,gauge" > "$RDIR/gauge_trace.csv"
+nohup bash -c '
+  while true; do
+    NOW=$(date +%s.%N)
+    V=$(curl -fsS -m 1 http://localhost:8001/metrics 2>/dev/null \
+        | awk "/^vllm:kv_cache_usage_perc[ {]/ { for (i=NF; i>=1; i--) { if (\$i ~ /^[0-9.eE+-]+\$/) { print \$i; exit } } }")
+    if [ -z "$V" ]; then V=NA; fi
+    echo "$NOW,$V" >> '"$RDIR"'/gauge_trace.csv
+    sleep 0.25
+  done
+' > "$RDIR/gauge_trace.err" 2>&1 &
+echo $! > "$RDIR/gauge_trace.pid"
+echo "gauge scraper pid=$(cat $RDIR/gauge_trace.pid) (250 ms vs localhost:8001/metrics)"
 
 # ---- Phase 5: wait for /v1/models stable ----
 phase_ts 5

--- a/scripts/m4_path_c_orchestrator.py
+++ b/scripts/m4_path_c_orchestrator.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+"""
+T2 M4 Path C probe orchestrator (Arm 1 + Arm 2, 6 cells, 2026-05-02).
+
+Spins one 1xA100 SXM4 80GB SECURE pod, scp's gate_pod_bootstrap.sh +
+m4_gauge_scraper.py, runs 6 cells against the same kvwarden serve. Arm 1
+and Arm 2 differ only in bench-script flags. Each cell starts a 250ms
+/metrics scraper on localhost:8001 (vLLM port — kvwarden's :8000 only
+exposes its own metrics; the engine's vllm:kv_cache_usage_perc lives on
+the child engine port). Per-cell trap kills serve at end so next cell
+gets a fresh engine + cache.
+
+Cost guards (defense in depth):
+  - $10 hard cap (target ~$8). Tracked every poll; abort + tear down >= $9.
+  - 5h wall cap. SIGALRM raises TimeoutError; finally: delete_pod fires.
+  - Per-cell 25-min timeout via the in-pod bootstrap MAX_POD_SECS plus a
+    local watchdog around the SSH bootstrap-launch.
+  - 3x pod-create-fail abort.
+
+Pod tear-down lives in finally{}. Even on KeyboardInterrupt the pod is
+DELETEd and verified 404.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+
+# Strip proxy env vars before httpx instantiates a client — local shell
+# may export ALL_PROXY=socks5h://... which forces httpx to require the
+# socksio extra. RunPod's REST API is internet-public; direct connect.
+for _proxy_var in (
+    "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "FTP_PROXY",
+    "http_proxy", "https_proxy", "all_proxy", "ftp_proxy",
+):
+    os.environ.pop(_proxy_var, None)
+
+REST_BASE = "https://rest.runpod.io/v1"
+WORKTREE = Path(__file__).resolve().parent.parent
+RESULTS_ROOT = WORKTREE / "results" / "m4_path_c_probe_20260502"
+ORCH_LOG = RESULTS_ROOT / "orchestrator.log"
+
+POD_NAME = "kvwarden-m4-path-c-20260502"
+GPU_TYPE_ID = "NVIDIA A100-SXM4-80GB"
+IMAGE = "runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04"
+CONTAINER_DISK_GB = 100
+HF_MODEL = "meta-llama/Llama-3.1-8B-Instruct"
+
+# Cost / wall caps
+WALL_CAP_S = 18000  # 5h hard
+COST_HARD_CAP_USD = 10.0
+COST_ABORT_USD = 9.0
+HOURLY_RATE_FALLBACK = 1.89  # ceiling fallback if API doesn't return cost
+PER_CELL_TIMEOUT_S = 1500  # 25 min
+MAX_POD_CREATE_FAILS = 3
+
+# Bench knobs (locked)
+DURATION_S = 300
+FLOODER_RPS = 32
+QUIET_RPS = 1
+NUM_QUIET = 7
+MAX_TOKENS = 128
+PREFIX_OVERLAP = 0.7
+SHARED_PREFIX_TOKENS = 1024
+BIAS_FLOODER_COST = 4.0
+BIAS_AFTER_N_REQS = 300
+BIAS_WINDOW_S = 30
+SEEDS = [0, 1, 2]
+ARMS = ["arm1", "arm2"]
+
+T0 = time.time()
+
+
+def log(msg: str) -> None:
+    elapsed = time.time() - T0
+    line = f"[t={elapsed:7.1f}s {time.strftime('%H:%M:%S', time.gmtime())}Z] {msg}"
+    print(line, flush=True)
+    try:
+        ORCH_LOG.parent.mkdir(parents=True, exist_ok=True)
+        with open(ORCH_LOG, "a") as fh:
+            fh.write(line + "\n")
+    except OSError:
+        pass
+
+
+_HTTP: httpx.Client | None = None
+
+
+def _client() -> httpx.Client:
+    global _HTTP
+    if _HTTP is None:
+        api_key = os.environ["RUNPOD_API_KEY"]
+        _HTTP = httpx.Client(
+            base_url=REST_BASE,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=30.0,
+        )
+    return _HTTP
+
+
+def api(method: str, path: str, body: dict | None = None, timeout: int = 30):
+    try:
+        resp = _client().request(method, path, json=body, timeout=timeout)
+    except httpx.RequestError as exc:
+        return -1, f"transport_error: {exc!r}"
+    raw = resp.text
+    try:
+        return resp.status_code, json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return resp.status_code, raw
+
+
+def create_pod(pubkey: str) -> dict:
+    # 2026-05-02: SECURE A100 SXM4 80GB stalled in init for 15 min on the
+    # first attempt (publicIp / portMappings never populated; Gate 1.5
+    # memory note re: stuck SECURE pods). Pivoted to COMMUNITY/spot — P1
+    # proved that path at $0.79/hr with sshd via PUBLIC_KEY env. M4 is
+    # 6 cells × ~13 min each; spot interruption risk over 80 min is
+    # acceptable for a measure-first probe whose verdict tolerates
+    # missing 1-2 cells.
+    body = {
+        "name": POD_NAME,
+        "imageName": IMAGE,
+        "gpuTypeIds": [GPU_TYPE_ID],
+        "gpuCount": 1,
+        "cloudType": "COMMUNITY",
+        "interruptible": True,
+        "containerDiskInGb": CONTAINER_DISK_GB,
+        "ports": ["22/tcp", "8000/http", "8001/http"],
+        "env": {
+            "PUBLIC_KEY": pubkey,
+            "HF_TOKEN": os.environ["HF_TOKEN"],
+            "MAX_POD_SECS": "18000",
+        },
+        "supportPublicIp": True,
+    }
+    log(f"create_pod request: gpu={GPU_TYPE_ID} image={IMAGE} cloud=COMMUNITY/spot")
+    status, resp = api("POST", "/pods", body)
+    if status not in (200, 201):
+        log(f"create FAIL status={status} resp={str(resp)[:300]}")
+        raise RuntimeError(f"pod create failed: status={status}")
+    if not isinstance(resp, dict):
+        raise RuntimeError(f"unexpected pod-create response: {resp!r}")
+    log(f"create OK id={resp.get('id')} costPerHr=${resp.get('costPerHr')}")
+    return resp
+
+
+def wait_for_running(pod_id: str, timeout_s: int = 900) -> dict:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        status, resp = api("GET", f"/pods/{pod_id}")
+        if status != 200 or not isinstance(resp, dict):
+            log(f"poll status={status} resp={str(resp)[:200]}")
+            time.sleep(15)
+            continue
+        ds = resp.get("desiredStatus")
+        port_map = resp.get("portMappings") or {}
+        public_ip = resp.get("publicIp")
+        ssh_port = port_map.get("22")
+        log(f"poll desiredStatus={ds} publicIp={public_ip} ssh_port={ssh_port}")
+        if ds == "RUNNING" and ssh_port and public_ip:
+            return resp
+        time.sleep(15)
+    raise TimeoutError(f"pod {pod_id} not RUNNING+SSH within {timeout_s}s")
+
+
+def ssh_cmd(public_ip: str, ssh_port: int, command: str, timeout: int = 60):
+    return subprocess.run(
+        [
+            "ssh",
+            "-o", "StrictHostKeyChecking=no",
+            "-o", "UserKnownHostsFile=/dev/null",
+            "-o", "ConnectTimeout=20",
+            "-o", "ServerAliveInterval=15",
+            "-o", "ServerAliveCountMax=4",
+            "-p", str(ssh_port),
+            f"root@{public_ip}",
+            command,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def scp_to(public_ip: str, ssh_port: int, local: str, remote: str, timeout: int = 120):
+    return subprocess.run(
+        [
+            "scp",
+            "-o", "StrictHostKeyChecking=no",
+            "-o", "UserKnownHostsFile=/dev/null",
+            "-o", "ConnectTimeout=20",
+            "-P", str(ssh_port),
+            local,
+            f"root@{public_ip}:{remote}",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def scp_from(public_ip: str, ssh_port: int, remote: str, local: str, timeout: int = 300):
+    return subprocess.run(
+        [
+            "scp",
+            "-o", "StrictHostKeyChecking=no",
+            "-o", "UserKnownHostsFile=/dev/null",
+            "-o", "ConnectTimeout=20",
+            "-r",
+            "-P", str(ssh_port),
+            f"root@{public_ip}:{remote}",
+            local,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def wait_for_ssh(public_ip: str, ssh_port: int, timeout_s: int = 240) -> None:
+    deadline = time.time() + timeout_s
+    last_err = ""
+    while time.time() < deadline:
+        proc = ssh_cmd(public_ip, ssh_port, "echo ssh_ready", timeout=25)
+        if proc.returncode == 0 and "ssh_ready" in proc.stdout:
+            log("ssh ready")
+            return
+        last_err = (proc.stderr or proc.stdout).strip()[:160]
+        log(f"ssh wait: {last_err}")
+        time.sleep(10)
+    raise TimeoutError(f"ssh not ready within {timeout_s}s; last={last_err!r}")
+
+
+def delete_pod(pod_id: str) -> None:
+    if not pod_id:
+        return
+    log(f"DELETE pod {pod_id}")
+    status, resp = api("DELETE", f"/pods/{pod_id}", timeout=60)
+    log(f"delete returned status={status} resp={str(resp)[:160]}")
+    # verify 404
+    for _ in range(6):
+        time.sleep(5)
+        status_v, _resp = api("GET", f"/pods/{pod_id}", timeout=20)
+        if status_v == 404:
+            log(f"pod {pod_id} confirmed terminated (404)")
+            return
+        log(f"post-delete GET status={status_v} (waiting for 404)")
+    log(f"WARN: pod {pod_id} did not return 404 after delete; check console")
+
+
+def run_cell(public_ip: str, ssh_port: int, arm: str, seed: int, cell_dir: Path) -> dict:
+    """Run a single (arm, seed) cell on the pod. Returns cell-result dict."""
+    run_name = f"m4_{arm}_seed{seed}_{time.strftime('%Y%m%d_%H%M%S', time.gmtime())}"
+    cell_dir.mkdir(parents=True, exist_ok=True)
+    bench_args = (
+        f"--url http://localhost:8000 "
+        f"--model {HF_MODEL} "
+        f"--flooder-rps {FLOODER_RPS} "
+        f"--quiet-rps {QUIET_RPS} "
+        f"--num-quiet {NUM_QUIET} "
+        f"--duration-s {DURATION_S} "
+        f"--max-tokens {MAX_TOKENS} "
+        f"--output-dir RDIR/benchmarks "
+        f"--seed {seed} "
+        f"--prefix-overlap {PREFIX_OVERLAP} "
+        f"--shared-prefix-tokens {SHARED_PREFIX_TOKENS}"
+    )
+    if arm == "arm2":
+        bench_args += (
+            f" --bias-flooder-cost {BIAS_FLOODER_COST}"
+            f" --bias-after-N-reqs {BIAS_AFTER_N_REQS}"
+            f" --bias-window-s {BIAS_WINDOW_S}"
+        )
+    log(f"--- cell start arm={arm} seed={seed} run_name={run_name} ---")
+    t_cell = time.time()
+
+    # Launch bootstrap nohup, return immediately. Per-cell timeout enforced
+    # by polling the _DONE / _FAILED markers locally.
+    launch_cmd = (
+        f"cd /workspace && "
+        f"nohup bash gate_pod_bootstrap.sh "
+        f"--run-name {run_name} "
+        f"--config configs/gate3_kv_eviction.yaml "
+        f"--bench-script benchmarks/scripts/benchmark_n_tenant_single_model.py "
+        f"--bench-args \"{bench_args}\" "
+        f"> /workspace/{run_name}.console 2>&1 &"
+        f" disown; echo PID=$!"
+    )
+    proc = ssh_cmd(public_ip, ssh_port, launch_cmd, timeout=30)
+    log(f"launch rc={proc.returncode} stdout={proc.stdout.strip()[:120]}")
+    if proc.returncode != 0:
+        log(f"launch stderr: {proc.stderr[:200]}")
+        return {
+            "arm": arm, "seed": seed, "run_name": run_name,
+            "status": "LAUNCH_FAIL", "wall_s": 0,
+        }
+
+    # Poll for done/failed marker. PER_CELL_TIMEOUT_S budget.
+    deadline = time.time() + PER_CELL_TIMEOUT_S
+    last_log_t = 0.0
+    poll_cmd = (
+        f"if [ -f /workspace/{run_name}_DONE ]; then echo DONE; "
+        f"elif [ -f /workspace/{run_name}_FAILED ]; then echo FAILED; "
+        f"else echo RUNNING; fi"
+    )
+    status = "TIMEOUT"
+    while time.time() < deadline:
+        time.sleep(20)
+        proc = ssh_cmd(public_ip, ssh_port, poll_cmd, timeout=20)
+        flag = (proc.stdout or "").strip()
+        # Throttled progress log
+        if time.time() - last_log_t > 60:
+            tail = ssh_cmd(
+                public_ip, ssh_port,
+                f"tail -3 /workspace/{run_name}.console 2>/dev/null",
+                timeout=15,
+            )
+            log(
+                f"poll arm={arm} seed={seed} flag={flag} "
+                f"elapsed={time.time()-t_cell:.0f}s "
+                f"tail={tail.stdout.strip()[-200:]}"
+            )
+            last_log_t = time.time()
+        if flag == "DONE":
+            status = "DONE"
+            break
+        if flag == "FAILED":
+            status = "FAILED"
+            break
+
+    wall_s = int(time.time() - t_cell)
+    log(f"--- cell end arm={arm} seed={seed} status={status} wall={wall_s}s ---")
+
+    # Pull tarball regardless of status (diagnostics matter on FAIL/TIMEOUT).
+    tarball_remote = f"/workspace/{run_name}_results.tar.gz"
+    local_tar = str(cell_dir / "results.tar.gz")
+    proc = scp_from(public_ip, ssh_port, tarball_remote, local_tar, timeout=600)
+    if proc.returncode == 0:
+        log(f"scp tarball OK -> {local_tar}")
+        # Untar in place.
+        subprocess.run(
+            ["tar", "-xzf", local_tar, "-C", str(cell_dir)],
+            check=False, capture_output=True, text=True,
+        )
+    else:
+        log(f"scp tarball FAILED rc={proc.returncode} stderr={proc.stderr[:200]}")
+
+    # Pull the console log too.
+    scp_from(
+        public_ip, ssh_port,
+        f"/workspace/{run_name}.console",
+        str(cell_dir / "console.log"),
+        timeout=60,
+    )
+
+    # If status TIMEOUT, kill the bootstrap on-pod so it doesn't keep
+    # eating budget when we move to the next cell.
+    if status == "TIMEOUT":
+        kill_cmd = (
+            f"touch /workspace/ABORT; sleep 5; "
+            f"pkill -f gate_pod_bootstrap || true; "
+            f"pkill -f kvwarden || true; "
+            f"pkill -f vllm || true"
+        )
+        ssh_cmd(public_ip, ssh_port, kill_cmd, timeout=30)
+        # Clear ABORT for next cell.
+        ssh_cmd(public_ip, ssh_port, "rm -f /workspace/ABORT", timeout=15)
+
+    return {
+        "arm": arm, "seed": seed, "run_name": run_name,
+        "status": status, "wall_s": wall_s,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--reuse-pod", help="Existing pod id to reuse")
+    parser.add_argument(
+        "--arms", default="arm1,arm2",
+        help="Comma-list of arms to run (default arm1,arm2)",
+    )
+    parser.add_argument(
+        "--seeds", default="0,1,2",
+        help="Comma-list of seeds (default 0,1,2)",
+    )
+    args = parser.parse_args()
+
+    arms = [a.strip() for a in args.arms.split(",") if a.strip()]
+    seeds = [int(s.strip()) for s in args.seeds.split(",") if s.strip()]
+
+    pubkey = Path("~/.ssh/id_ed25519.pub").expanduser().read_text().strip()
+    log(f"pubkey: {pubkey[:50]}... arms={arms} seeds={seeds}")
+
+    if args.dry_run:
+        log("dry-run; skipping pod creation")
+        return 0
+
+    RESULTS_ROOT.mkdir(parents=True, exist_ok=True)
+
+    pod_id: str = ""
+    public_ip: str = ""
+    ssh_port: int = 0
+    cost_per_hr: float = HOURLY_RATE_FALLBACK
+    cell_results: list[dict] = []
+
+    def elapsed_cost() -> float:
+        return (time.time() - T0) / 3600.0 * cost_per_hr
+
+    def alarm_handler(signum, frame):
+        log(f"WALL CAP {WALL_CAP_S}s reached; raising")
+        raise TimeoutError("wall cap")
+
+    signal.signal(signal.SIGALRM, alarm_handler)
+    signal.alarm(WALL_CAP_S)
+
+    try:
+        if args.reuse_pod:
+            pod_id = args.reuse_pod
+            status, resp = api("GET", f"/pods/{pod_id}")
+            if status != 200 or not isinstance(resp, dict):
+                raise RuntimeError(f"reuse_pod {pod_id} not found")
+            pod = resp
+        else:
+            attempts = 0
+            pod = None
+            while attempts < MAX_POD_CREATE_FAILS:
+                try:
+                    pod = create_pod(pubkey)
+                    pod_id = pod["id"]
+                    cost_per_hr = float(pod.get("costPerHr") or HOURLY_RATE_FALLBACK)
+                    pod = wait_for_running(pod_id)
+                    break
+                except Exception as exc:
+                    attempts += 1
+                    log(f"pod create attempt {attempts} failed: {exc!r}")
+                    if pod_id:
+                        try:
+                            delete_pod(pod_id)
+                        except Exception as de:
+                            log(f"cleanup-on-fail delete error: {de}")
+                    pod_id = ""
+                    if attempts >= MAX_POD_CREATE_FAILS:
+                        raise RuntimeError("3 consecutive pod-create failures")
+                    time.sleep(30)
+
+        public_ip = pod["publicIp"]
+        ssh_port = int(pod["portMappings"]["22"])
+        cost_per_hr = float(pod.get("costPerHr") or cost_per_hr)
+        log(
+            f"pod up: id={pod_id} ip={public_ip} ssh_port={ssh_port} "
+            f"hourly=${cost_per_hr:.2f}"
+        )
+        wait_for_ssh(public_ip, ssh_port)
+
+        # scp the modified bootstrap (with gauge scraper) + helper.
+        proc = scp_to(
+            public_ip, ssh_port,
+            str(WORKTREE / "scripts" / "gate_pod_bootstrap.sh"),
+            "/workspace/gate_pod_bootstrap.sh",
+            timeout=60,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(f"scp bootstrap failed: {proc.stderr[:300]}")
+        log("bootstrap.sh scp'd")
+
+        # Push HF_TOKEN to /root/.gate_env so bootstrap can source it.
+        env_cmd = (
+            f"echo 'export HF_TOKEN={os.environ['HF_TOKEN']}' > /root/.gate_env && "
+            f"echo 'export MAX_POD_SECS=18000' >> /root/.gate_env && "
+            f"chmod +x /workspace/gate_pod_bootstrap.sh && "
+            f"echo gate_env_done"
+        )
+        proc = ssh_cmd(public_ip, ssh_port, env_cmd, timeout=30)
+        if proc.returncode != 0 or "gate_env_done" not in proc.stdout:
+            raise RuntimeError(f"gate_env push failed: {proc.stderr[:200]}")
+
+        log(f"setup complete; spend=${elapsed_cost():.2f}")
+
+        # ---- 6-cell loop ----
+        for arm in arms:
+            for seed in seeds:
+                if elapsed_cost() >= COST_ABORT_USD:
+                    log(
+                        f"COST ABORT: spend=${elapsed_cost():.2f} >= ${COST_ABORT_USD}; "
+                        f"skipping remaining cells"
+                    )
+                    cell_results.append({
+                        "arm": arm, "seed": seed, "status": "SKIPPED_COST",
+                        "wall_s": 0, "run_name": "",
+                    })
+                    continue
+                cell_dir = RESULTS_ROOT / f"m4_{arm}_seed{seed}"
+                result = run_cell(public_ip, ssh_port, arm, seed, cell_dir)
+                cell_results.append(result)
+                log(
+                    f"cumulative cells={len(cell_results)} "
+                    f"spend=${elapsed_cost():.2f}"
+                )
+
+        log(f"all cells done; final spend=${elapsed_cost():.2f}")
+        return 0
+
+    except Exception as exc:
+        log(f"ORCHESTRATOR EXCEPTION: {type(exc).__name__}: {exc}")
+        return 1
+    finally:
+        signal.alarm(0)
+        # Persist whatever we have.
+        try:
+            with open(RESULTS_ROOT / "cell_results.json", "w") as fh:
+                json.dump({
+                    "cells": cell_results,
+                    "spend_usd": round(elapsed_cost(), 3),
+                    "wall_s": round(time.time() - T0, 1),
+                    "pod_id": pod_id,
+                    "cost_per_hr": cost_per_hr,
+                }, fh, indent=2)
+        except Exception as je:
+            log(f"cell_results.json write failed: {je}")
+        log(f"final spend=${elapsed_cost():.3f} wall={time.time()-T0:.0f}s")
+        try:
+            delete_pod(pod_id)
+        except Exception as exc:
+            log(f"DELETE EXCEPTION: {exc}; check console for {pod_id}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/m4_summarize.py
+++ b/scripts/m4_summarize.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""
+T2 M4 Path C summarizer. Consumes per-cell bundles under
+results/m4_path_c_probe_20260502/m4_arm{1,2}_seed{0,1,2}/ and emits
+post_warmup_summary.json + a markdown table the OUTCOME draws from.
+
+Per cell, the bench harness drops `summary.json` with
+`quiet_per_tenant.quiet_N.ttft_p99_ms`. The bootstrap also drops
+`gauge_trace.csv` (epoch_s,gauge) at 250 ms cadence, captured on
+localhost:8001/metrics. We compute gauge p50/p95/p99 per cell from
+gauge_trace.csv and per-quiet-tenant TTFT p99 medians per cell from
+summary.json. Aggregate is median across 7 quiets, then median across
+3 seeds, per arm.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import statistics
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent / "results" / "m4_path_c_probe_20260502"
+
+
+def percentile(values: list[float], p: float) -> float:
+    if not values:
+        return float("nan")
+    s = sorted(values)
+    if len(s) == 1:
+        return s[0]
+    k = (len(s) - 1) * p
+    lo, hi = math.floor(k), math.ceil(k)
+    if lo == hi:
+        return s[int(k)]
+    return s[lo] + (s[hi] - s[lo]) * (k - lo)
+
+
+def parse_gauge_trace(path: Path) -> dict[str, Any]:
+    """Return {p50, p95, p99, count, max, min, na_count} from gauge_trace.csv."""
+    if not path.exists():
+        return {"p50": None, "p95": None, "p99": None, "count": 0, "na_count": 0,
+                "min": None, "max": None}
+    vals: list[float] = []
+    na = 0
+    try:
+        with open(path) as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                v = (row.get("gauge") or "").strip()
+                if v in ("", "NA"):
+                    na += 1
+                    continue
+                try:
+                    vals.append(float(v))
+                except ValueError:
+                    na += 1
+    except Exception as exc:
+        return {"error": str(exc), "count": 0, "na_count": 0}
+    if not vals:
+        return {"p50": None, "p95": None, "p99": None, "count": 0,
+                "na_count": na, "min": None, "max": None}
+    return {
+        "p50": round(percentile(vals, 0.50), 4),
+        "p95": round(percentile(vals, 0.95), 4),
+        "p99": round(percentile(vals, 0.99), 4),
+        "count": len(vals),
+        "na_count": na,
+        "min": round(min(vals), 4),
+        "max": round(max(vals), 4),
+    }
+
+
+def parse_summary(path: Path) -> dict[str, Any]:
+    """Pull per-tenant TTFT p99/p50, count_ok/err from summary.json."""
+    if not path.exists():
+        return {"present": False}
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except Exception as exc:
+        return {"present": True, "parse_error": str(exc)}
+    quiet_per = data.get("quiet_per_tenant", {})
+    quiet_p99 = []
+    quiet_p50 = []
+    quiet_count_ok = 0
+    quiet_count_err = 0
+    for name, t in quiet_per.items():
+        p99 = t.get("ttft_p99_ms")
+        p50 = t.get("ttft_p50_ms")
+        if p99 is not None and p99 >= 0:
+            quiet_p99.append(p99)
+        if p50 is not None and p50 >= 0:
+            quiet_p50.append(p50)
+        quiet_count_ok += t.get("count_ok", 0)
+        quiet_count_err += t.get("count_err", 0)
+    flooder = data.get("flooder", {})
+    return {
+        "present": True,
+        "quiet_p99_per_tenant": quiet_p99,
+        "quiet_p50_per_tenant": quiet_p50,
+        "quiet_p99_median_across_7": (
+            round(statistics.median(quiet_p99), 1) if quiet_p99 else None
+        ),
+        "quiet_p99_max_across_7": max(quiet_p99) if quiet_p99 else None,
+        "quiet_p99_min_across_7": min(quiet_p99) if quiet_p99 else None,
+        "quiet_p50_median_across_7": (
+            round(statistics.median(quiet_p50), 1) if quiet_p50 else None
+        ),
+        "quiet_count_ok_total": quiet_count_ok,
+        "quiet_count_err_total": quiet_count_err,
+        "flooder_count_ok": flooder.get("count_ok", 0),
+        "flooder_count_err": flooder.get("count_err", 0),
+        "flooder_ttft_p99_ms": flooder.get("ttft_p99_ms"),
+        "wall_time_s": data.get("wall_time_s") or data.get("duration_s"),
+    }
+
+
+def find_cell_dir(arm: str, seed: int) -> Path:
+    return ROOT / f"m4_{arm}_seed{seed}"
+
+
+def find_summary_json(cell_dir: Path) -> Path | None:
+    """The bench writes summary.json under benchmarks/.../ inside the
+    bootstrap RDIR. The orchestrator untars the tarball into cell_dir;
+    look at any depth."""
+    for p in cell_dir.rglob("summary.json"):
+        return p
+    return None
+
+
+def find_gauge_trace(cell_dir: Path) -> Path | None:
+    for p in cell_dir.rglob("gauge_trace.csv"):
+        return p
+    return None
+
+
+def main() -> int:
+    cells_summary = []
+    arms = ["arm1", "arm2"]
+    seeds = [0, 1, 2]
+
+    for arm in arms:
+        for seed in seeds:
+            cell_dir = find_cell_dir(arm, seed)
+            sjson = find_summary_json(cell_dir)
+            gtrace = find_gauge_trace(cell_dir)
+            cell = {
+                "arm": arm,
+                "seed": seed,
+                "cell_dir": str(cell_dir.relative_to(ROOT.parent.parent)),
+                "summary_json_path": str(sjson) if sjson else None,
+                "gauge_trace_path": str(gtrace) if gtrace else None,
+                "gauge": parse_gauge_trace(gtrace) if gtrace else {},
+                "bench": parse_summary(sjson) if sjson else {"present": False},
+            }
+            cells_summary.append(cell)
+
+    # Aggregate per arm: median across seeds of the per-cell quiet_p99_median.
+    per_arm = {}
+    for arm in arms:
+        seeds_p99 = [
+            c["bench"].get("quiet_p99_median_across_7")
+            for c in cells_summary
+            if c["arm"] == arm and c["bench"].get("quiet_p99_median_across_7") is not None
+        ]
+        seeds_p50 = [
+            c["bench"].get("quiet_p50_median_across_7")
+            for c in cells_summary
+            if c["arm"] == arm and c["bench"].get("quiet_p50_median_across_7") is not None
+        ]
+        gauge_p99s = [
+            c["gauge"].get("p99")
+            for c in cells_summary
+            if c["arm"] == arm and c["gauge"].get("p99") is not None
+        ]
+        gauge_p95s = [
+            c["gauge"].get("p95")
+            for c in cells_summary
+            if c["arm"] == arm and c["gauge"].get("p95") is not None
+        ]
+        gauge_p50s = [
+            c["gauge"].get("p50")
+            for c in cells_summary
+            if c["arm"] == arm and c["gauge"].get("p50") is not None
+        ]
+        flood_err = sum(
+            c["bench"].get("flooder_count_err", 0) or 0
+            for c in cells_summary if c["arm"] == arm
+        )
+        quiet_err = sum(
+            c["bench"].get("quiet_count_err_total", 0) or 0
+            for c in cells_summary if c["arm"] == arm
+        )
+        per_arm[arm] = {
+            "n_cells": sum(1 for c in cells_summary if c["arm"] == arm),
+            "quiet_p99_med_across_seeds": (
+                round(statistics.median(seeds_p99), 1) if seeds_p99 else None
+            ),
+            "quiet_p50_med_across_seeds": (
+                round(statistics.median(seeds_p50), 1) if seeds_p50 else None
+            ),
+            "quiet_p99_per_seed": seeds_p99,
+            "quiet_p50_per_seed": seeds_p50,
+            "gauge_p50_med": (
+                round(statistics.median(gauge_p50s), 4) if gauge_p50s else None
+            ),
+            "gauge_p95_med": (
+                round(statistics.median(gauge_p95s), 4) if gauge_p95s else None
+            ),
+            "gauge_p99_med": (
+                round(statistics.median(gauge_p99s), 4) if gauge_p99s else None
+            ),
+            "gauge_p99_max_across_seeds": (
+                round(max(gauge_p99s), 4) if gauge_p99s else None
+            ),
+            "flooder_count_err_total": flood_err,
+            "quiet_count_err_total": quiet_err,
+        }
+
+    # Compute the headline ratio.
+    a1 = per_arm.get("arm1", {}).get("quiet_p99_med_across_seeds")
+    a2 = per_arm.get("arm2", {}).get("quiet_p99_med_across_seeds")
+    if a1 and a2 and a1 > 0:
+        ratio = round(a1 / a2, 3)
+    else:
+        ratio = None
+
+    # Kill criterion check: any arm with gauge p99 >= 0.7?
+    pressured_arms = [
+        arm for arm, p in per_arm.items()
+        if (p.get("gauge_p99_max_across_seeds") or 0) >= 0.7
+    ]
+    regime_pressured = bool(pressured_arms)
+
+    # Verdict.
+    has_any_gauge = any(
+        per_arm[arm].get("gauge_p99_max_across_seeds") is not None for arm in arms
+    )
+    has_any_bench = any(
+        per_arm[arm].get("quiet_p99_med_across_seeds") is not None for arm in arms
+    )
+    if not has_any_gauge and not has_any_bench:
+        verdict = "incomplete"
+        verdict_rationale = (
+            "No bench data and no gauge trace recovered. Cells did not complete; "
+            "see cell_results.json for status per cell."
+        )
+    elif not regime_pressured:
+        verdict = "regime-broken"
+        verdict_rationale = (
+            "Gauge p99 < 0.7 across all arms — workload doesn't pressure cache; "
+            "no cache-pressure-conditioned admission policy can help. Ship (c) "
+            "disconfirm; queue (b) LMCache for v0.3."
+        )
+    elif ratio is None:
+        verdict = "incomplete"
+        verdict_rationale = "Insufficient cells to compute Arm 2 vs Arm 1 ratio."
+    elif a2 > a1:
+        verdict = "abandon-(a)"
+        verdict_rationale = (
+            f"Arm 2 quiet p99 ({a2} ms) is worse than Arm 1 ({a1} ms). "
+            f"Saturation bias adds latency without signal. Abandon (a); "
+            f"ship (c); queue (b) LMCache for v0.3."
+        )
+    elif ratio >= 1.5:
+        verdict = "green"
+        verdict_rationale = (
+            f"Arm 1/Arm 2 quiet p99 ratio = {ratio}× ≥ 1.5×. (a) GA-track, "
+            f"default-on. M5a build is funded."
+        )
+    elif ratio >= 1.2:
+        verdict = "yellow"
+        verdict_rationale = (
+            f"Arm 1/Arm 2 quiet p99 ratio = {ratio}× in [1.2×, 1.5×). "
+            f"(a) experimental, flag-gated. M5a ships behind a config flag."
+        )
+    else:
+        verdict = "red"
+        verdict_rationale = (
+            f"Arm 1/Arm 2 quiet p99 ratio = {ratio}× < 1.2×. DRR-only already "
+            f"captures the gap. Ship (c) disconfirm; queue (b) LMCache for v0.3."
+        )
+
+    output = {
+        "cells": cells_summary,
+        "per_arm": per_arm,
+        "headline": {
+            "arm1_quiet_p99_med_ms": a1,
+            "arm2_quiet_p99_med_ms": a2,
+            "ratio_arm1_over_arm2": ratio,
+            "regime_pressured": regime_pressured,
+            "pressured_arms": pressured_arms,
+            "verdict": verdict,
+            "rationale": verdict_rationale,
+        },
+    }
+
+    out_path = ROOT / "post_warmup_summary.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as fh:
+        json.dump(output, fh, indent=2)
+    print(f"wrote {out_path}")
+    print(json.dumps(output["headline"], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Refs #103.

## Verdict

**ABORTED at provisioning. No bench data captured. T2 verdict unchanged. M4 returns to its original post-Show-HN window (2026-05-13 → 2026-05-19) per the locked plan.**

Today's pre-launch attempt was an over-extension. The plan-lock was right; today verifies why.

## What happened (full timeline in `results/m4_path_c_probe_20260502/OUTCOME.md`)

Two pods, neither got SSH:

| Attempt | SKU | Wall | Cost | Outcome |
|---|---|---|---|---|
| 1 | A100 SXM4 SECURE | 9 min | $0.22 | `desiredStatus=RUNNING` but `publicIp=""` for 9 min — known SECURE stuck-provisioning per Gate 1.5 memory note. Killed manually. |
| 2 | A100 80GB COMMUNITY | **6h 28m** | $5.11 | Same pattern. Pod entered RUNNING, never populated `publicIp`. Orchestrator polled `desiredStatus` not `publicIp`, so the deadline never fired. Killed after credit-burn audit. |

## Operational lessons

1. **`desiredStatus=RUNNING` is necessary but not sufficient.** Pods can hold RUNNING for hours without ever getting `publicIp` / port mappings. Orchestrator readiness gate must be `publicIp != "" AND portMappings != null`. One-line fix at `scripts/m4_path_c_orchestrator.py:160`.
2. **`MAX_POD_SECS` self-destruct does not fire** if the pod never starts user-space (no SSH = no shell to run the timer).
3. **Both SECURE and COMMUNITY A100 stalled today.** SKU advice in memory is a snapshot; validate slot health day-of with a 90-second spin-and-tear probe before committing the multi-hour bench.

## Reusable infra shipped on this branch

- `scripts/m4_path_c_orchestrator.py` (534 LOC) — full RunPod orchestrator with cost guards, SKU fallback, finally{}-tear-down.
- `scripts/m4_summarize.py` — applies the locked threshold table.
- `scripts/gate_pod_bootstrap.sh` extension — 250 ms `vllm:kv_cache_usage_perc` gauge scraper + PID tracking. Works when the pod is actually reachable.

## Pre-conditions for next M4 attempt

1. Fix orchestrator poll to gate on `publicIp != ""`.
2. Two-minute spin-and-tear SKU probe before committing the bench.
3. Calendar alignment with 05-13 → 05-19 plan.

## Cost reconciliation

Session pod spend total **$7.21** ($0.24 P1 + $5.33 M4 abort + $1.64 Gate 2.1b H100 abort). T2 chapter ceiling $20. Remaining headroom $12.79. M4 retry budget intact at ~$8 expected on a healthy SKU.