### PR TITLE
docs: bump README BibTeX cite-as to v0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ MIT. See [LICENSE](LICENSE).
   title  = {kvwarden: tenant-fair LLM inference on a single GPU},
   author = {Patel, Shrey and {Coconut Labs contributors}},
   year   = {2026},
-  version = {0.1.3},
+  version = {0.1.5},
   url    = {https://github.com/coconut-labs/kvwarden}
 }
 ```


### PR DESCRIPTION
One-line follow-up to PR #133. The README BibTeX block was pinned at v0.1.3 (rename-era first-real-release tag); bumping to v0.1.5 to match the Show HN launch tag a reader will actually install.