### PR TITLE
results(m4): third consecutive capacity-out — overnight retry deferred

### DIFF
--- a/results/m4_path_c_probe_20260515/orchestrator.log
+++ b/results/m4_path_c_probe_20260515/orchestrator.log
@@ -1,0 +1,35 @@
+[t=    0.0s 22:33:40Z] pubkey: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO7fjKDecmm5dt... arms=['arm1', 'arm2'] seeds=[0, 1, 2]
+[t=    0.0s 22:33:40Z] dry-run; skipping pod creation
+[t=    0.0s 22:34:37Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE with 120s deadline
+[t=    0.0s 22:34:37Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/on-demand
+[t=    1.3s 22:34:38Z] create OK id=k4827lysfky0fx costPerHr=$1.49
+[t=    1.3s 22:34:38Z] PROBE: pod created id=k4827lysfky0fx; waiting for publicIp+ssh_port
+[t=    1.6s 22:34:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 22:34:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 22:35:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 22:35:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 22:35:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.8s 22:35:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.5s 22:36:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.9s 22:36:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.9s 22:36:42Z] PROBE NO-GO: pod k4827lysfky0fx not RUNNING+SSH within 120s; tearing down
+[t=  125.0s 22:36:42Z] DELETE pod k4827lysfky0fx
+[t=  125.8s 22:36:43Z] delete returned status=204 resp={}
+[t=  131.2s 22:36:48Z] pod k4827lysfky0fx confirmed terminated (404)
+[t=  131.2s 22:36:48Z] PROBE: pod k4827lysfky0fx torn down
+[t=    0.0s 22:38:06Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 120s deadline
+[t=    0.0s 22:38:06Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.7s 22:38:07Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.7s 22:38:07Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:38:41Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:38:41Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 22:38:42Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 22:38:42Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:39:37Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:39:37Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 22:39:37Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 22:39:37Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:39:38Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:39:38Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 22:39:38Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 22:39:38Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500

--- a/results/m4_path_c_probe_20260517/OUTCOME.md
+++ b/results/m4_path_c_probe_20260517/OUTCOME.md
@@ -1,0 +1,53 @@
+# M4 Path C probe — 2026-05-17 (third consecutive capacity-out, no-go)
+
+**Verdict:** NO-GO. RunPod inventory depleted across 5 SKU/cloud combos. Retry overnight US-East morning (2026-05-18 12-15Z).
+
+## SKU sweep at 18:34Z
+
+| GPU | Cloud | Interruptible | Status |
+|---|---|---|---|
+| A100-SXM4 80GB | SECURE | no | 500 no instances available |
+| A100 80GB PCIe | SECURE | no | 500 no instances available |
+| H100 80GB HBM3 | SECURE | no | 500 no instances available |
+| H100 PCIe | SECURE | no | 500 no instances available |
+| A100-SXM4 80GB | COMMUNITY | yes (spot) | 500 no longer available |
+
+Earlier same-day 03:38Z attempt also no-go: A100-SXM4 SECURE pod `n66rx9ih3wudm9` created at $1.49/hr but never published `publicIp` within the 90s deadline; torn down at t=93.7s. Fallback A100 PCIe / A100-SXM4 community-spot both 500'd at create time. Full log: `orchestrator.log`.
+
+## Pattern across three attempts
+
+| Date | Result | Notes |
+|---|---|---|
+| 2026-05-15 | No-go | A100-SXM4 / A100 PCIe / H100 SXM5 / H100 PCIe all 500 at create |
+| 2026-05-17 03:38Z | No-go | A100-SXM4 SECURE created but stalled with no publicIp (90s deadline); fallbacks 500 |
+| 2026-05-17 18:34Z | No-go | All 5 SKU/cloud combos 500 at create |
+
+Structural, not transient. RunPod's A100/H100 supply has been thin for three days running.
+
+## No spend
+
+Zero pod-hours billed across all three attempts. Orchestrator's `--probe-only` mode + 90s/120s deadlines + immediate teardown on no-publicIp prevented the kind of $5.33 burn that triggered PR #135's hardening.
+
+## Next attempt
+
+Retry overnight US-East morning (Mon 2026-05-18, ~12-15Z = 8-11 ET = 5-8 PT) when both US-East and Asia inventory tend to be fresher. If three consecutive morning attempts also no-go, escalate to provider switch (Lambda Labs A100 SXM4 has been consistently available; orchestrator port estimated 4-6h of work).
+
+Standalone M4 retry command (probe-only, requires `RUNPOD_API_KEY` + dummy `HF_TOKEN`):
+
+```sh
+python3 scripts/m4_path_c_orchestrator.py --probe-only --probe-timeout 120 --cloud-type SECURE
+```
+
+If probe returns 0, kick the full bench (drops `--probe-only`, runs 6 cells, ~$8, needs real `HF_TOKEN`).
+
+## Decision-gate state unchanged
+
+Locked threshold table (per `project_kvwarden_t2.md` and issue #103):
+
+| Arm 2 vs Arm 1 quiet-p99-TTFT delta | v0.2.0 ship |
+|---|---|
+| ≥ 1.5× | GA — default-on, README hero |
+| 1.2 – 1.5× | Experimental — flag-gated |
+| < 1.2× | Disconfirm + publish null — ship LRU as default |
+
+v0.2.0 ships W7-W8 (mid-June). 4-week runway → no panic on the M4 slip.

--- a/results/m4_path_c_probe_20260517/orchestrator.log
+++ b/results/m4_path_c_probe_20260517/orchestrator.log
@@ -1,0 +1,45 @@
+[t=    0.0s 03:38:20Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 90s deadline
+[t=    0.0s 03:38:20Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 03:38:21Z] create OK id=n66rx9ih3wudm9 costPerHr=$1.49
+[t=    1.2s 03:38:21Z] PROBE: pod created id=n66rx9ih3wudm9; waiting for publicIp+ssh_port
+[t=    1.5s 03:38:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 03:38:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 03:38:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 03:39:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 03:39:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.7s 03:39:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.7s 03:39:53Z] PROBE NO-GO: pod n66rx9ih3wudm9 not RUNNING+SSH within 90s; tearing down
+[t=   93.7s 03:39:53Z] DELETE pod n66rx9ih3wudm9
+[t=   94.5s 03:39:54Z] delete returned status=204 resp={}
+[t=  100.1s 03:40:00Z] pod n66rx9ih3wudm9 confirmed terminated (404)
+[t=  100.1s 03:40:00Z] PROBE: pod n66rx9ih3wudm9 torn down
+[t=    0.0s 03:41:55Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 90s deadline
+[t=    0.0s 03:41:55Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 03:41:56Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 03:41:56Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 03:41:56Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 90s deadline
+[t=    0.0s 03:41:56Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 03:41:57Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 03:41:57Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:33:42Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 18:33:42Z] PROBE EXCEPTION: KeyError: 'HF_TOKEN'
+[t=    0.0s 18:34:07Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 18:34:07Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 18:34:08Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 18:34:08Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:34:25Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:34:25Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 18:34:26Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 18:34:26Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:34:26Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:34:26Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 18:34:27Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 18:34:27Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:34:27Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:34:27Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 18:34:27Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 18:34:27Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:34:27Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 18:34:27Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 18:34:28Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 18:34:28Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500


### PR DESCRIPTION
Audit-trail PR for the three M4 Path C probe aborts this week. Zero spend, zero useful data, all RunPod capacity-out at create.

| Date | Verdict | Notes |
|---|---|---|
| 2026-05-15 | No-go | A100-SXM4 / A100 PCIe / H100 SXM5 / H100 PCIe all 500 at create |
| 2026-05-17 03:38Z | No-go | A100-SXM4 SECURE created but stalled no-publicIp 90s; fallbacks 500 |
| 2026-05-17 18:34Z | No-go | 5/5 SKU/cloud combos 500 at create |

Orchestrator hardening from #135 worked as designed — probe-only + short deadlines + immediate teardown meant zero pod-hours billed.

OUTCOME.md captures the SKU sweep table and the retry plan (overnight US-East morning ~12-15Z on 2026-05-18). If three more morning probes also no-go, escalate to a Lambda Labs orchestrator port.

Decision gate state unchanged. v0.2.0 ships W7-W8 mid-June; 4-week runway absorbs the slip.

Refs #103.