### PR TITLE
docs: post-launch hygiene — CHANGELOG + version-pin sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog
+
+All notable changes to the [`kvwarden`](https://pypi.org/project/kvwarden/) package are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Planned for v0.2.0 (mid-June 2026)
+
+- **Cache-pressure-aware admission.** kvwarden polls vLLM's `vllm:kv_cache_usage_perc` gauge (250 ms cadence) and scales admission priority by engine cache load. Same budget gate, smarter gating. Honest scope: 0.2 reacts to *global* cache pressure, not per-tenant pressure (the gauge has no tenant label). Per-tenant cache visibility waits on the LMCache substrate in 0.3+. RFC: [`docs/rfcs/T2-cache-pressure-admission.md`](docs/rfcs/T2-cache-pressure-admission.md). Tracker: [#103](https://github.com/coconut-labs/kvwarden/issues/103). Gated on the M4 Path C measure-first probe (2026-05-13 → 2026-05-19).
+
+## [0.1.5] — 2026-05-12 — Show HN launch tag
+
+Docs-only release. No Python source changes since v0.1.4; this tag exists so PyPI, the GitHub release page, the README pin, the FAQ pin, and the Show HN post draft all reference the same version on launch day.
+
+### Changed
+
+- **README "About the name"** — v0.2 framing reset from "tenant-aware KV eviction" to "cache-pressure-aware admission." The 04-28 reframe (eviction → admission, locked after verifying the cache-manager scaffold is a shadow ledger no engine adapter reads) now propagates to the launch surface. The original eviction RFC (#116) is closed as superseded by RFC #121.
+- **README + FAQ** — global-gauge limitation surfaced upfront: `vllm:kv_cache_usage_perc` is labeled by `model_name` only, not by tenant. v0.2 reacts to global cache pressure, not whose. Per-tenant cache visibility waits on LMCache (v0.3+).
+- **FAQ** — new entry: *"The name says KV warden but you're not touching the KV cache."*
+- **`docs/launch/show_hn.md`** — hero pin to v0.1.5, test count to ~200, total compute to ~$24 (drift since the original draft from Gate 2.1b $1.64 + M4 aborted attempt $5.33).
+
+### Released
+
+- [PyPI v0.1.5](https://pypi.org/project/kvwarden/0.1.5/) — `pip install kvwarden==0.1.5`
+- [GitHub release v0.1.5](https://github.com/coconut-labs/kvwarden/releases/tag/v0.1.5)
+
+## [0.1.4] — 2026-04-22 — PyPI hero image fix
+
+### Fixed
+
+- README hero chart used a relative path in the v0.1.3 PyPI README, which rendered broken on pypi.org. Switched to absolute raw-content URL so the chart loads on the PyPI project page.
+
+## [0.1.3] — 2026-04-22 — First substantive `kvwarden` release on PyPI
+
+The first real release of the package under the `kvwarden` name. v0.0.1 was a placeholder; v0.1.3 is the first version a user installing `pip install kvwarden` can do anything with.
+
+### Added
+
+- Full middleware: tenant-aware admission (token-bucket at the budget gate), multi-model lifecycle on a single GPU (freq+recency eviction, hot-swap), OpenAI-compatible HTTP API in front of vLLM and SGLang subprocess adapters.
+- CLI: `kvwarden serve`, `kvwarden bench`, `kvwarden status`, `kvwarden models`, `kvwarden man`, `kvwarden telemetry`, `kvwarden doctor`.
+- Opt-in anonymous install/usage telemetry (first interactive run prompts; default off).
+- Reproduce-hero one-liner: `kvwarden bench reproduce-hero` against a vLLM 0.19.1 install on A100 + Llama-3.1-8B.
+
+### Note on the rename
+
+This is the first kvwarden release shipped with substantive code; the prior development lineage lived on PyPI as `infergrid` (versions 0.1.1 and 0.1.2). The `infergrid` package now ships a deprecation stub pointing here. Audit trail: [`docs/naming/rename_plan.md`](docs/naming/rename_plan.md), [`docs/naming/rename_sequence.md`](docs/naming/rename_sequence.md), [`docs/naming/infergrid_name_audit.md`](docs/naming/infergrid_name_audit.md).
+
+## [0.0.1] — 2026-04-22 — PyPI name reservation stub
+
+Placeholder release on PyPI to claim the `kvwarden` package name in the window between the rename becoming visible (any tweet, any commit on a public repo) and the real v0.1.3 release. No usable code — a stub `__init__.py` and an import-only `__version__`. Rationale and full reservation runbook: [`docs/launch/pypi_reservation.md`](docs/launch/pypi_reservation.md).
+
+---
+
+## Pre-rename history (package was named `infergrid`)
+
+Prior to the 2026-04-22 rename, the same codebase shipped on PyPI under the [`infergrid`](https://pypi.org/project/infergrid/) name. The `infergrid` 0.1.1 and 0.1.2 releases are not part of `kvwarden`'s version history; they are documented here for continuity only. The current `infergrid` PyPI package is a deprecation stub.
+
+- **infergrid 0.1.2** (2026-04-20) — Interactive `serve` wizard, offline `man [topic]` help, `doctor` env sanity check, rich-table CLI output, durable `__version__` via `importlib.metadata`.
+- **infergrid 0.1.1** (2026-04-20) — `pyproject.toml` TOML structure fix that broke `pip install -e .` on some Python builds.
+
+[Unreleased]: https://github.com/coconut-labs/kvwarden/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/coconut-labs/kvwarden/releases/tag/v0.1.5
+[0.1.4]: https://github.com/coconut-labs/kvwarden/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/coconut-labs/kvwarden/compare/v0.0.1...v0.1.3
+[0.0.1]: https://pypi.org/project/kvwarden/0.0.1/

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,7 +1,7 @@
 # InferGrid — Project Progress
 
-**Last updated:** April 21, 2026 (post-launch-polish + PyPI 0.1.2 + LP live at infergrid.org, through PR #76)
-**Repository:** [coconut-labs/infergrid](https://github.com/coconut-labs/infergrid)
+**Last updated:** May 13, 2026 (M3 Show HN launch — v0.1.5 on PyPI, doc reframe to cache-pressure admission, through PR #132)
+**Repository:** [coconut-labs/kvwarden](https://github.com/coconut-labs/kvwarden) (renamed from `infergrid` on 2026-04-22 — see [rename history](#) below)
 **Author:** Shrey Patel (patelshrey77@gmail.com)
 
 ---
@@ -702,3 +702,40 @@ Post-hoc shadow review surfaced a material framing risk. The 4 gates hold agains
 - **Docker Hub `kvwarden` namespace reserved on 2026-04-22.** Token stored in `~/.infergrid/secrets.env` as `DOCKER_HUB_TOKEN`. No images pushed yet — reservation only.
 - **PyPI `kvwarden` 0.1.3 first real release shipped on 2026-04-22.** Live at https://pypi.org/project/kvwarden/0.1.3/; `pip install kvwarden` now resolves to 0.1.3 (the 0.0.1 stub remains pin-queryable). Uploaded with the project-scoped `PYPI_KVWARDEN_TOKEN` (stored in `~/.infergrid/secrets.env`); the prior account-scoped token from the 0.0.1 stub should be revoked now. Git tag `v0.1.3` pushed. Wheel smoke-tested pre-upload on macOS Python 3.13.7: version, --help, doctor, man topics, bench reproduce-hero --help all clean.
 - **Paste-ready artifacts for all four user-side blockers landed in #99** (squash-merged to `main` as ed02973): Samuel email at `docs/naming/email_samuel_bell.md`, cold outreach at `docs/launch/cold_outreach_template.md`, PyPI stub at `scripts/publish_kvwarden_stub.sh` + `docs/launch/pypi_reservation.md`, demo script at `docs/launch/demo_video_script.md`. Each blocker now a few-minutes execution for the user rather than a vague TODO.
+
+## 2026-04-22 → 2026-05-02 — T2 chapter scaffolded, M4 prep landed
+
+Detail in [`docs/rfcs/T2-cache-pressure-admission.md`](docs/rfcs/T2-cache-pressure-admission.md) and the [M3 SHIPPED section of memory](https://github.com/coconut-labs/kvwarden/issues/103#issuecomment-4425678050). Highlights:
+
+- **T2 reframed 2026-04-28.** Original plan was tenant-aware KV eviction; god-planner verified the cache-manager scaffold is a shadow ledger no engine adapter reads, so v0.2 reframed to **cache-pressure-aware admission** (poll vLLM's `vllm:kv_cache_usage_perc`, scale admission priority by global cache load). Original eviction RFC (#116) closed as superseded by RFC #121.
+- **M1 SHIPPED 2026-04-30** (8 PRs squash-merged to main): #114 docstrings, #115 sig stub, #119 Gate 3 bench config, #121 cache-pressure RFC, #123 tests skeleton, #124 py3.13 CI, #125 M4 harness flags, #126 Docker Compose bundle.
+- **M4 unblocked but probe deferred.** Gate 3 Path C harness gaps (`--prefix-overlap`, `--bias-flooder-cost`) landed via #125. Pre-launch M4 probe attempted 2026-05-02/03 — aborted at RunPod provisioning ($5.33 sunk, no bench data). Orchestrator polled `desiredStatus` instead of `runtime.publicIp != ""`. Pre-conditions for next attempt locked in `results/gate3_TBD/OUTCOME.md`. M4 returns to its locked 05-13 → 05-19 post-Show-HN window.
+- **P1 pre-flight 2026-05-02** (#128): vLLM gauge endpoint verified + #125 harness smoke verified. M4 unblocked apart from the provisioning fix.
+- **CI integration-tests gate added in #115.** Prior CI ran `pytest tests/unit/` only; now also runs `pytest tests/integration/` so silent skips are visible.
+
+## 2026-05-12 — M3 Show HN launch (v0.1.5 on PyPI)
+
+### What shipped
+
+| artifact | location |
+|---|---|
+| PR #132 — doc reframe + version bump | merged squash to main as `0def248` |
+| git tag `v0.1.5` | annotated, pushed |
+| GitHub release v0.1.5 | https://github.com/coconut-labs/kvwarden/releases/tag/v0.1.5 (wheel + sdist attached) |
+| PyPI `kvwarden==0.1.5` | https://pypi.org/project/kvwarden/0.1.5/ |
+| Issue #103 supersession pin | https://github.com/coconut-labs/kvwarden/issues/103#issuecomment-4425678050 |
+| `CHANGELOG.md` | new — Keep-a-Changelog format, v0.0.1 → v0.1.5 |
+
+### What v0.1.5 changes
+
+Docs-only release. No Python source touched between v0.1.4 (2026-04-22) and v0.1.5; the tag exists so PyPI, GitHub, README pin, FAQ pin, and the Show HN post draft all reference the same version on launch day.
+
+- **README "About the name"** — v0.2 framing reset from "tenant-aware KV eviction" to "cache-pressure-aware admission" + v0.3+ via LMCache as the actual KV-cache-wardening path.
+- **Global-gauge limitation surfaced upfront** in README + FAQ: `vllm:kv_cache_usage_perc` is labeled by `model_name` only, not by tenant. v0.2 reacts to *global* cache pressure, not whose. Per-tenant cache visibility waits on LMCache (v0.3+). This was the load-bearing open RFC question (item 3) flagged "must resolve before M3."
+- **FAQ** — new entry: "The name says KV warden but you're not touching the KV cache."
+- **show_hn.md hero pin** — `v0.1.5`, `~200 unit tests`, `~$24 total compute` (drift from Gate 2.1b $1.64 + M4 abort $5.33 since the original draft).
+- **pyproject.toml** — `0.1.4` → `0.1.5`.
+
+### M4 path next
+
+M4 Path C measure-first probe window: **2026-05-13 → 2026-05-19**. Pre-conditions in `results/gate3_TBD/OUTCOME.md`. Do NOT begin A1 implementation until M4 reports — Path C is measure-first by locked design. M5a implementation (~200 LOC if M4 says go) targets 05-20 → 06-02. v0.2.0 ship target 2026-06-23.

--- a/docs/launch/demo_video_script.md
+++ b/docs/launch/demo_video_script.md
@@ -56,9 +56,9 @@ $ kvwarden bench reproduce-hero --flavor=2tenant
 ```bash
 $ pip install kvwarden
 ```
-**Viewer sees:** pip flashes `Successfully installed kvwarden-0.1.0`, then cut to a static kvwarden.org end-card.
+**Viewer sees:** pip flashes `Successfully installed kvwarden-0.1.5`, then cut to a static kvwarden.org end-card.
 
-> **Note:** the last line shows `kvwarden-0.1.0`, which only lands on PyPI when the real 0.1.0 release ships. If you're filming before the PyPI upload, substitute `Successfully installed kvwarden-0.0.1` (the stub), or re-record the last second after the real upload.
+> **Note:** the last line shows `kvwarden-0.1.5`, which is the Show HN launch tag live on PyPI as of 2026-05-12. Re-record if the version on PyPI has moved by film time.
 
 ---
 
@@ -80,7 +80,7 @@ pip install kvwarden
 $ pip install kvwarden
 $ kvwarden --help
 ```
-**Viewer sees:** `Successfully installed kvwarden-0.1.0`, then the top-level `kvwarden --help` output showing the subcommand list (`serve`, `bench`, `status`, `models`, `man`, `telemetry`).
+**Viewer sees:** `Successfully installed kvwarden-0.1.5`, then the top-level `kvwarden --help` output showing the subcommand list (`serve`, `bench`, `status`, `models`, `man`, `telemetry`).
 
 ### 0:07-0:15 — bench command
 **Voiceover:** "The headline bench replays the published measurement — two tenants, Llama-3.1-8B, vLLM 0.19.1 — against any vLLM-compatible engine you point it at."

--- a/docs/launch/one_pager.md
+++ b/docs/launch/one_pager.md
@@ -32,15 +32,15 @@ Gimlet is the only production competitor with fairness, and they're a managed mu
 
 ## Traction and validation
 
-- **PyPI:** `kvwarden 0.1.2` live.
+- **PyPI:** `kvwarden 0.1.5` live.
 - **Landing page:** kvwarden.org with waitlist.
-- **Code:** 4,100 LOC src, 2,900 LOC tests, 153 unit tests passing, CI-gated lint + format.
+- **Code:** 4,100 LOC src, 2,900 LOC tests, ~200 unit tests passing, CI-gated lint + format.
 - **Empirical gate ladder v0.2 — 4 gates, 3 CONFIRM + 1 PASS:**
   - Gate 2.1 (N=8 tenants, A100, Llama-3.1-8B): CONFIRM
   - Gate 2.4 (Mixtral-8×7B MoE, 2×A100 TP=2): CONFIRM with engine-headroom caveat
   - Gate 2.3 (Llama-3.1-70B, 4×H100 TP=4): CONFIRM — mechanism scales 8B→70B and 1-GPU→TP=4; p50 ratio flat (1.03× at 8B → 1.07× at 70B)
   - Gate 2.2 (mixed prompt-length distribution): PASS
-- **Total compute spend across full experimental arc:** ~$17 on RunPod, self-funded.
+- **Total compute spend across full experimental arc:** ~$24 on RunPod, self-funded.
 
 ## Honest caveats
 

--- a/docs/launch/twitter_thread.md
+++ b/docs/launch/twitter_thread.md
@@ -48,7 +48,7 @@ kvwarden serve --config configs/quickstart_fairness.yaml
 curl localhost:8000/v1/completions -H "X-Tenant-ID: quiet" -d '{...}'
 ```
 
-PyPI: v0.1.2. 153 unit tests. 4,100 LOC src, ~3,500 LOC middleware, OpenAI-compatible HTTP API, no Kubernetes.
+PyPI: v0.1.5. ~200 unit tests. 4,100 LOC src, ~3,500 LOC middleware, OpenAI-compatible HTTP API, no Kubernetes.
 
 **7/**
 Honest caveats. This is validated at:

--- a/docs/privacy/telemetry.md
+++ b/docs/privacy/telemetry.md
@@ -16,7 +16,7 @@ object with these fields and nothing else:
 | Field            | Example                                | Notes                                          |
 |------------------|----------------------------------------|------------------------------------------------|
 | `install_id`     | `f47ac10b-58cc-4372-a567-0e02b2c3d479` | uuid4 minted on your machine on first run       |
-| `version`        | `0.1.2`                                | KVWarden's own version                         |
+| `version`        | `0.1.5`                                | KVWarden's own version                         |
 | `python_version` | `3.12`                                 | major.minor only                                |
 | `platform`       | `linux`                                | one of `linux` / `darwin` / `win32` / `other`  |
 | `gpu_class`      | `a100`                                 | from `nvidia-smi`; bucketed to `h100`/`a100`/`rtx4090`/`other`/`none` |

--- a/docs/rfcs/T2-cache-pressure-admission.md
+++ b/docs/rfcs/T2-cache-pressure-admission.md
@@ -223,7 +223,7 @@ Discussion [#117](https://github.com/coconut-labs/kvwarden/discussions/117) is a
 |---|---|---|
 | M1 | 04-29 → 05-04 | This RFC + sig-stub edit + tests rewrite + bench config rewrite. Landing in parallel today across 4 sibling agents (R/T/B + this one). |
 | M2 | 05-05 → 05-11 | RFC review window. CI green across the reframed surface. PROGRESS.md anchor pointing at v0.2 chapter. |
-| M3 | 2026-05-12 | **Show HN — v0.1.0 ships.** RFC + skeletons + bench config visible in repo. No T2 code wired. |
+| M3 | 2026-05-12 | **Show HN — v0.1.5 ships.** RFC + skeletons + bench config visible in repo. No T2 code wired. (Shipped as v0.1.5, not v0.1.0, because the rename arc consumed 0.1.0–0.1.4 of the version space; see [CHANGELOG.md](../../CHANGELOG.md).) |
 | M4 | 05-13 → 05-19 | **Gate 3 Path C probe.** Arm 1 + Arm 2 on 1× A100. Decision gate per §8. |
 | M5a | 05-20 → 06-02 | ~200 LOC implementation if M4 says go. Poller + snapshot surface + admission scaling + priority composition + tests. Unwind T-agent xfail markers. |
 | M5b | 05-20 → 06-02 | (c) disconfirm publication if M4 says no-go. Park to v0.3. Chapter ships as null result + replay tooling. |


### PR DESCRIPTION
## What

Post-M3 (v0.1.5 PyPI ship) doc catch-up. No code touched.

## Files

### New

- **\`CHANGELOG.md\`** — Keep-a-Changelog format. v0.0.1 → v0.1.5 entries for the \`kvwarden\` package on PyPI, plus a separate "pre-rename history" section for the \`infergrid\` 0.1.1/0.1.2 releases (audit-trail continuity, since the git tags live in this repo).

### Edited

- **\`PROGRESS.md\`** — header re-anchored to 2026-05-13 / PR #132 / new repo URL (\`coconut-labs/kvwarden\`, was \`coconut-labs/infergrid\`). New sections for the T2 chapter scaffolding (2026-04-22 → 2026-05-02) and the M3 Show HN launch (2026-05-12). Restores chronological alignment.
- **\`docs/launch/twitter_thread.md\`** — PyPI pin v0.1.2 → v0.1.5, tests 153 → ~200.
- **\`docs/launch/one_pager.md\`** — same + compute total \$17 → \$24.
- **\`docs/launch/demo_video_script.md\`** — installed-product flash text 0.1.0 → 0.1.5 in both Variant A and Variant B; pre-upload caveat note rewritten as re-record-if-version-moves note.
- **\`docs/privacy/telemetry.md\`** — example version field 0.1.2 → 0.1.5.
- **\`docs/rfcs/T2-cache-pressure-admission.md\`** — M3 timeline row pinned to v0.1.5 with a footnote pointing at \`CHANGELOG.md\` explaining why the Show HN tag is v0.1.5 not v0.1.0 (rename arc consumed 0.1.0–0.1.4).

### Intentionally NOT touched

Audit-trail / dated docs that reflect point-in-time state — \`docs/naming/*\`, \`docs/metrics_audit_20260421.md\`, \`docs/runbooks/secrets.md\`, \`docs/runbooks/token_rotation_20260421.md\`. These document history; updating them would destroy the audit trail.

## Verification

Docs only. CI runs the unit + integration + lint matrix on Linux as a sanity check.

Refs #103.