### PR TITLE
results(m4): 4-day RunPod retry chain rundown — 512 pods, $47, 0 GO

### DIFF
--- a/results/m4_path_c_probe_20260517/orchestrator.log
+++ b/results/m4_path_c_probe_20260517/orchestrator.log
@@ -1,0 +1,289 @@
+[t=    0.0s 19:21:37Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 19:21:37Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 19:21:38Z] create OK id=irzy7g9ptc9opw costPerHr=$1.49
+[t=    1.0s 19:21:38Z] PROBE: pod created id=irzy7g9ptc9opw; waiting for publicIp+ssh_port
+[t=    1.3s 19:21:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 19:21:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 19:22:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 19:22:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 19:22:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.4s 19:22:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.7s 19:23:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.1s 19:23:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.1s 19:23:41Z] PROBE NO-GO: pod irzy7g9ptc9opw not RUNNING+SSH within 120s; tearing down
+[t=  124.1s 19:23:41Z] DELETE pod irzy7g9ptc9opw
+[t=  124.7s 19:23:41Z] delete returned status=204 resp={}
+[t=  130.1s 19:23:47Z] pod irzy7g9ptc9opw confirmed terminated (404)
+[t=  130.1s 19:23:47Z] PROBE: pod irzy7g9ptc9opw torn down
+[t=    0.0s 19:44:56Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 19:44:56Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 19:44:56Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 19:44:56Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:44:57Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:44:57Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 19:44:57Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 19:44:57Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:44:57Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:44:57Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 19:44:58Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 19:44:58Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:44:58Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:44:58Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 19:44:59Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 19:44:59Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:44:59Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 19:44:59Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 19:44:59Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 19:44:59Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:40:27Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 20:40:27Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 20:40:28Z] create OK id=7zg8oaj64rirmy costPerHr=$1.49
+[t=    1.2s 20:40:28Z] PROBE: pod created id=7zg8oaj64rirmy; waiting for publicIp+ssh_port
+[t=    1.6s 20:40:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 20:40:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  440.9s 20:47:47Z] PROBE NO-GO: pod 7zg8oaj64rirmy not RUNNING+SSH within 120s; tearing down
+[t=  440.9s 20:47:47Z] DELETE pod 7zg8oaj64rirmy
+[t=  440.9s 20:47:47Z] delete returned status=-1 resp=transport_error: ConnectError('[Errno 8] nodename nor servname provided, or not known')
+[t=  446.3s 20:47:53Z] post-delete GET status=200 (waiting for 404)
+[t=  451.8s 20:47:58Z] post-delete GET status=200 (waiting for 404)
+[t=  457.7s 20:48:04Z] post-delete GET status=200 (waiting for 404)
+[t=  463.1s 20:48:10Z] post-delete GET status=200 (waiting for 404)
+[t=  468.6s 20:48:15Z] post-delete GET status=200 (waiting for 404)
+[t=  782.3s 20:53:29Z] post-delete GET status=200 (waiting for 404)
+[t=  782.3s 20:53:29Z] WARN: pod 7zg8oaj64rirmy did not return 404 after delete; check console
+[t=  782.3s 20:53:29Z] PROBE: pod 7zg8oaj64rirmy torn down
+[t=    0.0s 20:53:29Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:53:29Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 20:53:30Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 20:53:30Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:53:30Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:53:30Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 20:53:31Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 20:53:31Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:53:31Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:53:31Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 20:53:31Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 20:53:31Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:53:31Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 20:53:31Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    2.0s 20:53:33Z] create OK id=akzuczrq0lxjlq costPerHr=$1.39
+[t=    2.0s 20:53:33Z] PROBE: pod created id=akzuczrq0lxjlq; waiting for publicIp+ssh_port
+[t=    2.3s 20:53:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 20:53:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.1s 20:54:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.5s 20:54:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.5s 20:54:35Z] PROBE NO-GO: pod akzuczrq0lxjlq not RUNNING+SSH within 60s; tearing down
+[t=   63.5s 20:54:35Z] DELETE pod akzuczrq0lxjlq
+[t=   64.0s 20:54:35Z] delete returned status=204 resp={}
+[t=   69.3s 20:54:41Z] pod akzuczrq0lxjlq confirmed terminated (404)
+[t=   69.3s 20:54:41Z] PROBE: pod akzuczrq0lxjlq torn down
+[t=    0.0s 20:55:10Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 20:55:10Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 20:55:12Z] create OK id=n0o3bjv7v9w093 costPerHr=$1.49
+[t=    1.2s 20:55:12Z] PROBE: pod created id=n0o3bjv7v9w093; waiting for publicIp+ssh_port
+[t=    1.5s 20:55:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 20:55:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 20:55:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 20:55:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 20:56:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.6s 20:56:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.9s 20:56:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.3s 20:57:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.3s 20:57:15Z] PROBE NO-GO: pod n0o3bjv7v9w093 not RUNNING+SSH within 120s; tearing down
+[t=  124.3s 20:57:15Z] DELETE pod n0o3bjv7v9w093
+[t=  124.9s 20:57:15Z] delete returned status=204 resp={}
+[t=  130.2s 20:57:21Z] pod n0o3bjv7v9w093 confirmed terminated (404)
+[t=  130.2s 20:57:21Z] PROBE: pod n0o3bjv7v9w093 torn down
+[t=    0.0s 20:57:21Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:57:21Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 20:57:21Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 20:57:21Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:57:21Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:57:21Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 20:57:22Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 20:57:22Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:57:22Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:57:22Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 20:57:23Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 20:57:23Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:57:23Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 20:57:23Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 20:57:24Z] create OK id=b2mqkcvdwm7omn costPerHr=$1.39
+[t=    0.9s 20:57:24Z] PROBE: pod created id=b2mqkcvdwm7omn; waiting for publicIp+ssh_port
+[t=    1.2s 20:57:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.6s 20:57:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 20:57:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 20:58:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.4s 20:58:25Z] PROBE NO-GO: pod b2mqkcvdwm7omn not RUNNING+SSH within 60s; tearing down
+[t=   62.4s 20:58:25Z] DELETE pod b2mqkcvdwm7omn
+[t=   62.9s 20:58:26Z] delete returned status=204 resp={}
+[t=   68.3s 20:58:31Z] pod b2mqkcvdwm7omn confirmed terminated (404)
+[t=   68.3s 20:58:31Z] PROBE: pod b2mqkcvdwm7omn torn down
+[t=    0.0s 21:14:46Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 21:14:46Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 21:14:47Z] create OK id=04ijy3ieg117t0 costPerHr=$1.49
+[t=    1.3s 21:14:47Z] PROBE: pod created id=04ijy3ieg117t0; waiting for publicIp+ssh_port
+[t=    1.6s 21:14:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.5s 21:15:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.0s 21:15:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 21:15:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.0s 21:15:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.5s 21:16:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.9s 21:16:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.4s 21:16:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.4s 21:16:52Z] PROBE NO-GO: pod 04ijy3ieg117t0 not RUNNING+SSH within 120s; tearing down
+[t=  126.4s 21:16:52Z] DELETE pod 04ijy3ieg117t0
+[t=  127.0s 21:16:52Z] delete returned status=204 resp={}
+[t=  132.3s 21:16:58Z] pod 04ijy3ieg117t0 confirmed terminated (404)
+[t=  132.3s 21:16:58Z] PROBE: pod 04ijy3ieg117t0 torn down
+[t=    0.0s 21:16:58Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:16:58Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 21:16:59Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 21:16:59Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:16:59Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:16:59Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 21:16:59Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 21:16:59Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:16:59Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:16:59Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 21:17:00Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 21:17:00Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:17:00Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 21:17:00Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 21:17:01Z] create OK id=u0oyqbsuo40i5z costPerHr=$1.39
+[t=    0.9s 21:17:01Z] PROBE: pod created id=u0oyqbsuo40i5z; waiting for publicIp+ssh_port
+[t=    1.3s 21:17:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 21:17:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 21:17:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 21:17:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 21:18:03Z] PROBE NO-GO: pod u0oyqbsuo40i5z not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 21:18:03Z] DELETE pod u0oyqbsuo40i5z
+[t=   63.2s 21:18:03Z] delete returned status=204 resp={}
+[t=   68.5s 21:18:09Z] pod u0oyqbsuo40i5z confirmed terminated (404)
+[t=   68.5s 21:18:09Z] PROBE: pod u0oyqbsuo40i5z torn down
+[t=    0.0s 21:44:44Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 21:44:44Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:44:45Z] create OK id=dk4dmk96164gw2 costPerHr=$1.49
+[t=    1.1s 21:44:45Z] PROBE: pod created id=dk4dmk96164gw2; waiting for publicIp+ssh_port
+[t=    1.4s 21:44:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 21:45:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 21:45:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 21:45:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 21:45:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.7s 21:46:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.0s 21:46:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.4s 21:46:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.4s 21:46:48Z] PROBE NO-GO: pod dk4dmk96164gw2 not RUNNING+SSH within 120s; tearing down
+[t=  124.4s 21:46:48Z] DELETE pod dk4dmk96164gw2
+[t=  124.9s 21:46:49Z] delete returned status=204 resp={}
+[t=  130.2s 21:46:54Z] pod dk4dmk96164gw2 confirmed terminated (404)
+[t=  130.2s 21:46:54Z] PROBE: pod dk4dmk96164gw2 torn down
+[t=    0.0s 21:46:54Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:46:54Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 21:46:55Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 21:46:55Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:46:55Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:46:55Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 21:46:56Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 21:46:56Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:46:56Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:46:56Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 21:46:56Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 21:46:56Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:46:57Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 21:46:57Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 21:46:57Z] create OK id=i12b78z4v80878 costPerHr=$1.39
+[t=    0.9s 21:46:57Z] PROBE: pod created id=i12b78z4v80878; waiting for publicIp+ssh_port
+[t=    1.2s 21:46:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.6s 21:47:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 21:47:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 21:47:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.4s 21:47:59Z] PROBE NO-GO: pod i12b78z4v80878 not RUNNING+SSH within 60s; tearing down
+[t=   62.4s 21:47:59Z] DELETE pod i12b78z4v80878
+[t=   62.9s 21:47:59Z] delete returned status=204 resp={}
+[t=   68.3s 21:48:05Z] pod i12b78z4v80878 confirmed terminated (404)
+[t=   68.3s 21:48:05Z] PROBE: pod i12b78z4v80878 torn down
+[t=    0.0s 22:15:00Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:15:00Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:15:01Z] create OK id=qvjr1r868zxhvw costPerHr=$1.49
+[t=    1.1s 22:15:01Z] PROBE: pod created id=qvjr1r868zxhvw; waiting for publicIp+ssh_port
+[t=    1.4s 22:15:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 22:15:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 22:15:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 22:15:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.9s 22:16:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.3s 22:16:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.8s 22:16:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.1s 22:16:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.1s 22:17:05Z] PROBE NO-GO: pod qvjr1r868zxhvw not RUNNING+SSH within 120s; tearing down
+[t=  125.1s 22:17:05Z] DELETE pod qvjr1r868zxhvw
+[t=  128.3s 22:17:08Z] delete returned status=204 resp={}
+[t=  133.9s 22:17:13Z] pod qvjr1r868zxhvw confirmed terminated (404)
+[t=  133.9s 22:17:13Z] PROBE: pod qvjr1r868zxhvw torn down
+[t=    0.0s 22:17:14Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:17:14Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 22:17:15Z] create OK id=wd00bxitb5o096 costPerHr=$1.39
+[t=    1.6s 22:17:15Z] PROBE: pod created id=wd00bxitb5o096; waiting for publicIp+ssh_port
+[t=    2.1s 22:17:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 22:17:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 22:17:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 22:18:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 22:18:18Z] PROBE NO-GO: pod wd00bxitb5o096 not RUNNING+SSH within 60s; tearing down
+[t=   64.1s 22:18:18Z] DELETE pod wd00bxitb5o096
+[t=   64.7s 22:18:18Z] delete returned status=204 resp={}
+[t=   70.0s 22:18:24Z] pod wd00bxitb5o096 confirmed terminated (404)
+[t=   70.0s 22:18:24Z] PROBE: pod wd00bxitb5o096 torn down
+[t=    0.0s 22:18:24Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:18:24Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 22:18:24Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 22:18:24Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:18:25Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:18:25Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 22:18:25Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 22:18:25Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:18:25Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 22:18:25Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 22:18:26Z] create OK id=j1dipi0xbwp7b2 costPerHr=$1.39
+[t=    0.9s 22:18:26Z] PROBE: pod created id=j1dipi0xbwp7b2; waiting for publicIp+ssh_port
+[t=    1.2s 22:18:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.6s 22:18:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 22:18:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 22:19:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.5s 22:19:28Z] PROBE NO-GO: pod j1dipi0xbwp7b2 not RUNNING+SSH within 60s; tearing down
+[t=   62.5s 22:19:28Z] DELETE pod j1dipi0xbwp7b2
+[t=   63.0s 22:19:28Z] delete returned status=204 resp={}
+[t=   68.3s 22:19:34Z] pod j1dipi0xbwp7b2 confirmed terminated (404)
+[t=   68.3s 22:19:34Z] PROBE: pod j1dipi0xbwp7b2 torn down
+[t=    0.0s 22:44:46Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:44:46Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:44:47Z] create OK id=1begzvptssc8fo costPerHr=$1.49
+[t=    1.1s 22:44:47Z] PROBE: pod created id=1begzvptssc8fo; waiting for publicIp+ssh_port
+[t=    1.4s 22:44:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 22:45:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 22:45:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 22:45:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.4s 22:45:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.8s 22:46:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.2s 22:46:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.5s 22:46:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.5s 22:46:51Z] PROBE NO-GO: pod 1begzvptssc8fo not RUNNING+SSH within 120s; tearing down
+[t=  124.6s 22:46:51Z] DELETE pod 1begzvptssc8fo
+[t=  125.2s 22:46:51Z] delete returned status=204 resp={}
+[t=  130.5s 22:46:56Z] pod 1begzvptssc8fo confirmed terminated (404)
+[t=  130.5s 22:46:56Z] PROBE: pod 1begzvptssc8fo torn down
+[t=    0.0s 22:46:57Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:46:57Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 22:46:57Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 22:46:57Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:46:57Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:46:57Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 22:46:58Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 22:46:58Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:46:58Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:46:58Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 22:46:59Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 22:46:59Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:46:59Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 22:46:59Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 22:46:59Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 22:46:59Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500

--- a/results/m4_path_c_probe_20260518/orchestrator.log
+++ b/results/m4_path_c_probe_20260518/orchestrator.log
@@ -1,0 +1,1231 @@
+[t=    0.0s 00:00:21Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 00:00:21Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    2.3s 00:00:23Z] create OK id=bc8mwdanz6bxw4 costPerHr=$1.49
+[t=    2.3s 00:00:23Z] PROBE: pod created id=bc8mwdanz6bxw4; waiting for publicIp+ssh_port
+[t=    2.5s 00:00:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.0s 00:00:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t= 2886.7s 00:48:28Z] PROBE NO-GO: pod bc8mwdanz6bxw4 not RUNNING+SSH within 120s; tearing down
+[t= 2886.7s 00:48:28Z] DELETE pod bc8mwdanz6bxw4
+[t= 2887.5s 00:48:29Z] delete returned status=204 resp={}
+[t= 2892.8s 00:48:34Z] pod bc8mwdanz6bxw4 confirmed terminated (404)
+[t= 2892.8s 00:48:34Z] PROBE: pod bc8mwdanz6bxw4 torn down
+[t=    0.0s 00:48:34Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:48:34Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 00:48:35Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 00:48:35Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 00:48:35Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:48:35Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 00:48:36Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 00:48:36Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 00:48:36Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:48:36Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 00:48:36Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 00:48:36Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 00:48:36Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 00:48:36Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 00:48:37Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.9s 00:48:37Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 02:32:11Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 02:32:11Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 02:32:12Z] create OK id=44pw3zd8xvzb1q costPerHr=$1.49
+[t=    1.5s 02:32:12Z] PROBE: pod created id=44pw3zd8xvzb1q; waiting for publicIp+ssh_port
+[t=    2.0s 02:32:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 02:32:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  104.4s 02:33:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  120.0s 02:34:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  135.0s 02:34:26Z] PROBE NO-GO: pod 44pw3zd8xvzb1q not RUNNING+SSH within 120s; tearing down
+[t=  135.0s 02:34:26Z] DELETE pod 44pw3zd8xvzb1q
+[t=  135.6s 02:34:26Z] delete returned status=204 resp={}
+[t=  206.8s 02:35:37Z] pod 44pw3zd8xvzb1q confirmed terminated (404)
+[t=  206.8s 02:35:37Z] PROBE: pod 44pw3zd8xvzb1q torn down
+[t=    0.0s 02:35:38Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:35:38Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 02:35:39Z] create OK id=lo8iaa8hgrto1i costPerHr=$1.39
+[t=    1.2s 02:35:39Z] PROBE: pod created id=lo8iaa8hgrto1i; waiting for publicIp+ssh_port
+[t=    1.5s 02:35:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 02:35:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 02:36:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  149.6s 02:38:07Z] PROBE NO-GO: pod lo8iaa8hgrto1i not RUNNING+SSH within 60s; tearing down
+[t=  149.6s 02:38:07Z] DELETE pod lo8iaa8hgrto1i
+[t=  150.2s 02:38:08Z] delete returned status=204 resp={}
+[t=  155.5s 02:38:13Z] pod lo8iaa8hgrto1i confirmed terminated (404)
+[t=  155.5s 02:38:13Z] PROBE: pod lo8iaa8hgrto1i torn down
+[t=    0.0s 02:38:13Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:38:13Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 02:38:14Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 02:38:14Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 02:38:14Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:38:14Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 02:38:15Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 02:38:15Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 02:38:15Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 02:38:15Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 02:38:16Z] create OK id=h83fhvf3uuhkmb costPerHr=$1.39
+[t=    0.9s 02:38:16Z] PROBE: pod created id=h83fhvf3uuhkmb; waiting for publicIp+ssh_port
+[t=    1.2s 02:38:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 02:38:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 02:38:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  140.6s 02:40:35Z] PROBE NO-GO: pod h83fhvf3uuhkmb not RUNNING+SSH within 60s; tearing down
+[t=  140.6s 02:40:35Z] DELETE pod h83fhvf3uuhkmb
+[t=  141.3s 02:40:36Z] delete returned status=204 resp={}
+[t=  146.8s 02:40:42Z] pod h83fhvf3uuhkmb confirmed terminated (404)
+[t=  146.8s 02:40:42Z] PROBE: pod h83fhvf3uuhkmb torn down
+[t=    0.0s 03:23:20Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 03:23:20Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 03:23:22Z] create OK id=vpe8kifb4ut5v4 costPerHr=$1.49
+[t=    1.2s 03:23:22Z] PROBE: pod created id=vpe8kifb4ut5v4; waiting for publicIp+ssh_port
+[t=    1.5s 03:23:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 03:23:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 03:23:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 03:24:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 03:24:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.7s 03:24:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.1s 03:24:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.6s 03:25:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.6s 03:25:25Z] PROBE NO-GO: pod vpe8kifb4ut5v4 not RUNNING+SSH within 120s; tearing down
+[t=  124.6s 03:25:25Z] DELETE pod vpe8kifb4ut5v4
+[t=  125.2s 03:25:26Z] delete returned status=204 resp={}
+[t=  130.5s 03:25:31Z] pod vpe8kifb4ut5v4 confirmed terminated (404)
+[t=  130.5s 03:25:31Z] PROBE: pod vpe8kifb4ut5v4 torn down
+[t=    0.0s 03:25:31Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 03:25:31Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 03:25:32Z] create OK id=d4uo1esaqvwnm4 costPerHr=$1.39
+[t=    1.2s 03:25:32Z] PROBE: pod created id=d4uo1esaqvwnm4; waiting for publicIp+ssh_port
+[t=    1.9s 03:25:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 03:25:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.1s 03:26:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.5s 03:26:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.5s 03:26:35Z] PROBE NO-GO: pod d4uo1esaqvwnm4 not RUNNING+SSH within 60s; tearing down
+[t=   63.5s 03:26:35Z] DELETE pod d4uo1esaqvwnm4
+[t=   64.1s 03:26:35Z] delete returned status=204 resp={}
+[t=   69.6s 03:26:41Z] pod d4uo1esaqvwnm4 confirmed terminated (404)
+[t=   69.6s 03:26:41Z] PROBE: pod d4uo1esaqvwnm4 torn down
+[t=    0.0s 03:26:41Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 03:26:41Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    2.3s 03:26:43Z] create OK id=cd6ggqn7a9a8bf costPerHr=$2.99
+[t=    2.3s 03:26:43Z] PROBE: pod created id=cd6ggqn7a9a8bf; waiting for publicIp+ssh_port
+[t=    3.0s 03:26:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.7s 03:27:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.6s 03:27:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   50.3s 03:27:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.3s 03:27:46Z] PROBE NO-GO: pod cd6ggqn7a9a8bf not RUNNING+SSH within 60s; tearing down
+[t=   65.3s 03:27:46Z] DELETE pod cd6ggqn7a9a8bf
+[t=   65.9s 03:27:47Z] delete returned status=204 resp={}
+[t=   71.2s 03:27:52Z] pod cd6ggqn7a9a8bf confirmed terminated (404)
+[t=   71.2s 03:27:52Z] PROBE: pod cd6ggqn7a9a8bf torn down
+[t=    0.0s 03:27:52Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 03:27:52Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 03:27:53Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 03:27:53Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 03:27:53Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 03:27:53Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 03:27:54Z] create OK id=livzdpbjmu9mre costPerHr=$1.39
+[t=    1.0s 03:27:54Z] PROBE: pod created id=livzdpbjmu9mre; waiting for publicIp+ssh_port
+[t=    1.4s 03:27:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 03:28:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 03:28:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 03:28:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 03:28:56Z] PROBE NO-GO: pod livzdpbjmu9mre not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 03:28:56Z] DELETE pod livzdpbjmu9mre
+[t=   63.5s 03:28:57Z] delete returned status=204 resp={}
+[t=   68.9s 03:29:02Z] pod livzdpbjmu9mre confirmed terminated (404)
+[t=   68.9s 03:29:02Z] PROBE: pod livzdpbjmu9mre torn down
+[t=    0.0s 03:44:44Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 03:44:44Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 03:44:46Z] create OK id=0cn4dxg1cz9v77 costPerHr=$1.49
+[t=    1.3s 03:44:46Z] PROBE: pod created id=0cn4dxg1cz9v77; waiting for publicIp+ssh_port
+[t=    1.7s 03:44:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 03:45:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 03:45:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 03:45:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.8s 03:45:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.2s 03:46:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.6s 03:46:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.1s 03:46:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.1s 03:46:49Z] PROBE NO-GO: pod 0cn4dxg1cz9v77 not RUNNING+SSH within 120s; tearing down
+[t=  125.1s 03:46:49Z] DELETE pod 0cn4dxg1cz9v77
+[t=  125.7s 03:46:50Z] delete returned status=204 resp={}
+[t=  131.0s 03:46:55Z] pod 0cn4dxg1cz9v77 confirmed terminated (404)
+[t=  131.0s 03:46:55Z] PROBE: pod 0cn4dxg1cz9v77 torn down
+[t=    0.0s 03:46:55Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 03:46:55Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 03:46:56Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 03:46:56Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 03:46:56Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 03:46:56Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 03:46:57Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 03:46:57Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 03:46:57Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 03:46:57Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 03:46:58Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 03:46:58Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 03:46:58Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 03:46:58Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.8s 03:46:59Z] create OK id=uhqxgvneillimh costPerHr=$1.39
+[t=    0.8s 03:46:59Z] PROBE: pod created id=uhqxgvneillimh; waiting for publicIp+ssh_port
+[t=    1.2s 03:46:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 03:47:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 03:47:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 03:47:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 03:48:00Z] PROBE NO-GO: pod uhqxgvneillimh not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 03:48:00Z] DELETE pod uhqxgvneillimh
+[t=   63.3s 03:48:01Z] delete returned status=204 resp={}
+[t=   68.7s 03:48:06Z] pod uhqxgvneillimh confirmed terminated (404)
+[t=   68.7s 03:48:06Z] PROBE: pod uhqxgvneillimh torn down
+[t=    0.0s 04:14:45Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 04:14:45Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 04:14:46Z] create OK id=bqykgvzvwyqi8a costPerHr=$1.49
+[t=    1.4s 04:14:46Z] PROBE: pod created id=bqykgvzvwyqi8a; waiting for publicIp+ssh_port
+[t=    1.7s 04:14:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 04:15:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 04:15:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 04:15:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.7s 04:15:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.3s 04:16:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.8s 04:16:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.2s 04:16:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.2s 04:16:50Z] PROBE NO-GO: pod bqykgvzvwyqi8a not RUNNING+SSH within 120s; tearing down
+[t=  125.2s 04:16:50Z] DELETE pod bqykgvzvwyqi8a
+[t=  125.9s 04:16:51Z] delete returned status=204 resp={}
+[t=  131.2s 04:16:56Z] pod bqykgvzvwyqi8a confirmed terminated (404)
+[t=  131.3s 04:16:56Z] PROBE: pod bqykgvzvwyqi8a torn down
+[t=    0.0s 04:16:56Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:16:56Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 04:16:57Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 04:16:57Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 04:16:57Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:16:57Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 04:16:58Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 04:16:58Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 04:16:58Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:16:58Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 04:16:58Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 04:16:58Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 04:16:59Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 04:16:59Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 04:16:59Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 04:16:59Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 04:44:45Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 04:44:45Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 04:44:46Z] create OK id=bxi1ej76pg1oky costPerHr=$1.49
+[t=    1.3s 04:44:46Z] PROBE: pod created id=bxi1ej76pg1oky; waiting for publicIp+ssh_port
+[t=    1.6s 04:44:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 04:45:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 04:45:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 04:45:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.4s 04:45:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.8s 04:46:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.3s 04:46:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.7s 04:46:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.7s 04:46:49Z] PROBE NO-GO: pod bxi1ej76pg1oky not RUNNING+SSH within 120s; tearing down
+[t=  124.7s 04:46:49Z] DELETE pod bxi1ej76pg1oky
+[t=  125.4s 04:46:50Z] delete returned status=204 resp={}
+[t=  130.8s 04:46:55Z] pod bxi1ej76pg1oky confirmed terminated (404)
+[t=  130.8s 04:46:55Z] PROBE: pod bxi1ej76pg1oky torn down
+[t=    0.0s 04:46:56Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:46:56Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 04:46:56Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 04:46:56Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 04:46:56Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:46:56Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 04:46:58Z] create OK id=v58wkdy81f8wua costPerHr=$2.99
+[t=    1.4s 04:46:58Z] PROBE: pod created id=v58wkdy81f8wua; waiting for publicIp+ssh_port
+[t=    2.0s 04:46:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 04:47:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 04:47:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.4s 04:47:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.4s 04:48:01Z] PROBE NO-GO: pod v58wkdy81f8wua not RUNNING+SSH within 60s; tearing down
+[t=   64.4s 04:48:01Z] DELETE pod v58wkdy81f8wua
+[t=   65.0s 04:48:01Z] delete returned status=204 resp={}
+[t=   70.5s 04:48:07Z] pod v58wkdy81f8wua confirmed terminated (404)
+[t=   70.5s 04:48:07Z] PROBE: pod v58wkdy81f8wua torn down
+[t=    0.0s 04:48:07Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:48:07Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 04:48:08Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 04:48:08Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 04:48:08Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 04:48:08Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 04:48:09Z] create OK id=jpfxovst579t5k costPerHr=$1.39
+[t=    1.0s 04:48:09Z] PROBE: pod created id=jpfxovst579t5k; waiting for publicIp+ssh_port
+[t=    1.3s 04:48:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 04:48:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 04:48:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 04:48:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 04:49:11Z] PROBE NO-GO: pod jpfxovst579t5k not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 04:49:11Z] DELETE pod jpfxovst579t5k
+[t=   63.4s 04:49:11Z] delete returned status=204 resp={}
+[t=   68.9s 04:49:17Z] pod jpfxovst579t5k confirmed terminated (404)
+[t=   68.9s 04:49:17Z] PROBE: pod jpfxovst579t5k torn down
+[t=    0.0s 05:14:46Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 05:14:46Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 05:14:47Z] create OK id=qqum3c7e44ffyi costPerHr=$1.49
+[t=    1.1s 05:14:47Z] PROBE: pod created id=qqum3c7e44ffyi; waiting for publicIp+ssh_port
+[t=    1.4s 05:14:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 05:15:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 05:15:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.8s 05:15:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.2s 05:15:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.7s 05:16:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.1s 05:16:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.5s 05:16:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.5s 05:16:51Z] PROBE NO-GO: pod qqum3c7e44ffyi not RUNNING+SSH within 120s; tearing down
+[t=  125.5s 05:16:51Z] DELETE pod qqum3c7e44ffyi
+[t=  126.1s 05:16:52Z] delete returned status=204 resp={}
+[t=  131.5s 05:16:57Z] pod qqum3c7e44ffyi confirmed terminated (404)
+[t=  131.5s 05:16:57Z] PROBE: pod qqum3c7e44ffyi torn down
+[t=    0.0s 05:16:57Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:16:57Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 05:16:58Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 05:16:58Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 05:16:58Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:16:58Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 05:16:59Z] create OK id=y8t3s1j2srd9ye costPerHr=$2.99
+[t=    1.2s 05:16:59Z] PROBE: pod created id=y8t3s1j2srd9ye; waiting for publicIp+ssh_port
+[t=    1.5s 05:17:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 05:17:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 05:17:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 05:17:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 05:18:01Z] PROBE NO-GO: pod y8t3s1j2srd9ye not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 05:18:01Z] DELETE pod y8t3s1j2srd9ye
+[t=   63.5s 05:18:02Z] delete returned status=204 resp={}
+[t=   68.9s 05:18:07Z] pod y8t3s1j2srd9ye confirmed terminated (404)
+[t=   68.9s 05:18:07Z] PROBE: pod y8t3s1j2srd9ye torn down
+[t=    0.0s 05:18:07Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:18:07Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 05:18:08Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 05:18:08Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 05:18:08Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 05:18:08Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 05:18:09Z] create OK id=wtdqk3ie0kwl6c costPerHr=$1.39
+[t=    0.9s 05:18:09Z] PROBE: pod created id=wtdqk3ie0kwl6c; waiting for publicIp+ssh_port
+[t=    1.3s 05:18:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 05:18:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 05:18:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 05:18:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 05:19:11Z] PROBE NO-GO: pod wtdqk3ie0kwl6c not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 05:19:11Z] DELETE pod wtdqk3ie0kwl6c
+[t=   63.2s 05:19:11Z] delete returned status=204 resp={}
+[t=   68.6s 05:19:17Z] pod wtdqk3ie0kwl6c confirmed terminated (404)
+[t=   68.6s 05:19:17Z] PROBE: pod wtdqk3ie0kwl6c torn down
+[t=    0.0s 05:51:20Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 05:51:20Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 05:51:21Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.8s 05:51:21Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 05:51:21Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:51:21Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 05:51:22Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 05:51:22Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 05:51:22Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:51:22Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 05:51:23Z] create OK id=512m8085na76qu costPerHr=$2.99
+[t=    1.3s 05:51:23Z] PROBE: pod created id=512m8085na76qu; waiting for publicIp+ssh_port
+[t=    1.9s 05:51:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 05:51:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   45.8s 05:52:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   61.5s 05:52:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   76.5s 05:52:38Z] PROBE NO-GO: pod 512m8085na76qu not RUNNING+SSH within 60s; tearing down
+[t=   76.5s 05:52:38Z] DELETE pod 512m8085na76qu
+[t=   77.4s 05:52:39Z] delete returned status=204 resp={}
+[t=   82.8s 05:52:45Z] pod 512m8085na76qu confirmed terminated (404)
+[t=   82.8s 05:52:45Z] PROBE: pod 512m8085na76qu torn down
+[t=    0.0s 05:52:45Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:52:45Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 05:52:46Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 05:52:46Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 05:52:46Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 05:52:46Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 05:52:47Z] create OK id=ni01hyd76qbhg0 costPerHr=$1.39
+[t=    0.9s 05:52:47Z] PROBE: pod created id=ni01hyd76qbhg0; waiting for publicIp+ssh_port
+[t=    1.2s 05:52:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t= 1938.4s 06:25:04Z] PROBE NO-GO: pod ni01hyd76qbhg0 not RUNNING+SSH within 60s; tearing down
+[t= 1938.4s 06:25:04Z] DELETE pod ni01hyd76qbhg0
+[t= 1939.0s 06:25:05Z] delete returned status=204 resp={}
+[t= 1944.4s 06:25:10Z] pod ni01hyd76qbhg0 confirmed terminated (404)
+[t= 1944.4s 06:25:10Z] PROBE: pod ni01hyd76qbhg0 torn down
+[t=    0.0s 06:59:31Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 06:59:31Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 06:59:32Z] create OK id=q1soxc1pzahc3x costPerHr=$1.49
+[t=    1.2s 06:59:32Z] PROBE: pod created id=q1soxc1pzahc3x; waiting for publicIp+ssh_port
+[t=    1.5s 06:59:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t= 1045.7s 07:16:56Z] PROBE NO-GO: pod q1soxc1pzahc3x not RUNNING+SSH within 120s; tearing down
+[t= 1045.7s 07:16:56Z] DELETE pod q1soxc1pzahc3x
+[t= 1046.4s 07:16:57Z] delete returned status=204 resp={}
+[t= 1051.8s 07:17:02Z] pod q1soxc1pzahc3x confirmed terminated (404)
+[t= 1051.8s 07:17:02Z] PROBE: pod q1soxc1pzahc3x torn down
+[t=    0.0s 07:17:03Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 07:17:03Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 07:17:03Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 07:17:03Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 07:17:03Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 07:17:03Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 07:17:05Z] create OK id=982w8qugjqo918 costPerHr=$2.99
+[t=    1.4s 07:17:05Z] PROBE: pod created id=982w8qugjqo918; waiting for publicIp+ssh_port
+[t=    1.9s 07:17:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 07:17:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  588.8s 07:26:52Z] PROBE NO-GO: pod 982w8qugjqo918 not RUNNING+SSH within 60s; tearing down
+[t=  588.8s 07:26:52Z] DELETE pod 982w8qugjqo918
+[t=  589.5s 07:26:53Z] delete returned status=204 resp={}
+[t=  594.9s 07:26:58Z] pod 982w8qugjqo918 confirmed terminated (404)
+[t=  594.9s 07:26:58Z] PROBE: pod 982w8qugjqo918 torn down
+[t=    0.0s 07:26:58Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 07:26:58Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 07:26:59Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 07:26:59Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 07:26:59Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 07:26:59Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.3s 07:27:00Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    1.3s 07:27:00Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 09:04:39Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 09:04:39Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 09:04:40Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 09:04:40Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 09:04:40Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 09:04:40Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 09:04:41Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 09:04:41Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 09:04:41Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 09:04:41Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 09:04:42Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 09:04:42Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 09:04:42Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 09:04:42Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 09:04:42Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 09:04:42Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 09:04:42Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 09:04:42Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 09:04:43Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 09:04:43Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 09:16:21Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 09:16:21Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 09:16:22Z] create OK id=d06jbyjv37mst8 costPerHr=$1.49
+[t=    1.3s 09:16:22Z] PROBE: pod created id=d06jbyjv37mst8; waiting for publicIp+ssh_port
+[t=    1.6s 09:16:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 09:16:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 09:16:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  160.7s 09:19:01Z] PROBE NO-GO: pod d06jbyjv37mst8 not RUNNING+SSH within 120s; tearing down
+[t=  160.7s 09:19:01Z] DELETE pod d06jbyjv37mst8
+[t=  161.4s 09:19:02Z] delete returned status=204 resp={}
+[t=  166.7s 09:19:07Z] pod d06jbyjv37mst8 confirmed terminated (404)
+[t=  166.7s 09:19:07Z] PROBE: pod d06jbyjv37mst8 torn down
+[t=    0.0s 09:19:07Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 09:19:07Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 09:19:09Z] create OK id=asuhh3pjgy1kzf costPerHr=$1.39
+[t=    1.2s 09:19:09Z] PROBE: pod created id=asuhh3pjgy1kzf; waiting for publicIp+ssh_port
+[t=    1.6s 09:19:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 09:19:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   98.8s 09:20:46Z] PROBE NO-GO: pod asuhh3pjgy1kzf not RUNNING+SSH within 60s; tearing down
+[t=   98.8s 09:20:46Z] DELETE pod asuhh3pjgy1kzf
+[t=   99.5s 09:20:47Z] delete returned status=204 resp={}
+[t=  104.9s 09:20:52Z] pod asuhh3pjgy1kzf confirmed terminated (404)
+[t=  104.9s 09:20:52Z] PROBE: pod asuhh3pjgy1kzf torn down
+[t=    0.0s 09:20:53Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 09:20:53Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 09:20:54Z] create OK id=exsq5sptaiasdj costPerHr=$2.99
+[t=    1.5s 09:20:54Z] PROBE: pod created id=exsq5sptaiasdj; waiting for publicIp+ssh_port
+[t=    2.2s 09:20:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.0s 09:21:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.8s 09:21:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.5s 09:22:43Z] PROBE NO-GO: pod exsq5sptaiasdj not RUNNING+SSH within 60s; tearing down
+[t=  110.5s 09:22:43Z] DELETE pod exsq5sptaiasdj
+[t=  111.2s 09:22:44Z] delete returned status=204 resp={}
+[t=  116.6s 09:22:49Z] pod exsq5sptaiasdj confirmed terminated (404)
+[t=  116.6s 09:22:49Z] PROBE: pod exsq5sptaiasdj torn down
+[t=    0.0s 09:22:49Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 09:22:49Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 09:22:50Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 09:22:50Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 09:22:50Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 09:22:50Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 09:22:51Z] create OK id=c628oyyo6shj5w costPerHr=$1.39
+[t=    1.0s 09:22:51Z] PROBE: pod created id=c628oyyo6shj5w; waiting for publicIp+ssh_port
+[t=    1.3s 09:22:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 09:23:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  113.7s 09:24:44Z] PROBE NO-GO: pod c628oyyo6shj5w not RUNNING+SSH within 60s; tearing down
+[t=  113.7s 09:24:44Z] DELETE pod c628oyyo6shj5w
+[t=  114.3s 09:24:44Z] delete returned status=204 resp={}
+[t=  119.7s 09:24:50Z] pod c628oyyo6shj5w confirmed terminated (404)
+[t=  119.7s 09:24:50Z] PROBE: pod c628oyyo6shj5w torn down
+[t=    0.0s 09:47:05Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 09:47:05Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 09:47:06Z] create OK id=cifiw8zfv4z70f costPerHr=$1.49
+[t=    1.2s 09:47:06Z] PROBE: pod created id=cifiw8zfv4z70f; waiting for publicIp+ssh_port
+[t=    1.6s 09:47:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 09:47:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  166.5s 09:49:52Z] PROBE NO-GO: pod cifiw8zfv4z70f not RUNNING+SSH within 120s; tearing down
+[t=  166.5s 09:49:52Z] DELETE pod cifiw8zfv4z70f
+[t=  167.6s 09:49:53Z] delete returned status=204 resp={}
+[t=  173.0s 09:49:58Z] pod cifiw8zfv4z70f confirmed terminated (404)
+[t=  173.0s 09:49:58Z] PROBE: pod cifiw8zfv4z70f torn down
+[t=    0.0s 09:49:58Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 09:49:58Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 09:49:59Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 09:49:59Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 09:49:59Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 09:49:59Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 09:50:00Z] create OK id=zs94gfb745l5y4 costPerHr=$2.99
+[t=    1.2s 09:50:00Z] PROBE: pod created id=zs94gfb745l5y4; waiting for publicIp+ssh_port
+[t=    1.6s 09:50:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 09:50:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 09:50:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  532.2s 09:58:51Z] PROBE NO-GO: pod zs94gfb745l5y4 not RUNNING+SSH within 60s; tearing down
+[t=  532.2s 09:58:51Z] DELETE pod zs94gfb745l5y4
+[t=  533.0s 09:58:52Z] delete returned status=204 resp={}
+[t=  538.4s 09:58:58Z] pod zs94gfb745l5y4 confirmed terminated (404)
+[t=  538.4s 09:58:58Z] PROBE: pod zs94gfb745l5y4 torn down
+[t=    0.0s 09:58:58Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 09:58:58Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.8s 09:58:59Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.8s 09:58:59Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 09:58:59Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 09:58:59Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.2s 09:59:00Z] create OK id=8k0g2r08p1o1z4 costPerHr=$1.39
+[t=    1.2s 09:59:00Z] PROBE: pod created id=8k0g2r08p1o1z4; waiting for publicIp+ssh_port
+[t=    1.5s 09:59:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 09:59:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  143.7s 10:01:23Z] PROBE NO-GO: pod 8k0g2r08p1o1z4 not RUNNING+SSH within 60s; tearing down
+[t=  143.7s 10:01:23Z] DELETE pod 8k0g2r08p1o1z4
+[t=  144.4s 10:01:23Z] delete returned status=204 resp={}
+[t=  149.7s 10:01:29Z] pod 8k0g2r08p1o1z4 confirmed terminated (404)
+[t=  149.7s 10:01:29Z] PROBE: pod 8k0g2r08p1o1z4 torn down
+[t=    0.0s 10:17:26Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 10:17:26Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.8s 10:17:26Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.8s 10:17:26Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 10:17:26Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 10:17:26Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 10:17:27Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 10:17:27Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 10:17:27Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 10:17:27Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 10:17:28Z] create OK id=w6m3tff4rbiwme costPerHr=$2.99
+[t=    1.3s 10:17:28Z] PROBE: pod created id=w6m3tff4rbiwme; waiting for publicIp+ssh_port
+[t=    1.8s 10:17:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 10:17:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  256.6s 10:21:44Z] PROBE NO-GO: pod w6m3tff4rbiwme not RUNNING+SSH within 60s; tearing down
+[t=  256.6s 10:21:44Z] DELETE pod w6m3tff4rbiwme
+[t=  257.2s 10:21:44Z] delete returned status=204 resp={}
+[t=  262.6s 10:21:50Z] pod w6m3tff4rbiwme confirmed terminated (404)
+[t=  262.6s 10:21:50Z] PROBE: pod w6m3tff4rbiwme torn down
+[t=    0.0s 10:21:50Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 10:21:50Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 10:21:50Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 10:21:50Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 10:21:51Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 10:21:51Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 10:21:51Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 10:21:51Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 10:46:54Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 10:46:54Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 10:46:56Z] create OK id=9whrsk2mvy3207 costPerHr=$1.49
+[t=    1.2s 10:46:56Z] PROBE: pod created id=9whrsk2mvy3207; waiting for publicIp+ssh_port
+[t=    1.7s 10:46:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 10:47:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 10:47:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  948.6s 11:02:43Z] PROBE NO-GO: pod 9whrsk2mvy3207 not RUNNING+SSH within 120s; tearing down
+[t=  948.6s 11:02:43Z] DELETE pod 9whrsk2mvy3207
+[t=  949.3s 11:02:44Z] delete returned status=204 resp={}
+[t=  954.7s 11:02:49Z] pod 9whrsk2mvy3207 confirmed terminated (404)
+[t=  954.7s 11:02:49Z] PROBE: pod 9whrsk2mvy3207 torn down
+[t=    0.0s 11:02:49Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 11:02:49Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 11:02:50Z] create OK id=h0hpong6kt6vqp costPerHr=$1.39
+[t=    1.1s 11:02:50Z] PROBE: pod created id=h0hpong6kt6vqp; waiting for publicIp+ssh_port
+[t=    1.4s 11:02:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 11:03:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  141.3s 11:05:11Z] PROBE NO-GO: pod h0hpong6kt6vqp not RUNNING+SSH within 60s; tearing down
+[t=  141.3s 11:05:11Z] DELETE pod h0hpong6kt6vqp
+[t=  141.9s 11:05:11Z] delete returned status=204 resp={}
+[t=  147.2s 11:05:17Z] pod h0hpong6kt6vqp confirmed terminated (404)
+[t=  147.2s 11:05:17Z] PROBE: pod h0hpong6kt6vqp torn down
+[t=    0.0s 11:05:17Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 11:05:17Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.8s 11:05:19Z] create OK id=yla3h9pqqi5wwp costPerHr=$2.99
+[t=    1.8s 11:05:19Z] PROBE: pod created id=yla3h9pqqi5wwp; waiting for publicIp+ssh_port
+[t=    2.3s 11:05:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.3s 11:05:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.9s 11:05:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  337.9s 11:10:55Z] PROBE NO-GO: pod yla3h9pqqi5wwp not RUNNING+SSH within 60s; tearing down
+[t=  337.9s 11:10:55Z] DELETE pod yla3h9pqqi5wwp
+[t=  338.7s 11:10:55Z] delete returned status=204 resp={}
+[t=  344.1s 11:11:01Z] pod yla3h9pqqi5wwp confirmed terminated (404)
+[t=  344.1s 11:11:01Z] PROBE: pod yla3h9pqqi5wwp torn down
+[t=    0.0s 11:11:01Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 11:11:01Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 11:11:02Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 11:11:02Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 11:11:02Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 11:11:02Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.1s 11:11:03Z] create OK id=vwib0e5brun32e costPerHr=$1.39
+[t=    1.1s 11:11:03Z] PROBE: pod created id=vwib0e5brun32e; waiting for publicIp+ssh_port
+[t=    1.4s 11:11:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 11:11:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  210.6s 11:14:32Z] PROBE NO-GO: pod vwib0e5brun32e not RUNNING+SSH within 60s; tearing down
+[t=  210.6s 11:14:32Z] DELETE pod vwib0e5brun32e
+[t=  211.3s 11:14:33Z] delete returned status=204 resp={}
+[t=  216.8s 11:14:39Z] pod vwib0e5brun32e confirmed terminated (404)
+[t=  216.8s 11:14:39Z] PROBE: pod vwib0e5brun32e torn down
+[t=    0.0s 12:05:47Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 12:05:47Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 12:05:48Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 12:05:48Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 12:05:48Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 12:05:48Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 12:05:49Z] create OK id=02bvrupwwus8d9 costPerHr=$1.39
+[t=    1.2s 12:05:49Z] PROBE: pod created id=02bvrupwwus8d9; waiting for publicIp+ssh_port
+[t=    1.6s 12:05:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t= 1037.6s 12:23:06Z] PROBE NO-GO: pod 02bvrupwwus8d9 not RUNNING+SSH within 60s; tearing down
+[t= 1037.6s 12:23:06Z] DELETE pod 02bvrupwwus8d9
+[t= 1038.4s 12:23:06Z] delete returned status=204 resp={}
+[t= 1561.5s 12:31:49Z] pod 02bvrupwwus8d9 confirmed terminated (404)
+[t= 1561.5s 12:31:49Z] PROBE: pod 02bvrupwwus8d9 torn down
+[t=    0.0s 12:31:50Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 12:31:50Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 12:31:51Z] create OK id=oz1e3y4xjkx0up costPerHr=$2.99
+[t=    1.4s 12:31:51Z] PROBE: pod created id=oz1e3y4xjkx0up; waiting for publicIp+ssh_port
+[t=    2.0s 12:31:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 12:32:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 12:32:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  139.2s 12:34:09Z] PROBE NO-GO: pod oz1e3y4xjkx0up not RUNNING+SSH within 60s; tearing down
+[t=  139.2s 12:34:09Z] DELETE pod oz1e3y4xjkx0up
+[t=  139.7s 12:34:09Z] delete returned status=204 resp={}
+[t=  145.1s 12:34:15Z] pod oz1e3y4xjkx0up confirmed terminated (404)
+[t=  145.1s 12:34:15Z] PROBE: pod oz1e3y4xjkx0up torn down
+[t=    0.0s 12:34:15Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 12:34:15Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 12:34:15Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 12:34:15Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 12:34:16Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 12:34:16Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 12:34:16Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 12:34:16Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 12:46:14Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 12:46:14Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 12:46:15Z] create OK id=4srz7hv0i5o6cb costPerHr=$1.49
+[t=    1.2s 12:46:15Z] PROBE: pod created id=4srz7hv0i5o6cb; waiting for publicIp+ssh_port
+[t=    1.5s 12:46:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 12:46:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   40.2s 12:46:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   55.6s 12:47:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   71.0s 12:47:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   88.6s 12:47:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  104.0s 12:47:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  119.4s 12:48:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  134.4s 12:48:29Z] PROBE NO-GO: pod 4srz7hv0i5o6cb not RUNNING+SSH within 120s; tearing down
+[t=  134.5s 12:48:29Z] DELETE pod 4srz7hv0i5o6cb
+[t=  136.6s 12:48:31Z] delete returned status=204 resp={}
+[t=  142.0s 12:48:36Z] pod 4srz7hv0i5o6cb confirmed terminated (404)
+[t=  142.0s 12:48:36Z] PROBE: pod 4srz7hv0i5o6cb torn down
+[t=    0.0s 12:48:36Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 12:48:36Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 12:48:37Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 12:48:37Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 12:48:37Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 12:48:37Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 12:48:39Z] create OK id=3kvn3wa34gucdp costPerHr=$2.99
+[t=    1.4s 12:48:39Z] PROBE: pod created id=3kvn3wa34gucdp; waiting for publicIp+ssh_port
+[t=    1.9s 12:48:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 12:48:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.8s 12:49:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  691.5s 13:00:09Z] PROBE NO-GO: pod 3kvn3wa34gucdp not RUNNING+SSH within 60s; tearing down
+[t=  691.5s 13:00:09Z] DELETE pod 3kvn3wa34gucdp
+[t=  692.2s 13:00:09Z] delete returned status=204 resp={}
+[t=  697.6s 13:00:15Z] pod 3kvn3wa34gucdp confirmed terminated (404)
+[t=  697.6s 13:00:15Z] PROBE: pod 3kvn3wa34gucdp torn down
+[t=    0.0s 13:00:17Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 13:00:17Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.9s 13:00:17Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.9s 13:00:17Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 13:00:18Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 13:00:18Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.7s 13:00:18Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.7s 13:00:18Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 15:35:20Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 15:35:20Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 15:35:21Z] create OK id=m3rhn0fzak451e costPerHr=$1.49
+[t=    1.3s 15:35:21Z] PROBE: pod created id=m3rhn0fzak451e; waiting for publicIp+ssh_port
+[t=    1.6s 15:35:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  956.5s 15:51:16Z] PROBE NO-GO: pod m3rhn0fzak451e not RUNNING+SSH within 120s; tearing down
+[t=  956.5s 15:51:16Z] DELETE pod m3rhn0fzak451e
+[t=  957.3s 15:51:17Z] delete returned status=204 resp={}
+[t= 2013.4s 16:08:53Z] pod m3rhn0fzak451e confirmed terminated (404)
+[t= 2013.4s 16:08:53Z] PROBE: pod m3rhn0fzak451e torn down
+[t=    0.0s 16:08:53Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 16:08:53Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 16:08:54Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 16:08:54Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 16:08:54Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 16:08:54Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 16:08:55Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 16:08:55Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 16:08:55Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 16:08:55Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 16:08:55Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 16:08:55Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 16:08:56Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 16:08:56Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=  991.0s 16:25:27Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=  991.0s 16:25:27Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 16:55:39Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 16:55:39Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 16:55:41Z] create OK id=1oy6vws5eu6t3l costPerHr=$1.49
+[t=    1.4s 16:55:41Z] PROBE: pod created id=1oy6vws5eu6t3l; waiting for publicIp+ssh_port
+[t=    1.8s 16:55:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   22.6s 16:56:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   38.0s 16:56:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   53.5s 16:56:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   69.9s 16:56:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   85.5s 16:57:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  101.0s 16:57:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  133.2s 16:57:52Z] PROBE NO-GO: pod 1oy6vws5eu6t3l not RUNNING+SSH within 120s; tearing down
+[t=  133.2s 16:57:52Z] DELETE pod 1oy6vws5eu6t3l
+[t=  133.8s 16:57:53Z] delete returned status=204 resp={}
+[t=  139.2s 16:57:59Z] pod 1oy6vws5eu6t3l confirmed terminated (404)
+[t=  139.2s 16:57:59Z] PROBE: pod 1oy6vws5eu6t3l torn down
+[t=    0.0s 16:57:59Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 16:57:59Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 16:57:59Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 16:57:59Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 16:58:00Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 16:58:00Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 16:58:01Z] create OK id=amu4qor04e62ux costPerHr=$2.99
+[t=    1.6s 16:58:01Z] PROBE: pod created id=amu4qor04e62ux; waiting for publicIp+ssh_port
+[t=    2.2s 16:58:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.3s 16:58:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.2s 16:58:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   51.6s 16:58:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   66.6s 16:59:06Z] PROBE NO-GO: pod amu4qor04e62ux not RUNNING+SSH within 60s; tearing down
+[t=   66.6s 16:59:06Z] DELETE pod amu4qor04e62ux
+[t=   67.4s 16:59:07Z] delete returned status=204 resp={}
+[t=   73.0s 16:59:12Z] pod amu4qor04e62ux confirmed terminated (404)
+[t=   73.0s 16:59:12Z] PROBE: pod amu4qor04e62ux torn down
+[t=    0.0s 16:59:13Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 16:59:13Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 16:59:13Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 16:59:13Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 16:59:13Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 16:59:13Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 16:59:14Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 16:59:14Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:41:35Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 17:41:35Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 17:41:36Z] create OK id=p4tasnnkrhq8oz costPerHr=$1.49
+[t=    1.4s 17:41:36Z] PROBE: pod created id=p4tasnnkrhq8oz; waiting for publicIp+ssh_port
+[t=    1.7s 17:41:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 17:41:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.2s 17:42:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.0s 17:42:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 17:42:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.4s 17:42:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   96.3s 17:43:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.9s 17:43:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.9s 17:43:42Z] PROBE NO-GO: pod p4tasnnkrhq8oz not RUNNING+SSH within 120s; tearing down
+[t=  126.9s 17:43:42Z] DELETE pod p4tasnnkrhq8oz
+[t=  130.0s 17:43:45Z] delete returned status=204 resp={}
+[t=  135.5s 17:43:50Z] pod p4tasnnkrhq8oz confirmed terminated (404)
+[t=  135.5s 17:43:50Z] PROBE: pod p4tasnnkrhq8oz torn down
+[t=    0.0s 17:43:51Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:43:51Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 17:43:51Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 17:43:51Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:43:51Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:43:51Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.9s 17:43:53Z] create OK id=aefy53iwk1hh8c costPerHr=$2.99
+[t=    1.9s 17:43:53Z] PROBE: pod created id=aefy53iwk1hh8c; waiting for publicIp+ssh_port
+[t=    2.6s 17:43:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.3s 17:44:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.9s 17:44:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.8s 17:44:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.8s 17:44:56Z] PROBE NO-GO: pod aefy53iwk1hh8c not RUNNING+SSH within 60s; tearing down
+[t=   64.8s 17:44:56Z] DELETE pod aefy53iwk1hh8c
+[t=   65.5s 17:44:57Z] delete returned status=204 resp={}
+[t=   71.0s 17:45:02Z] pod aefy53iwk1hh8c confirmed terminated (404)
+[t=   71.0s 17:45:02Z] PROBE: pod aefy53iwk1hh8c torn down
+[t=    0.0s 17:45:03Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:45:03Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 17:45:03Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 17:45:03Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:45:03Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 17:45:03Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 17:45:04Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 17:45:04Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:44:46Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 18:44:46Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 18:44:46Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 18:44:46Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:44:46Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:44:46Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 18:44:47Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 18:44:47Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:44:47Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:44:47Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 18:44:48Z] create OK id=w2chx13g0ggn7o costPerHr=$2.99
+[t=    1.2s 18:44:48Z] PROBE: pod created id=w2chx13g0ggn7o; waiting for publicIp+ssh_port
+[t=    1.6s 18:44:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 18:45:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 18:45:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 18:45:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 18:45:50Z] PROBE NO-GO: pod w2chx13g0ggn7o not RUNNING+SSH within 60s; tearing down
+[t=   63.3s 18:45:50Z] DELETE pod w2chx13g0ggn7o
+[t=   63.9s 18:45:51Z] delete returned status=204 resp={}
+[t=   69.2s 18:45:56Z] pod w2chx13g0ggn7o confirmed terminated (404)
+[t=   69.2s 18:45:56Z] PROBE: pod w2chx13g0ggn7o torn down
+[t=    0.0s 18:45:57Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:45:57Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 18:45:57Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 18:45:57Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:45:57Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 18:45:57Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 18:45:58Z] create OK id=25gtsdwwzulufg costPerHr=$1.39
+[t=    0.9s 18:45:58Z] PROBE: pod created id=25gtsdwwzulufg; waiting for publicIp+ssh_port
+[t=    1.2s 18:45:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.6s 18:46:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 18:46:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 18:46:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.4s 18:47:00Z] PROBE NO-GO: pod 25gtsdwwzulufg not RUNNING+SSH within 60s; tearing down
+[t=   62.4s 18:47:00Z] DELETE pod 25gtsdwwzulufg
+[t=   63.2s 18:47:00Z] delete returned status=204 resp={}
+[t=   68.5s 18:47:06Z] pod 25gtsdwwzulufg confirmed terminated (404)
+[t=   68.5s 18:47:06Z] PROBE: pod 25gtsdwwzulufg torn down
+[t=    0.0s 19:14:44Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 19:14:44Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 19:14:45Z] create OK id=k5wfpn0s9zt8p8 costPerHr=$1.49
+[t=    1.1s 19:14:45Z] PROBE: pod created id=k5wfpn0s9zt8p8; waiting for publicIp+ssh_port
+[t=    1.4s 19:14:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 19:15:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 19:15:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 19:15:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 19:15:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.7s 19:16:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.2s 19:16:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.6s 19:16:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.6s 19:16:49Z] PROBE NO-GO: pod k5wfpn0s9zt8p8 not RUNNING+SSH within 120s; tearing down
+[t=  124.6s 19:16:49Z] DELETE pod k5wfpn0s9zt8p8
+[t=  125.3s 19:16:50Z] delete returned status=204 resp={}
+[t=  130.7s 19:16:55Z] pod k5wfpn0s9zt8p8 confirmed terminated (404)
+[t=  130.7s 19:16:55Z] PROBE: pod k5wfpn0s9zt8p8 torn down
+[t=    0.0s 19:16:55Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:16:55Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 19:16:56Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 19:16:56Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:16:56Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:16:56Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 19:16:57Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 19:16:57Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:16:57Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:16:57Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 19:16:57Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 19:16:57Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:16:57Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 19:16:57Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 19:16:58Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 19:16:58Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:44:46Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 19:44:46Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 19:44:47Z] create OK id=u4p5yabhczlo16 costPerHr=$1.49
+[t=    1.2s 19:44:47Z] PROBE: pod created id=u4p5yabhczlo16; waiting for publicIp+ssh_port
+[t=    1.5s 19:44:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 19:45:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 19:45:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 19:45:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 19:45:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.6s 19:46:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.1s 19:46:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.5s 19:46:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.5s 19:46:51Z] PROBE NO-GO: pod u4p5yabhczlo16 not RUNNING+SSH within 120s; tearing down
+[t=  124.5s 19:46:51Z] DELETE pod u4p5yabhczlo16
+[t=  125.0s 19:46:51Z] delete returned status=204 resp={}
+[t=  130.3s 19:46:56Z] pod u4p5yabhczlo16 confirmed terminated (404)
+[t=  130.3s 19:46:56Z] PROBE: pod u4p5yabhczlo16 torn down
+[t=    0.0s 19:46:57Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:46:57Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 19:46:58Z] create OK id=lj4epo0cizp7yk costPerHr=$1.39
+[t=    1.1s 19:46:58Z] PROBE: pod created id=lj4epo0cizp7yk; waiting for publicIp+ssh_port
+[t=    1.4s 19:46:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 19:47:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 19:47:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 19:47:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 19:47:59Z] PROBE NO-GO: pod lj4epo0cizp7yk not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 19:47:59Z] DELETE pod lj4epo0cizp7yk
+[t=   63.4s 19:48:00Z] delete returned status=204 resp={}
+[t=   68.7s 19:48:05Z] pod lj4epo0cizp7yk confirmed terminated (404)
+[t=   68.7s 19:48:05Z] PROBE: pod lj4epo0cizp7yk torn down
+[t=    0.0s 19:48:06Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:48:06Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 19:48:06Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 19:48:06Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:48:06Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:48:06Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 19:48:07Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 19:48:07Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:48:07Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 19:48:07Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 19:48:08Z] create OK id=0bv2uvhs5yl6w5 costPerHr=$1.39
+[t=    1.0s 19:48:08Z] PROBE: pod created id=0bv2uvhs5yl6w5; waiting for publicIp+ssh_port
+[t=    1.4s 19:48:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 19:48:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 19:48:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 19:48:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 19:49:10Z] PROBE NO-GO: pod 0bv2uvhs5yl6w5 not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 19:49:10Z] DELETE pod 0bv2uvhs5yl6w5
+[t=   63.1s 19:49:10Z] delete returned status=204 resp={}
+[t=   68.5s 19:49:16Z] pod 0bv2uvhs5yl6w5 confirmed terminated (404)
+[t=   68.5s 19:49:16Z] PROBE: pod 0bv2uvhs5yl6w5 torn down
+[t=    0.0s 20:14:44Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 20:14:44Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 20:14:45Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 20:14:45Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:14:45Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:14:45Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 20:14:46Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 20:14:46Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:14:46Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:14:46Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 20:14:46Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 20:14:46Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:14:47Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:14:47Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 20:14:47Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 20:14:47Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:14:47Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 20:14:47Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 20:14:48Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 20:14:48Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:44:45Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 20:44:45Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 20:44:46Z] create OK id=7i7nhes5uxrxl8 costPerHr=$1.49
+[t=    1.2s 20:44:46Z] PROBE: pod created id=7i7nhes5uxrxl8; waiting for publicIp+ssh_port
+[t=    1.5s 20:44:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 20:45:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 20:45:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 20:45:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 20:45:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.3s 20:46:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.7s 20:46:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.0s 20:46:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.0s 20:46:49Z] PROBE NO-GO: pod 7i7nhes5uxrxl8 not RUNNING+SSH within 120s; tearing down
+[t=  124.0s 20:46:49Z] DELETE pod 7i7nhes5uxrxl8
+[t=  124.6s 20:46:50Z] delete returned status=204 resp={}
+[t=  129.9s 20:46:55Z] pod 7i7nhes5uxrxl8 confirmed terminated (404)
+[t=  129.9s 20:46:55Z] PROBE: pod 7i7nhes5uxrxl8 torn down
+[t=    0.0s 20:46:55Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:46:55Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 20:46:56Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 20:46:56Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:46:56Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:46:56Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 20:46:57Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 20:46:57Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:46:57Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:46:57Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 20:46:57Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 20:46:57Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:46:57Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 20:46:57Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 20:46:58Z] create OK id=730jgdtz3cv2s8 costPerHr=$1.39
+[t=    0.9s 20:46:58Z] PROBE: pod created id=730jgdtz3cv2s8; waiting for publicIp+ssh_port
+[t=    1.3s 20:46:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 20:47:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 20:47:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 20:47:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.5s 20:48:00Z] PROBE NO-GO: pod 730jgdtz3cv2s8 not RUNNING+SSH within 60s; tearing down
+[t=   62.5s 20:48:00Z] DELETE pod 730jgdtz3cv2s8
+[t=   63.1s 20:48:01Z] delete returned status=204 resp={}
+[t=   68.4s 20:48:06Z] pod 730jgdtz3cv2s8 confirmed terminated (404)
+[t=   68.4s 20:48:06Z] PROBE: pod 730jgdtz3cv2s8 torn down
+[t=    0.0s 21:14:44Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 21:14:44Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:14:45Z] create OK id=k5dwoo5yad3y54 costPerHr=$1.49
+[t=    1.1s 21:14:45Z] PROBE: pod created id=k5dwoo5yad3y54; waiting for publicIp+ssh_port
+[t=    1.5s 21:14:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 21:15:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 21:15:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 21:15:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 21:15:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.3s 21:16:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.6s 21:16:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.0s 21:16:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.0s 21:16:48Z] PROBE NO-GO: pod k5dwoo5yad3y54 not RUNNING+SSH within 120s; tearing down
+[t=  124.1s 21:16:48Z] DELETE pod k5dwoo5yad3y54
+[t=  124.7s 21:16:49Z] delete returned status=204 resp={}
+[t=  130.0s 21:16:54Z] pod k5dwoo5yad3y54 confirmed terminated (404)
+[t=  130.0s 21:16:54Z] PROBE: pod k5dwoo5yad3y54 torn down
+[t=    0.0s 21:16:54Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:16:54Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 21:16:55Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 21:16:55Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:16:55Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:16:55Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 21:16:56Z] create OK id=1ck336l7ico10h costPerHr=$2.99
+[t=    1.6s 21:16:56Z] PROBE: pod created id=1ck336l7ico10h; waiting for publicIp+ssh_port
+[t=    2.0s 21:16:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.0s 21:17:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.7s 21:17:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.4s 21:17:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.4s 21:17:59Z] PROBE NO-GO: pod 1ck336l7ico10h not RUNNING+SSH within 60s; tearing down
+[t=   64.4s 21:17:59Z] DELETE pod 1ck336l7ico10h
+[t=   65.0s 21:18:00Z] delete returned status=204 resp={}
+[t=   70.4s 21:18:05Z] pod 1ck336l7ico10h confirmed terminated (404)
+[t=   70.4s 21:18:05Z] PROBE: pod 1ck336l7ico10h torn down
+[t=    0.0s 21:18:06Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:18:06Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 21:18:06Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 21:18:06Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:18:06Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 21:18:06Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 21:18:07Z] create OK id=t33c2o7us1noq4 costPerHr=$1.39
+[t=    1.0s 21:18:07Z] PROBE: pod created id=t33c2o7us1noq4; waiting for publicIp+ssh_port
+[t=    1.3s 21:18:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.6s 21:18:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 21:18:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 21:18:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.4s 21:19:09Z] PROBE NO-GO: pod t33c2o7us1noq4 not RUNNING+SSH within 60s; tearing down
+[t=   62.4s 21:19:09Z] DELETE pod t33c2o7us1noq4
+[t=   62.9s 21:19:09Z] delete returned status=204 resp={}
+[t=   68.2s 21:19:14Z] pod t33c2o7us1noq4 confirmed terminated (404)
+[t=   68.2s 21:19:14Z] PROBE: pod t33c2o7us1noq4 torn down
+[t=    0.0s 21:44:45Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 21:44:45Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 21:44:46Z] create OK id=3z5nmt51v95gw3 costPerHr=$1.49
+[t=    1.2s 21:44:46Z] PROBE: pod created id=3z5nmt51v95gw3; waiting for publicIp+ssh_port
+[t=    1.5s 21:44:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 21:45:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 21:45:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 21:45:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 21:45:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.4s 21:46:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.8s 21:46:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.3s 21:46:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.3s 21:46:50Z] PROBE NO-GO: pod 3z5nmt51v95gw3 not RUNNING+SSH within 120s; tearing down
+[t=  124.3s 21:46:50Z] DELETE pod 3z5nmt51v95gw3
+[t=  124.9s 21:46:50Z] delete returned status=204 resp={}
+[t=  130.2s 21:46:56Z] pod 3z5nmt51v95gw3 confirmed terminated (404)
+[t=  130.2s 21:46:56Z] PROBE: pod 3z5nmt51v95gw3 torn down
+[t=    0.0s 21:46:56Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:46:56Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:46:57Z] create OK id=yriwsd9izngmum costPerHr=$1.39
+[t=    1.1s 21:46:57Z] PROBE: pod created id=yriwsd9izngmum; waiting for publicIp+ssh_port
+[t=    1.5s 21:46:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 21:47:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.2s 21:47:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.7s 21:47:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.8s 21:48:00Z] PROBE NO-GO: pod yriwsd9izngmum not RUNNING+SSH within 60s; tearing down
+[t=   63.8s 21:48:00Z] DELETE pod yriwsd9izngmum
+[t=   64.3s 21:48:00Z] delete returned status=204 resp={}
+[t=   69.6s 21:48:05Z] pod yriwsd9izngmum confirmed terminated (404)
+[t=   69.6s 21:48:05Z] PROBE: pod yriwsd9izngmum torn down
+[t=    0.0s 21:48:06Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:48:06Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.7s 21:48:07Z] create OK id=5cvkcdyvxia4ey costPerHr=$2.99
+[t=    1.7s 21:48:07Z] PROBE: pod created id=5cvkcdyvxia4ey; waiting for publicIp+ssh_port
+[t=    2.1s 21:48:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 21:48:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.7s 21:48:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 21:48:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 21:49:10Z] PROBE NO-GO: pod 5cvkcdyvxia4ey not RUNNING+SSH within 60s; tearing down
+[t=   64.5s 21:49:10Z] DELETE pod 5cvkcdyvxia4ey
+[t=   65.0s 21:49:11Z] delete returned status=204 resp={}
+[t=   70.5s 21:49:16Z] pod 5cvkcdyvxia4ey confirmed terminated (404)
+[t=   70.5s 21:49:16Z] PROBE: pod 5cvkcdyvxia4ey torn down
+[t=    0.0s 21:49:16Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:49:16Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 21:49:17Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 21:49:17Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:49:17Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 21:49:17Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.8s 21:49:18Z] create OK id=a0y6amnrwksu3p costPerHr=$1.39
+[t=    0.8s 21:49:18Z] PROBE: pod created id=a0y6amnrwksu3p; waiting for publicIp+ssh_port
+[t=    1.2s 21:49:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 21:49:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 21:49:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 21:50:05Z] poll desiredStatus=EXITED publicIp= ssh_port=None
+[t=   62.5s 21:50:20Z] PROBE NO-GO: pod a0y6amnrwksu3p not RUNNING+SSH within 60s; tearing down
+[t=   62.5s 21:50:20Z] DELETE pod a0y6amnrwksu3p
+[t=   63.1s 21:50:20Z] delete returned status=204 resp={}
+[t=   68.4s 21:50:26Z] pod a0y6amnrwksu3p confirmed terminated (404)
+[t=   68.4s 21:50:26Z] PROBE: pod a0y6amnrwksu3p torn down
+[t=    0.0s 22:14:46Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:14:46Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:14:47Z] create OK id=99nyyv2lqeze94 costPerHr=$1.49
+[t=    1.1s 22:14:47Z] PROBE: pod created id=99nyyv2lqeze94; waiting for publicIp+ssh_port
+[t=    1.4s 22:14:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 22:15:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 22:15:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.4s 22:15:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.7s 22:15:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.1s 22:16:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.5s 22:16:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.9s 22:16:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.9s 22:16:50Z] PROBE NO-GO: pod 99nyyv2lqeze94 not RUNNING+SSH within 120s; tearing down
+[t=  124.9s 22:16:51Z] DELETE pod 99nyyv2lqeze94
+[t=  125.5s 22:16:51Z] delete returned status=204 resp={}
+[t=  130.8s 22:16:56Z] pod 99nyyv2lqeze94 confirmed terminated (404)
+[t=  130.8s 22:16:56Z] PROBE: pod 99nyyv2lqeze94 torn down
+[t=    0.0s 22:16:57Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:16:57Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 22:16:57Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 22:16:57Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:16:57Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:16:57Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 22:16:58Z] create OK id=ja30juuln625ro costPerHr=$2.99
+[t=    1.2s 22:16:58Z] PROBE: pod created id=ja30juuln625ro; waiting for publicIp+ssh_port
+[t=    1.7s 22:16:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 22:17:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.1s 22:17:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.9s 22:17:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.9s 22:18:01Z] PROBE NO-GO: pod ja30juuln625ro not RUNNING+SSH within 60s; tearing down
+[t=   63.9s 22:18:01Z] DELETE pod ja30juuln625ro
+[t=   64.5s 22:18:02Z] delete returned status=204 resp={}
+[t=   69.8s 22:18:07Z] pod ja30juuln625ro confirmed terminated (404)
+[t=   69.8s 22:18:07Z] PROBE: pod ja30juuln625ro torn down
+[t=    0.0s 22:18:07Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:18:07Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 22:18:08Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 22:18:08Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:18:08Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 22:18:08Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 22:18:09Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 22:18:09Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:44:50Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:44:50Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:44:51Z] create OK id=iqurz1kt21ob6g costPerHr=$1.49
+[t=    1.1s 22:44:51Z] PROBE: pod created id=iqurz1kt21ob6g; waiting for publicIp+ssh_port
+[t=    1.4s 22:44:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 22:45:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 22:45:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 22:45:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 22:45:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.3s 22:46:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.8s 22:46:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.1s 22:46:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.2s 22:46:54Z] PROBE NO-GO: pod iqurz1kt21ob6g not RUNNING+SSH within 120s; tearing down
+[t=  124.2s 22:46:54Z] DELETE pod iqurz1kt21ob6g
+[t=  124.8s 22:46:55Z] delete returned status=204 resp={}
+[t=  130.1s 22:47:00Z] pod iqurz1kt21ob6g confirmed terminated (404)
+[t=  130.1s 22:47:00Z] PROBE: pod iqurz1kt21ob6g torn down
+[t=    0.0s 22:47:00Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:47:00Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 22:47:01Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 22:47:01Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:47:01Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:47:01Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 22:47:03Z] create OK id=glklm166tj8jqb costPerHr=$2.99
+[t=    1.6s 22:47:03Z] PROBE: pod created id=glklm166tj8jqb; waiting for publicIp+ssh_port
+[t=    2.1s 22:47:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 22:47:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 22:47:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 22:47:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 22:48:05Z] PROBE NO-GO: pod glklm166tj8jqb not RUNNING+SSH within 60s; tearing down
+[t=   64.1s 22:48:05Z] DELETE pod glklm166tj8jqb
+[t=   64.7s 22:48:06Z] delete returned status=204 resp={}
+[t=   70.0s 22:48:11Z] pod glklm166tj8jqb confirmed terminated (404)
+[t=   70.0s 22:48:11Z] PROBE: pod glklm166tj8jqb torn down
+[t=    0.0s 22:48:11Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:48:11Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 22:48:12Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 22:48:12Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:48:12Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 22:48:12Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 22:48:13Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 22:48:13Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:57:40Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:57:40Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 22:57:41Z] create OK id=1khyfoob4m2aqr costPerHr=$1.49
+[t=    1.2s 22:57:41Z] PROBE: pod created id=1khyfoob4m2aqr; waiting for publicIp+ssh_port
+[t=    1.7s 22:57:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 22:57:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 22:58:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 22:58:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.6s 22:58:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.1s 22:59:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.6s 22:59:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.0s 22:59:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.0s 22:59:46Z] PROBE NO-GO: pod 1khyfoob4m2aqr not RUNNING+SSH within 120s; tearing down
+[t=  126.0s 22:59:46Z] DELETE pod 1khyfoob4m2aqr
+[t=  126.6s 22:59:47Z] delete returned status=204 resp={}
+[t=  132.0s 22:59:52Z] pod 1khyfoob4m2aqr confirmed terminated (404)
+[t=  132.0s 22:59:52Z] PROBE: pod 1khyfoob4m2aqr torn down
+[t=    0.0s 22:59:52Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:59:52Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 22:59:53Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 22:59:53Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:59:53Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:59:53Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 22:59:54Z] create OK id=rcbqpyekmolncc costPerHr=$2.99
+[t=    1.4s 22:59:54Z] PROBE: pod created id=rcbqpyekmolncc; waiting for publicIp+ssh_port
+[t=    2.1s 22:59:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 23:00:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.7s 23:00:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.4s 23:00:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 23:00:57Z] PROBE NO-GO: pod rcbqpyekmolncc not RUNNING+SSH within 60s; tearing down
+[t=   64.5s 23:00:57Z] DELETE pod rcbqpyekmolncc
+[t=   65.0s 23:00:58Z] delete returned status=204 resp={}
+[t=   70.3s 23:01:03Z] pod rcbqpyekmolncc confirmed terminated (404)
+[t=   70.3s 23:01:03Z] PROBE: pod rcbqpyekmolncc torn down
+[t=    0.0s 23:01:03Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:01:03Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 23:01:04Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 23:01:04Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:01:04Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 23:01:04Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 23:01:05Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 23:01:05Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:14:45Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 23:14:45Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:14:46Z] create OK id=q57rk3lx6z5tdc costPerHr=$1.49
+[t=    1.1s 23:14:46Z] PROBE: pod created id=q57rk3lx6z5tdc; waiting for publicIp+ssh_port
+[t=    1.5s 23:14:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 23:15:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 23:15:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.1s 23:15:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.6s 23:15:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.0s 23:16:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.4s 23:16:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.9s 23:16:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.9s 23:16:49Z] PROBE NO-GO: pod q57rk3lx6z5tdc not RUNNING+SSH within 120s; tearing down
+[t=  124.9s 23:16:49Z] DELETE pod q57rk3lx6z5tdc
+[t=  125.4s 23:16:50Z] delete returned status=204 resp={}
+[t=  130.8s 23:16:55Z] pod q57rk3lx6z5tdc confirmed terminated (404)
+[t=  130.8s 23:16:55Z] PROBE: pod q57rk3lx6z5tdc torn down
+[t=    0.0s 23:16:56Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:16:56Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 23:16:57Z] create OK id=czu6wbehiq6iws costPerHr=$1.39
+[t=    1.1s 23:16:57Z] PROBE: pod created id=czu6wbehiq6iws; waiting for publicIp+ssh_port
+[t=    1.3s 23:16:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 23:17:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 23:17:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 23:17:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 23:17:58Z] PROBE NO-GO: pod czu6wbehiq6iws not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 23:17:58Z] DELETE pod czu6wbehiq6iws
+[t=   63.4s 23:17:59Z] delete returned status=204 resp={}
+[t=   68.7s 23:18:04Z] pod czu6wbehiq6iws confirmed terminated (404)
+[t=   68.7s 23:18:04Z] PROBE: pod czu6wbehiq6iws torn down
+[t=    0.0s 23:18:05Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:18:05Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 23:18:06Z] create OK id=fm17spn7vos0mx costPerHr=$2.99
+[t=    1.5s 23:18:06Z] PROBE: pod created id=fm17spn7vos0mx; waiting for publicIp+ssh_port
+[t=    1.9s 23:18:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.6s 23:18:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 23:18:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 23:18:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 23:19:09Z] PROBE NO-GO: pod fm17spn7vos0mx not RUNNING+SSH within 60s; tearing down
+[t=   64.1s 23:19:09Z] DELETE pod fm17spn7vos0mx
+[t=   64.7s 23:19:09Z] delete returned status=204 resp={}
+[t=   70.0s 23:19:15Z] pod fm17spn7vos0mx confirmed terminated (404)
+[t=   70.0s 23:19:15Z] PROBE: pod fm17spn7vos0mx torn down
+[t=    0.0s 23:19:15Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:19:15Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 23:19:15Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 23:19:15Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:19:16Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 23:19:16Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 23:19:17Z] create OK id=e6lloh1g6ww9c5 costPerHr=$1.39
+[t=    1.0s 23:19:17Z] PROBE: pod created id=e6lloh1g6ww9c5; waiting for publicIp+ssh_port
+[t=    1.3s 23:19:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 23:19:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 23:19:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 23:20:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 23:20:18Z] PROBE NO-GO: pod e6lloh1g6ww9c5 not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 23:20:18Z] DELETE pod e6lloh1g6ww9c5
+[t=   63.2s 23:20:19Z] delete returned status=204 resp={}
+[t=   68.5s 23:20:24Z] pod e6lloh1g6ww9c5 confirmed terminated (404)
+[t=   68.5s 23:20:24Z] PROBE: pod e6lloh1g6ww9c5 torn down

--- a/results/m4_path_c_probe_20260519/orchestrator.log
+++ b/results/m4_path_c_probe_20260519/orchestrator.log
@@ -1,0 +1,4836 @@
+[t=    0.0s 00:55:01Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 00:55:01Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.9s 00:55:03Z] create OK id=4d61hkzgq9cyzx costPerHr=$1.49
+[t=    1.9s 00:55:03Z] PROBE: pod created id=4d61hkzgq9cyzx; waiting for publicIp+ssh_port
+[t=    2.3s 00:55:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 00:55:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  210.7s 00:58:32Z] PROBE NO-GO: pod 4d61hkzgq9cyzx not RUNNING+SSH within 120s; tearing down
+[t=  210.7s 00:58:32Z] DELETE pod 4d61hkzgq9cyzx
+[t=  211.4s 00:58:33Z] delete returned status=204 resp={}
+[t=  216.7s 00:58:38Z] pod 4d61hkzgq9cyzx confirmed terminated (404)
+[t=  216.7s 00:58:38Z] PROBE: pod 4d61hkzgq9cyzx torn down
+[t=    0.0s 00:58:38Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:58:38Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 00:58:40Z] create OK id=t6e4kleri11sav costPerHr=$1.39
+[t=    1.3s 00:58:40Z] PROBE: pod created id=t6e4kleri11sav; waiting for publicIp+ssh_port
+[t=    1.7s 00:58:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 00:58:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t= 1897.2s 01:30:16Z] PROBE NO-GO: pod t6e4kleri11sav not RUNNING+SSH within 60s; tearing down
+[t= 1897.2s 01:30:16Z] DELETE pod t6e4kleri11sav
+[t= 1898.0s 01:30:16Z] delete returned status=204 resp={}
+[t= 2080.4s 01:33:19Z] pod t6e4kleri11sav confirmed terminated (404)
+[t= 2080.4s 01:33:19Z] PROBE: pod t6e4kleri11sav torn down
+[t=    0.0s 01:33:19Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:33:19Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 01:33:21Z] create OK id=6elpplxojs6gkp costPerHr=$2.99
+[t=    1.5s 01:33:21Z] PROBE: pod created id=6elpplxojs6gkp; waiting for publicIp+ssh_port
+[t=    2.0s 01:33:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 01:33:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.6s 01:33:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   50.4s 01:34:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.4s 01:34:24Z] PROBE NO-GO: pod 6elpplxojs6gkp not RUNNING+SSH within 60s; tearing down
+[t=   65.4s 01:34:24Z] DELETE pod 6elpplxojs6gkp
+[t=   66.0s 01:34:25Z] delete returned status=204 resp={}
+[t=   71.4s 01:34:30Z] pod 6elpplxojs6gkp confirmed terminated (404)
+[t=   71.4s 01:34:30Z] PROBE: pod 6elpplxojs6gkp torn down
+[t=    0.0s 01:34:31Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:34:31Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 01:34:31Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 01:34:31Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 01:34:32Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 01:34:32Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 01:34:32Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 01:34:32Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 01:44:48Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 01:44:48Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 01:44:49Z] create OK id=bu5tvmt5lyhhe4 costPerHr=$1.49
+[t=    1.2s 01:44:49Z] PROBE: pod created id=bu5tvmt5lyhhe4; waiting for publicIp+ssh_port
+[t=    1.6s 01:44:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 01:45:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 01:45:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 01:45:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.5s 01:45:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.1s 01:46:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.5s 01:46:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.0s 01:46:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.0s 01:46:53Z] PROBE NO-GO: pod bu5tvmt5lyhhe4 not RUNNING+SSH within 120s; tearing down
+[t=  125.0s 01:46:53Z] DELETE pod bu5tvmt5lyhhe4
+[t=  125.7s 01:46:54Z] delete returned status=204 resp={}
+[t=  131.0s 01:46:59Z] pod bu5tvmt5lyhhe4 confirmed terminated (404)
+[t=  131.0s 01:46:59Z] PROBE: pod bu5tvmt5lyhhe4 torn down
+[t=    0.0s 01:47:00Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:47:00Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 01:47:01Z] create OK id=jmr182h9ng3n2t costPerHr=$1.39
+[t=    1.2s 01:47:01Z] PROBE: pod created id=jmr182h9ng3n2t; waiting for publicIp+ssh_port
+[t=    1.8s 01:47:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 01:47:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.0s 01:47:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.7s 01:47:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.7s 01:48:03Z] PROBE NO-GO: pod jmr182h9ng3n2t not RUNNING+SSH within 60s; tearing down
+[t=   63.7s 01:48:03Z] DELETE pod jmr182h9ng3n2t
+[t=   64.4s 01:48:04Z] delete returned status=204 resp={}
+[t=   69.8s 01:48:09Z] pod jmr182h9ng3n2t confirmed terminated (404)
+[t=   69.8s 01:48:09Z] PROBE: pod jmr182h9ng3n2t torn down
+[t=    0.0s 01:48:10Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:48:10Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 01:48:11Z] create OK id=jfp2pg1q6nrmrb costPerHr=$2.99
+[t=    1.4s 01:48:11Z] PROBE: pod created id=jfp2pg1q6nrmrb; waiting for publicIp+ssh_port
+[t=    1.9s 01:48:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.6s 01:48:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.4s 01:48:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.2s 01:48:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.2s 01:49:14Z] PROBE NO-GO: pod jfp2pg1q6nrmrb not RUNNING+SSH within 60s; tearing down
+[t=   64.2s 01:49:14Z] DELETE pod jfp2pg1q6nrmrb
+[t=   64.8s 01:49:15Z] delete returned status=204 resp={}
+[t=   70.2s 01:49:20Z] pod jfp2pg1q6nrmrb confirmed terminated (404)
+[t=   70.2s 01:49:20Z] PROBE: pod jfp2pg1q6nrmrb torn down
+[t=    0.0s 01:49:20Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:49:20Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 01:49:21Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 01:49:21Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 01:49:21Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 01:49:21Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 01:49:22Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 01:49:22Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 02:14:45Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 02:14:45Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 02:14:46Z] create OK id=wc835kqv4lwd6p costPerHr=$1.49
+[t=    1.1s 02:14:46Z] PROBE: pod created id=wc835kqv4lwd6p; waiting for publicIp+ssh_port
+[t=    1.5s 02:14:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 02:15:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 02:15:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 02:15:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.4s 02:15:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.0s 02:16:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.5s 02:16:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.9s 02:16:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.9s 02:16:50Z] PROBE NO-GO: pod wc835kqv4lwd6p not RUNNING+SSH within 120s; tearing down
+[t=  124.9s 02:16:50Z] DELETE pod wc835kqv4lwd6p
+[t=  125.5s 02:16:50Z] delete returned status=204 resp={}
+[t=  130.9s 02:16:56Z] pod wc835kqv4lwd6p confirmed terminated (404)
+[t=  130.9s 02:16:56Z] PROBE: pod wc835kqv4lwd6p torn down
+[t=    0.0s 02:16:56Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:16:56Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 02:16:57Z] create OK id=5x5dssmh94t1j7 costPerHr=$1.39
+[t=    1.3s 02:16:57Z] PROBE: pod created id=5x5dssmh94t1j7; waiting for publicIp+ssh_port
+[t=    1.7s 02:16:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 02:17:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.1s 02:17:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.8s 02:17:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.8s 02:18:00Z] PROBE NO-GO: pod 5x5dssmh94t1j7 not RUNNING+SSH within 60s; tearing down
+[t=   63.8s 02:18:00Z] DELETE pod 5x5dssmh94t1j7
+[t=   64.5s 02:18:01Z] delete returned status=204 resp={}
+[t=   69.8s 02:18:06Z] pod 5x5dssmh94t1j7 confirmed terminated (404)
+[t=   69.8s 02:18:06Z] PROBE: pod 5x5dssmh94t1j7 torn down
+[t=    0.0s 02:18:06Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:18:06Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 02:18:08Z] create OK id=s8fwhrr3s8wlus costPerHr=$2.99
+[t=    1.6s 02:18:08Z] PROBE: pod created id=s8fwhrr3s8wlus; waiting for publicIp+ssh_port
+[t=    2.3s 02:18:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.1s 02:18:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.9s 02:18:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.8s 02:18:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.8s 02:19:11Z] PROBE NO-GO: pod s8fwhrr3s8wlus not RUNNING+SSH within 60s; tearing down
+[t=   64.8s 02:19:11Z] DELETE pod s8fwhrr3s8wlus
+[t=   65.4s 02:19:12Z] delete returned status=204 resp={}
+[t=   70.9s 02:19:17Z] pod s8fwhrr3s8wlus confirmed terminated (404)
+[t=   70.9s 02:19:17Z] PROBE: pod s8fwhrr3s8wlus torn down
+[t=    0.0s 02:19:17Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:19:17Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 02:19:18Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 02:19:18Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 02:19:18Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 02:19:18Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 02:19:19Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 02:19:19Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 02:44:46Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 02:44:46Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 02:44:47Z] create OK id=undl8o9iqi7bh8 costPerHr=$1.49
+[t=    1.3s 02:44:47Z] PROBE: pod created id=undl8o9iqi7bh8; waiting for publicIp+ssh_port
+[t=    1.6s 02:44:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 02:45:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 02:45:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.4s 02:45:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.9s 02:45:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.5s 02:46:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.9s 02:46:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.3s 02:46:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  165.0s 02:47:31Z] PROBE NO-GO: pod undl8o9iqi7bh8 not RUNNING+SSH within 120s; tearing down
+[t=  165.1s 02:47:31Z] DELETE pod undl8o9iqi7bh8
+[t=  165.8s 02:47:32Z] delete returned status=204 resp={}
+[t=  171.2s 02:47:37Z] pod undl8o9iqi7bh8 confirmed terminated (404)
+[t=  171.2s 02:47:37Z] PROBE: pod undl8o9iqi7bh8 torn down
+[t=    0.0s 02:47:37Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:47:37Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 02:47:38Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 02:47:38Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 02:47:38Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:47:38Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 02:47:40Z] create OK id=gfyoc966fj1fdf costPerHr=$2.99
+[t=    1.6s 02:47:40Z] PROBE: pod created id=gfyoc966fj1fdf; waiting for publicIp+ssh_port
+[t=    2.3s 02:47:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.1s 02:47:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.9s 02:48:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.6s 02:48:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.6s 02:48:43Z] PROBE NO-GO: pod gfyoc966fj1fdf not RUNNING+SSH within 60s; tearing down
+[t=   64.6s 02:48:43Z] DELETE pod gfyoc966fj1fdf
+[t=   65.3s 02:48:43Z] delete returned status=204 resp={}
+[t=   70.7s 02:48:49Z] pod gfyoc966fj1fdf confirmed terminated (404)
+[t=   70.7s 02:48:49Z] PROBE: pod gfyoc966fj1fdf torn down
+[t=    0.0s 02:48:49Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:48:49Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 02:48:49Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 02:48:49Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 02:48:50Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 02:48:50Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 02:48:50Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 02:48:50Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 03:48:23Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 03:48:23Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 03:48:24Z] create OK id=4e3j55q5zahjl9 costPerHr=$1.49
+[t=    1.3s 03:48:24Z] PROBE: pod created id=4e3j55q5zahjl9; waiting for publicIp+ssh_port
+[t=    1.6s 03:48:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 03:48:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  129.7s 03:50:32Z] PROBE NO-GO: pod 4e3j55q5zahjl9 not RUNNING+SSH within 120s; tearing down
+[t=  129.8s 03:50:32Z] DELETE pod 4e3j55q5zahjl9
+[t=  130.4s 03:50:33Z] delete returned status=204 resp={}
+[t=  135.8s 03:50:38Z] pod 4e3j55q5zahjl9 confirmed terminated (404)
+[t=  135.8s 03:50:38Z] PROBE: pod 4e3j55q5zahjl9 torn down
+[t=    0.0s 03:50:39Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 03:50:39Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 03:50:40Z] create OK id=54ay0t0w3x0m74 costPerHr=$1.39
+[t=    1.3s 03:50:40Z] PROBE: pod created id=54ay0t0w3x0m74; waiting for publicIp+ssh_port
+[t=    1.7s 03:50:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 03:50:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  456.5s 03:58:15Z] poll status=-1 resp=transport_error: ConnectTimeout('_ssl.c:1015: The handshake operation timed out')
+[t=  471.5s 03:58:30Z] PROBE NO-GO: pod 54ay0t0w3x0m74 not RUNNING+SSH within 60s; tearing down
+[t=  471.5s 03:58:30Z] DELETE pod 54ay0t0w3x0m74
+[t=  590.9s 04:00:30Z] delete returned status=204 resp={}
+[t=  596.4s 04:00:35Z] pod 54ay0t0w3x0m74 confirmed terminated (404)
+[t=  596.4s 04:00:35Z] PROBE: pod 54ay0t0w3x0m74 torn down
+[t=    0.0s 04:00:35Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:00:35Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 04:00:36Z] create OK id=6ih8dgn8we9d6b costPerHr=$2.99
+[t=    1.1s 04:00:36Z] PROBE: pod created id=6ih8dgn8we9d6b; waiting for publicIp+ssh_port
+[t=    1.4s 04:00:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 04:00:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 04:01:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 04:01:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 04:01:38Z] PROBE NO-GO: pod 6ih8dgn8we9d6b not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 04:01:38Z] DELETE pod 6ih8dgn8we9d6b
+[t=   63.5s 04:01:39Z] delete returned status=204 resp={}
+[t=   68.9s 04:01:44Z] pod 6ih8dgn8we9d6b confirmed terminated (404)
+[t=   68.9s 04:01:44Z] PROBE: pod 6ih8dgn8we9d6b torn down
+[t=    0.0s 04:01:44Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:01:44Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 04:01:45Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 04:01:45Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 04:01:45Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 04:01:45Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 04:01:46Z] create OK id=mo63stf297fh2l costPerHr=$1.39
+[t=    1.0s 04:01:46Z] PROBE: pod created id=mo63stf297fh2l; waiting for publicIp+ssh_port
+[t=    1.3s 04:01:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 04:02:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 04:02:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 04:02:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 04:02:48Z] PROBE NO-GO: pod mo63stf297fh2l not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 04:02:48Z] DELETE pod mo63stf297fh2l
+[t=   63.3s 04:02:48Z] delete returned status=204 resp={}
+[t=   68.7s 04:02:54Z] pod mo63stf297fh2l confirmed terminated (404)
+[t=   68.7s 04:02:54Z] PROBE: pod mo63stf297fh2l torn down
+[t=    0.0s 04:14:50Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 04:14:50Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 04:14:51Z] create OK id=rddr2fakhekk23 costPerHr=$1.49
+[t=    1.3s 04:14:51Z] PROBE: pod created id=rddr2fakhekk23; waiting for publicIp+ssh_port
+[t=    1.6s 04:14:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 04:15:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 04:15:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.1s 04:15:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.7s 04:15:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.3s 04:16:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.7s 04:16:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.1s 04:16:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.1s 04:16:55Z] PROBE NO-GO: pod rddr2fakhekk23 not RUNNING+SSH within 120s; tearing down
+[t=  125.1s 04:16:55Z] DELETE pod rddr2fakhekk23
+[t=  125.8s 04:16:56Z] delete returned status=204 resp={}
+[t=  131.2s 04:17:01Z] pod rddr2fakhekk23 confirmed terminated (404)
+[t=  131.2s 04:17:01Z] PROBE: pod rddr2fakhekk23 torn down
+[t=    0.0s 04:17:02Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:17:02Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 04:17:02Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 04:17:02Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 04:17:02Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:17:02Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    2.5s 04:17:05Z] create OK id=6dm94xm5ztehx7 costPerHr=$2.99
+[t=    2.5s 04:17:05Z] PROBE: pod created id=6dm94xm5ztehx7; waiting for publicIp+ssh_port
+[t=    3.4s 04:17:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   19.3s 04:17:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   35.2s 04:17:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   51.1s 04:17:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   66.1s 04:18:09Z] PROBE NO-GO: pod 6dm94xm5ztehx7 not RUNNING+SSH within 60s; tearing down
+[t=   66.1s 04:18:09Z] DELETE pod 6dm94xm5ztehx7
+[t=   66.8s 04:18:09Z] delete returned status=204 resp={}
+[t=   72.3s 04:18:15Z] pod 6dm94xm5ztehx7 confirmed terminated (404)
+[t=   72.3s 04:18:15Z] PROBE: pod 6dm94xm5ztehx7 torn down
+[t=    0.0s 04:18:15Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:18:15Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.8s 04:18:16Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.8s 04:18:16Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 04:18:16Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 04:18:16Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.4s 04:18:17Z] create OK id=4wgtk9d6cbbdk4 costPerHr=$1.39
+[t=    1.4s 04:18:17Z] PROBE: pod created id=4wgtk9d6cbbdk4; waiting for publicIp+ssh_port
+[t=    1.7s 04:18:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 04:18:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 04:18:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 04:19:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 04:19:19Z] PROBE NO-GO: pod 4wgtk9d6cbbdk4 not RUNNING+SSH within 60s; tearing down
+[t=   63.3s 04:19:19Z] DELETE pod 4wgtk9d6cbbdk4
+[t=   63.9s 04:19:20Z] delete returned status=204 resp={}
+[t=   69.3s 04:19:25Z] pod 4wgtk9d6cbbdk4 confirmed terminated (404)
+[t=   69.3s 04:19:25Z] PROBE: pod 4wgtk9d6cbbdk4 torn down
+[t=    0.0s 04:44:47Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 04:44:47Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 04:44:48Z] create OK id=lhd5lclznjl2yt costPerHr=$1.49
+[t=    1.4s 04:44:48Z] PROBE: pod created id=lhd5lclznjl2yt; waiting for publicIp+ssh_port
+[t=    1.7s 04:44:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 04:45:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 04:45:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.1s 04:45:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.5s 04:45:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.1s 04:46:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.5s 04:46:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.9s 04:46:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.9s 04:46:52Z] PROBE NO-GO: pod lhd5lclznjl2yt not RUNNING+SSH within 120s; tearing down
+[t=  124.9s 04:46:52Z] DELETE pod lhd5lclznjl2yt
+[t=  125.5s 04:46:53Z] delete returned status=204 resp={}
+[t=  130.9s 04:46:58Z] pod lhd5lclznjl2yt confirmed terminated (404)
+[t=  130.9s 04:46:58Z] PROBE: pod lhd5lclznjl2yt torn down
+[t=    0.0s 04:46:58Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:46:58Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 04:46:59Z] create OK id=covfpnc1y02fy9 costPerHr=$1.39
+[t=    1.3s 04:46:59Z] PROBE: pod created id=covfpnc1y02fy9; waiting for publicIp+ssh_port
+[t=    1.9s 04:47:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 04:47:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 04:47:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 04:47:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 04:48:02Z] PROBE NO-GO: pod covfpnc1y02fy9 not RUNNING+SSH within 60s; tearing down
+[t=   63.4s 04:48:02Z] DELETE pod covfpnc1y02fy9
+[t=   64.0s 04:48:02Z] delete returned status=204 resp={}
+[t=   69.4s 04:48:08Z] pod covfpnc1y02fy9 confirmed terminated (404)
+[t=   69.4s 04:48:08Z] PROBE: pod covfpnc1y02fy9 torn down
+[t=    0.0s 04:48:08Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:48:08Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 04:48:09Z] create OK id=ehz959d26jl5vs costPerHr=$2.99
+[t=    1.5s 04:48:09Z] PROBE: pod created id=ehz959d26jl5vs; waiting for publicIp+ssh_port
+[t=    2.0s 04:48:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 04:48:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 04:48:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.6s 04:48:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.6s 04:49:12Z] PROBE NO-GO: pod ehz959d26jl5vs not RUNNING+SSH within 60s; tearing down
+[t=   64.6s 04:49:12Z] DELETE pod ehz959d26jl5vs
+[t=   65.2s 04:49:13Z] delete returned status=204 resp={}
+[t=   70.6s 04:49:18Z] pod ehz959d26jl5vs confirmed terminated (404)
+[t=   70.6s 04:49:18Z] PROBE: pod ehz959d26jl5vs torn down
+[t=    0.0s 04:49:19Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:49:19Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 04:49:19Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 04:49:19Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 04:49:19Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 04:49:19Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 04:49:20Z] create OK id=xu5nfgqjhoonx0 costPerHr=$1.39
+[t=    1.0s 04:49:20Z] PROBE: pod created id=xu5nfgqjhoonx0; waiting for publicIp+ssh_port
+[t=    1.3s 04:49:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 04:49:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 04:49:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 04:50:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 04:50:22Z] PROBE NO-GO: pod xu5nfgqjhoonx0 not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 04:50:22Z] DELETE pod xu5nfgqjhoonx0
+[t=   63.4s 04:50:23Z] delete returned status=204 resp={}
+[t=   68.7s 04:50:28Z] pod xu5nfgqjhoonx0 confirmed terminated (404)
+[t=   68.7s 04:50:28Z] PROBE: pod xu5nfgqjhoonx0 torn down
+[t=    0.0s 05:29:23Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 05:29:23Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 05:29:24Z] create OK id=zhtzk3lx4vd348 costPerHr=$1.49
+[t=    1.2s 05:29:24Z] PROBE: pod created id=zhtzk3lx4vd348; waiting for publicIp+ssh_port
+[t=    1.5s 05:29:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 05:29:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t= 1005.0s 05:46:08Z] PROBE NO-GO: pod zhtzk3lx4vd348 not RUNNING+SSH within 120s; tearing down
+[t= 1005.0s 05:46:08Z] DELETE pod zhtzk3lx4vd348
+[t= 1006.0s 05:46:09Z] delete returned status=204 resp={}
+[t= 1111.5s 05:47:54Z] pod zhtzk3lx4vd348 confirmed terminated (404)
+[t= 1111.5s 05:47:54Z] PROBE: pod zhtzk3lx4vd348 torn down
+[t=    0.0s 05:47:54Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:47:54Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 05:47:55Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 05:47:55Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 05:47:55Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:47:55Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 05:47:57Z] create OK id=or66mm59kvqftj costPerHr=$2.99
+[t=    1.5s 05:47:57Z] PROBE: pod created id=or66mm59kvqftj; waiting for publicIp+ssh_port
+[t=    1.9s 05:47:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 05:48:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.8s 05:48:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  948.6s 06:03:44Z] PROBE NO-GO: pod or66mm59kvqftj not RUNNING+SSH within 60s; tearing down
+[t=  948.6s 06:03:44Z] DELETE pod or66mm59kvqftj
+[t=  949.3s 06:03:45Z] delete returned status=204 resp={}
+[t=  954.7s 06:03:50Z] pod or66mm59kvqftj confirmed terminated (404)
+[t=  954.7s 06:03:50Z] PROBE: pod or66mm59kvqftj torn down
+[t=    0.0s 06:03:50Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 06:03:50Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 06:03:51Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 06:03:51Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 06:03:51Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 06:03:51Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 06:03:52Z] create OK id=6d756auahr5ns2 costPerHr=$1.39
+[t=    0.9s 06:03:52Z] PROBE: pod created id=6d756auahr5ns2; waiting for publicIp+ssh_port
+[t=    1.2s 06:03:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 06:04:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 06:04:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t= 2954.1s 06:53:05Z] PROBE NO-GO: pod 6d756auahr5ns2 not RUNNING+SSH within 60s; tearing down
+[t= 2954.1s 06:53:05Z] DELETE pod 6d756auahr5ns2
+[t= 2955.2s 06:53:06Z] delete returned status=204 resp={}
+[t= 2960.5s 06:53:12Z] pod 6d756auahr5ns2 confirmed terminated (404)
+[t= 2960.5s 06:53:12Z] PROBE: pod 6d756auahr5ns2 torn down
+[t=    0.0s 07:27:56Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 07:27:56Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 07:27:57Z] create OK id=vs3e7ugdupjymy costPerHr=$1.49
+[t=    1.2s 07:27:57Z] PROBE: pod created id=vs3e7ugdupjymy; waiting for publicIp+ssh_port
+[t=    1.5s 07:27:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  922.5s 07:43:18Z] PROBE NO-GO: pod vs3e7ugdupjymy not RUNNING+SSH within 120s; tearing down
+[t=  922.5s 07:43:18Z] DELETE pod vs3e7ugdupjymy
+[t=  923.2s 07:43:19Z] delete returned status=204 resp={}
+[t=  928.6s 07:43:24Z] pod vs3e7ugdupjymy confirmed terminated (404)
+[t=  928.6s 07:43:24Z] PROBE: pod vs3e7ugdupjymy torn down
+[t=    0.0s 07:43:25Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 07:43:25Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 07:43:25Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 07:43:25Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 07:43:25Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 07:43:25Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 07:43:27Z] create OK id=l0hzmfs94vo2zr costPerHr=$2.99
+[t=    1.5s 07:43:27Z] PROBE: pod created id=l0hzmfs94vo2zr; waiting for publicIp+ssh_port
+[t=    2.0s 07:43:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 07:43:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  113.4s 07:45:19Z] PROBE NO-GO: pod l0hzmfs94vo2zr not RUNNING+SSH within 60s; tearing down
+[t=  113.4s 07:45:19Z] DELETE pod l0hzmfs94vo2zr
+[t=  114.1s 07:45:20Z] delete returned status=204 resp={}
+[t=  119.5s 07:45:25Z] pod l0hzmfs94vo2zr confirmed terminated (404)
+[t=  119.5s 07:45:25Z] PROBE: pod l0hzmfs94vo2zr torn down
+[t=    0.0s 07:45:25Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 07:45:25Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 07:45:26Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 07:45:26Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 07:45:26Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 07:45:26Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 07:45:27Z] create OK id=imx8zkbfvbhek5 costPerHr=$1.39
+[t=    0.9s 07:45:27Z] PROBE: pod created id=imx8zkbfvbhek5; waiting for publicIp+ssh_port
+[t=    1.3s 07:45:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 07:45:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 07:45:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  731.3s 07:57:37Z] PROBE NO-GO: pod imx8zkbfvbhek5 not RUNNING+SSH within 60s; tearing down
+[t=  731.3s 07:57:37Z] DELETE pod imx8zkbfvbhek5
+[t=  731.9s 07:57:38Z] delete returned status=204 resp={}
+[t=  737.3s 07:57:43Z] pod imx8zkbfvbhek5 confirmed terminated (404)
+[t=  737.3s 07:57:43Z] PROBE: pod imx8zkbfvbhek5 torn down
+[t=    0.0s 08:34:24Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 08:34:24Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 08:34:26Z] create OK id=sgmit5cl6o3qfw costPerHr=$1.49
+[t=    1.2s 08:34:26Z] PROBE: pod created id=sgmit5cl6o3qfw; waiting for publicIp+ssh_port
+[t=    1.5s 08:34:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  192.1s 08:37:37Z] PROBE NO-GO: pod sgmit5cl6o3qfw not RUNNING+SSH within 120s; tearing down
+[t=  192.1s 08:37:37Z] DELETE pod sgmit5cl6o3qfw
+[t=  192.9s 08:37:37Z] delete returned status=204 resp={}
+[t=  198.2s 08:37:43Z] pod sgmit5cl6o3qfw confirmed terminated (404)
+[t=  198.2s 08:37:43Z] PROBE: pod sgmit5cl6o3qfw torn down
+[t=    0.0s 08:37:43Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 08:37:43Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 08:37:44Z] create OK id=3upyb8we290n72 costPerHr=$1.39
+[t=    1.1s 08:37:44Z] PROBE: pod created id=3upyb8we290n72; waiting for publicIp+ssh_port
+[t=    1.4s 08:37:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 08:38:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 08:38:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t= 1249.8s 08:58:33Z] PROBE NO-GO: pod 3upyb8we290n72 not RUNNING+SSH within 60s; tearing down
+[t= 1249.8s 08:58:33Z] DELETE pod 3upyb8we290n72
+[t= 1250.7s 08:58:33Z] delete returned status=204 resp={}
+[t= 1256.1s 08:58:39Z] pod 3upyb8we290n72 confirmed terminated (404)
+[t= 1256.1s 08:58:39Z] PROBE: pod 3upyb8we290n72 torn down
+[t=    0.0s 08:58:39Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 08:58:39Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 08:58:40Z] create OK id=mjbne6krm2i7ax costPerHr=$2.99
+[t=    1.2s 08:58:40Z] PROBE: pod created id=mjbne6krm2i7ax; waiting for publicIp+ssh_port
+[t=    1.6s 08:58:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 08:58:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 08:59:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t= 2985.9s 09:48:25Z] PROBE NO-GO: pod mjbne6krm2i7ax not RUNNING+SSH within 60s; tearing down
+[t= 2985.9s 09:48:25Z] DELETE pod mjbne6krm2i7ax
+[t= 2986.8s 09:48:26Z] delete returned status=204 resp={}
+[t= 3650.8s 09:59:30Z] pod mjbne6krm2i7ax confirmed terminated (404)
+[t= 3650.8s 09:59:30Z] PROBE: pod mjbne6krm2i7ax torn down
+[t=    0.0s 09:59:30Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 09:59:30Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 09:59:31Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 09:59:31Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 09:59:31Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 09:59:31Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 09:59:32Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.9s 09:59:32Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 11:57:50Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 11:57:50Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 11:57:51Z] create OK id=8i58so69uixkem costPerHr=$1.49
+[t=    1.2s 11:57:51Z] PROBE: pod created id=8i58so69uixkem; waiting for publicIp+ssh_port
+[t=    1.6s 11:57:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 11:58:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  166.2s 12:00:36Z] PROBE NO-GO: pod 8i58so69uixkem not RUNNING+SSH within 120s; tearing down
+[t=  166.2s 12:00:36Z] DELETE pod 8i58so69uixkem
+[t=  166.9s 12:00:37Z] delete returned status=204 resp={}
+[t=  172.2s 12:00:42Z] pod 8i58so69uixkem confirmed terminated (404)
+[t=  172.2s 12:00:42Z] PROBE: pod 8i58so69uixkem torn down
+[t=    0.0s 12:00:42Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 12:00:42Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 12:00:43Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 12:00:43Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 12:00:43Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 12:00:43Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 12:00:45Z] create OK id=ik9lx84gbofbxa costPerHr=$2.99
+[t=    1.5s 12:00:45Z] PROBE: pod created id=ik9lx84gbofbxa; waiting for publicIp+ssh_port
+[t=    2.0s 12:00:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 12:01:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  950.6s 12:16:34Z] PROBE NO-GO: pod ik9lx84gbofbxa not RUNNING+SSH within 60s; tearing down
+[t=  950.6s 12:16:34Z] DELETE pod ik9lx84gbofbxa
+[t=  951.2s 12:16:34Z] delete returned status=204 resp={}
+[t= 1132.0s 12:19:35Z] pod ik9lx84gbofbxa confirmed terminated (404)
+[t= 1132.0s 12:19:35Z] PROBE: pod ik9lx84gbofbxa torn down
+[t=    0.0s 12:19:35Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 12:19:35Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 12:19:36Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 12:19:36Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 12:19:36Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 12:19:36Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 12:19:37Z] create OK id=d5qpxdm5gy53a0 costPerHr=$1.39
+[t=    0.9s 12:19:37Z] PROBE: pod created id=d5qpxdm5gy53a0; waiting for publicIp+ssh_port
+[t=    1.2s 12:19:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 12:19:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 12:20:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  368.3s 12:25:44Z] PROBE NO-GO: pod d5qpxdm5gy53a0 not RUNNING+SSH within 60s; tearing down
+[t=  368.3s 12:25:44Z] DELETE pod d5qpxdm5gy53a0
+[t=  369.0s 12:25:45Z] delete returned status=204 resp={}
+[t=  374.5s 12:25:51Z] pod d5qpxdm5gy53a0 confirmed terminated (404)
+[t=  374.5s 12:25:51Z] PROBE: pod d5qpxdm5gy53a0 torn down
+[t=    0.0s 12:46:57Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 12:46:57Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 12:46:58Z] create OK id=x3t2ig2jrqeqvn costPerHr=$1.49
+[t=    1.2s 12:46:58Z] PROBE: pod created id=x3t2ig2jrqeqvn; waiting for publicIp+ssh_port
+[t=    1.6s 12:46:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 12:47:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  297.0s 12:51:54Z] PROBE NO-GO: pod x3t2ig2jrqeqvn not RUNNING+SSH within 120s; tearing down
+[t=  297.0s 12:51:54Z] DELETE pod x3t2ig2jrqeqvn
+[t=  298.0s 12:51:55Z] delete returned status=204 resp={}
+[t=  303.4s 12:52:00Z] pod x3t2ig2jrqeqvn confirmed terminated (404)
+[t=  303.4s 12:52:00Z] PROBE: pod x3t2ig2jrqeqvn torn down
+[t=    0.0s 12:52:00Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 12:52:00Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.8s 12:52:01Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.8s 12:52:01Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 12:52:01Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 12:52:01Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    2.2s 12:52:04Z] create OK id=8o46gtf1i6n6ex costPerHr=$2.99
+[t=    2.2s 12:52:04Z] PROBE: pod created id=8o46gtf1i6n6ex; waiting for publicIp+ssh_port
+[t=    2.7s 12:52:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.4s 12:52:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  480.0s 13:00:01Z] PROBE NO-GO: pod 8o46gtf1i6n6ex not RUNNING+SSH within 60s; tearing down
+[t=  480.0s 13:00:01Z] DELETE pod 8o46gtf1i6n6ex
+[t=  481.0s 13:00:02Z] delete returned status=204 resp={}
+[t=  486.3s 13:00:08Z] pod 8o46gtf1i6n6ex confirmed terminated (404)
+[t=  486.3s 13:00:08Z] PROBE: pod 8o46gtf1i6n6ex torn down
+[t=    0.0s 13:00:08Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 13:00:08Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 13:00:09Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 13:00:09Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 13:00:09Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 13:00:09Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 13:00:09Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.7s 13:00:09Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 14:18:31Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 14:18:31Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 14:18:33Z] create OK id=xx4iy863dugr9j costPerHr=$1.49
+[t=    1.5s 14:18:33Z] PROBE: pod created id=xx4iy863dugr9j; waiting for publicIp+ssh_port
+[t=    1.8s 14:18:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 14:18:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 14:19:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.1s 14:19:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.6s 14:19:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.0s 14:19:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.4s 14:20:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.9s 14:20:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.9s 14:20:36Z] PROBE NO-GO: pod xx4iy863dugr9j not RUNNING+SSH within 120s; tearing down
+[t=  124.9s 14:20:36Z] DELETE pod xx4iy863dugr9j
+[t=  125.4s 14:20:37Z] delete returned status=204 resp={}
+[t=  130.8s 14:20:42Z] pod xx4iy863dugr9j confirmed terminated (404)
+[t=  130.8s 14:20:42Z] PROBE: pod xx4iy863dugr9j torn down
+[t=    0.0s 14:20:42Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 14:20:42Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 14:20:43Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 14:20:43Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 14:20:43Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 14:20:43Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 14:20:44Z] create OK id=x6rus94k6icb31 costPerHr=$2.99
+[t=    1.3s 14:20:44Z] PROBE: pod created id=x6rus94k6icb31; waiting for publicIp+ssh_port
+[t=    1.8s 14:20:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 14:21:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.4s 14:21:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 14:21:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 14:21:47Z] PROBE NO-GO: pod x6rus94k6icb31 not RUNNING+SSH within 60s; tearing down
+[t=   64.5s 14:21:47Z] DELETE pod x6rus94k6icb31
+[t=   65.1s 14:21:48Z] delete returned status=204 resp={}
+[t=   70.4s 14:21:53Z] pod x6rus94k6icb31 confirmed terminated (404)
+[t=   70.4s 14:21:53Z] PROBE: pod x6rus94k6icb31 torn down
+[t=    0.0s 14:21:54Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 14:21:54Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 14:21:54Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 14:21:54Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 14:21:54Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 14:21:54Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 14:21:55Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 14:21:55Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 15:50:46Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 15:50:46Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 15:50:47Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    1.4s 15:50:47Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 15:50:47Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 15:50:47Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 15:50:48Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 15:50:48Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 15:50:48Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 15:50:48Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 15:50:49Z] create OK id=w3ou4f9d2o23ln costPerHr=$2.99
+[t=    1.3s 15:50:49Z] PROBE: pod created id=w3ou4f9d2o23ln; waiting for publicIp+ssh_port
+[t=    1.6s 15:50:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.5s 15:51:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.5s 15:51:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   50.5s 15:51:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.5s 15:51:53Z] PROBE NO-GO: pod w3ou4f9d2o23ln not RUNNING+SSH within 60s; tearing down
+[t=   65.5s 15:51:53Z] DELETE pod w3ou4f9d2o23ln
+[t=   66.0s 15:51:54Z] delete returned status=204 resp={}
+[t=   71.6s 15:52:00Z] pod w3ou4f9d2o23ln confirmed terminated (404)
+[t=   71.6s 15:52:00Z] PROBE: pod w3ou4f9d2o23ln torn down
+[t=    0.0s 15:52:00Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 15:52:00Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 15:52:01Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    1.5s 15:52:01Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 15:52:01Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 15:52:01Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.1s 15:52:02Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    1.1s 15:52:02Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 16:44:45Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 16:44:45Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 16:44:47Z] create OK id=9gyzr0dnc6w96i costPerHr=$1.49
+[t=    1.2s 16:44:47Z] PROBE: pod created id=9gyzr0dnc6w96i; waiting for publicIp+ssh_port
+[t=    1.5s 16:44:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 16:45:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 16:45:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 16:45:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 16:45:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.5s 16:46:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.9s 16:46:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.2s 16:46:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.2s 16:46:50Z] PROBE NO-GO: pod 9gyzr0dnc6w96i not RUNNING+SSH within 120s; tearing down
+[t=  124.2s 16:46:50Z] DELETE pod 9gyzr0dnc6w96i
+[t=  124.7s 16:46:50Z] delete returned status=204 resp={}
+[t=  130.0s 16:46:55Z] pod 9gyzr0dnc6w96i confirmed terminated (404)
+[t=  130.0s 16:46:55Z] PROBE: pod 9gyzr0dnc6w96i torn down
+[t=    0.0s 16:46:56Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 16:46:56Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 16:46:57Z] create OK id=0yci9urnwo744p costPerHr=$1.39
+[t=    1.0s 16:46:57Z] PROBE: pod created id=0yci9urnwo744p; waiting for publicIp+ssh_port
+[t=    1.4s 16:46:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 16:47:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 16:47:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 16:47:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 16:47:58Z] PROBE NO-GO: pod 0yci9urnwo744p not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 16:47:58Z] DELETE pod 0yci9urnwo744p
+[t=   63.5s 16:47:59Z] delete returned status=204 resp={}
+[t=   68.8s 16:48:04Z] pod 0yci9urnwo744p confirmed terminated (404)
+[t=   68.8s 16:48:04Z] PROBE: pod 0yci9urnwo744p torn down
+[t=    0.0s 16:48:05Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 16:48:05Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 16:48:06Z] create OK id=ww0zclgtzejth3 costPerHr=$2.99
+[t=    1.5s 16:48:06Z] PROBE: pod created id=ww0zclgtzejth3; waiting for publicIp+ssh_port
+[t=    2.0s 16:48:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.0s 16:48:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.8s 16:48:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 16:48:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 16:49:09Z] PROBE NO-GO: pod ww0zclgtzejth3 not RUNNING+SSH within 60s; tearing down
+[t=   64.5s 16:49:09Z] DELETE pod ww0zclgtzejth3
+[t=   65.1s 16:49:10Z] delete returned status=204 resp={}
+[t=   70.5s 16:49:15Z] pod ww0zclgtzejth3 confirmed terminated (404)
+[t=   70.5s 16:49:15Z] PROBE: pod ww0zclgtzejth3 torn down
+[t=    0.0s 16:49:15Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 16:49:15Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 16:49:16Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 16:49:16Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 16:49:16Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 16:49:16Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 16:49:17Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 16:49:17Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 16:55:13Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 16:55:13Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 16:55:14Z] create OK id=gxql8pmkqje2uj costPerHr=$1.49
+[t=    1.4s 16:55:14Z] PROBE: pod created id=gxql8pmkqje2uj; waiting for publicIp+ssh_port
+[t=    1.7s 16:55:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 16:55:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 16:55:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 16:56:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.4s 16:56:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.8s 16:56:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.2s 16:56:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.0s 16:57:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.0s 16:57:18Z] PROBE NO-GO: pod gxql8pmkqje2uj not RUNNING+SSH within 120s; tearing down
+[t=  125.0s 16:57:18Z] DELETE pod gxql8pmkqje2uj
+[t=  125.5s 16:57:18Z] delete returned status=204 resp={}
+[t=  130.9s 16:57:24Z] pod gxql8pmkqje2uj confirmed terminated (404)
+[t=  130.9s 16:57:24Z] PROBE: pod gxql8pmkqje2uj torn down
+[t=    0.0s 16:57:24Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 16:57:24Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 16:57:25Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 16:57:25Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 16:57:25Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 16:57:25Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 16:57:26Z] create OK id=b0z2ted93k3iwx costPerHr=$2.99
+[t=    1.4s 16:57:26Z] PROBE: pod created id=b0z2ted93k3iwx; waiting for publicIp+ssh_port
+[t=    1.9s 16:57:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.3s 16:57:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.0s 16:57:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   50.0s 16:58:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.0s 16:58:30Z] PROBE NO-GO: pod b0z2ted93k3iwx not RUNNING+SSH within 60s; tearing down
+[t=   65.0s 16:58:30Z] DELETE pod b0z2ted93k3iwx
+[t=   65.5s 16:58:30Z] delete returned status=204 resp={}
+[t=   70.7s 16:58:36Z] pod b0z2ted93k3iwx confirmed terminated (404)
+[t=   70.7s 16:58:36Z] PROBE: pod b0z2ted93k3iwx torn down
+[t=    0.0s 16:58:36Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 16:58:36Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 16:58:36Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 16:58:36Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 16:58:36Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 16:58:36Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 16:58:37Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 16:58:37Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:14:46Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 17:14:46Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 17:14:47Z] create OK id=4n515w72vwdjpg costPerHr=$1.49
+[t=    1.5s 17:14:47Z] PROBE: pod created id=4n515w72vwdjpg; waiting for publicIp+ssh_port
+[t=    1.9s 17:14:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   36.5s 17:15:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   52.1s 17:15:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   67.5s 17:15:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   83.1s 17:16:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   98.6s 17:16:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  114.2s 17:16:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  129.2s 17:16:55Z] PROBE NO-GO: pod 4n515w72vwdjpg not RUNNING+SSH within 120s; tearing down
+[t=  129.2s 17:16:55Z] DELETE pod 4n515w72vwdjpg
+[t=  130.0s 17:16:56Z] delete returned status=204 resp={}
+[t=  135.3s 17:17:01Z] pod 4n515w72vwdjpg confirmed terminated (404)
+[t=  135.3s 17:17:01Z] PROBE: pod 4n515w72vwdjpg torn down
+[t=    0.0s 17:17:03Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:17:03Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 17:17:03Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 17:17:03Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:17:03Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:17:03Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 17:17:05Z] create OK id=m0vqred2de1pdx costPerHr=$2.99
+[t=    1.4s 17:17:05Z] PROBE: pod created id=m0vqred2de1pdx; waiting for publicIp+ssh_port
+[t=    1.9s 17:17:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 17:17:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.9s 17:17:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.8s 17:17:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.8s 17:18:08Z] PROBE NO-GO: pod m0vqred2de1pdx not RUNNING+SSH within 60s; tearing down
+[t=   64.8s 17:18:08Z] DELETE pod m0vqred2de1pdx
+[t=   65.5s 17:18:09Z] delete returned status=204 resp={}
+[t=   70.8s 17:18:14Z] pod m0vqred2de1pdx confirmed terminated (404)
+[t=   70.8s 17:18:14Z] PROBE: pod m0vqred2de1pdx torn down
+[t=    0.0s 17:18:14Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:18:14Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 17:18:16Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    1.1s 17:18:16Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:18:16Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 17:18:16Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 17:18:17Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 17:18:17Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:22:20Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 17:22:20Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 17:22:22Z] create OK id=l4wq45tnecvqkf costPerHr=$1.49
+[t=    1.5s 17:22:22Z] PROBE: pod created id=l4wq45tnecvqkf; waiting for publicIp+ssh_port
+[t=    1.9s 17:22:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 17:22:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.5s 17:22:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 17:23:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.7s 17:23:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.2s 17:23:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.8s 17:23:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.3s 17:24:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.4s 17:24:26Z] PROBE NO-GO: pod l4wq45tnecvqkf not RUNNING+SSH within 120s; tearing down
+[t=  126.4s 17:24:26Z] DELETE pod l4wq45tnecvqkf
+[t=  126.9s 17:24:27Z] delete returned status=204 resp={}
+[t=  132.2s 17:24:32Z] pod l4wq45tnecvqkf confirmed terminated (404)
+[t=  132.2s 17:24:32Z] PROBE: pod l4wq45tnecvqkf torn down
+[t=    0.0s 17:24:33Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:24:33Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 17:24:33Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 17:24:33Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:24:33Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:24:33Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 17:24:35Z] create OK id=zeozmaj8jp4exo costPerHr=$2.99
+[t=    1.3s 17:24:35Z] PROBE: pod created id=zeozmaj8jp4exo; waiting for publicIp+ssh_port
+[t=    2.0s 17:24:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.0s 17:24:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   96.7s 17:26:10Z] PROBE NO-GO: pod zeozmaj8jp4exo not RUNNING+SSH within 60s; tearing down
+[t=   96.7s 17:26:10Z] DELETE pod zeozmaj8jp4exo
+[t=   97.6s 17:26:11Z] delete returned status=204 resp={}
+[t=  103.0s 17:26:16Z] pod zeozmaj8jp4exo confirmed terminated (404)
+[t=  103.0s 17:26:16Z] PROBE: pod zeozmaj8jp4exo torn down
+[t=    0.0s 17:26:17Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:26:17Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 17:26:18Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 17:26:18Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:26:18Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 17:26:18Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 17:26:19Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 17:26:19Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:27:46Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 17:27:46Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 17:27:48Z] create OK id=2tjjqzs61y3468 costPerHr=$1.49
+[t=    1.6s 17:27:48Z] PROBE: pod created id=2tjjqzs61y3468; waiting for publicIp+ssh_port
+[t=    1.9s 17:27:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 17:28:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 17:28:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.1s 17:28:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.6s 17:28:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.0s 17:29:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.4s 17:29:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.8s 17:29:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.8s 17:29:51Z] PROBE NO-GO: pod 2tjjqzs61y3468 not RUNNING+SSH within 120s; tearing down
+[t=  124.8s 17:29:51Z] DELETE pod 2tjjqzs61y3468
+[t=  125.4s 17:29:52Z] delete returned status=204 resp={}
+[t=  130.7s 17:29:57Z] pod 2tjjqzs61y3468 confirmed terminated (404)
+[t=  130.7s 17:29:57Z] PROBE: pod 2tjjqzs61y3468 torn down
+[t=    0.0s 17:29:57Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:29:57Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 17:29:59Z] create OK id=ps89c5ajc6mck9 costPerHr=$1.39
+[t=    1.3s 17:29:59Z] PROBE: pod created id=ps89c5ajc6mck9; waiting for publicIp+ssh_port
+[t=    1.7s 17:29:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 17:30:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 17:30:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 17:30:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 17:31:00Z] PROBE NO-GO: pod ps89c5ajc6mck9 not RUNNING+SSH within 60s; tearing down
+[t=   63.2s 17:31:00Z] DELETE pod ps89c5ajc6mck9
+[t=   63.8s 17:31:01Z] delete returned status=204 resp={}
+[t=   69.3s 17:31:07Z] pod ps89c5ajc6mck9 confirmed terminated (404)
+[t=   69.3s 17:31:07Z] PROBE: pod ps89c5ajc6mck9 torn down
+[t=    0.0s 17:31:07Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:31:07Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 17:31:08Z] create OK id=i3shfopmyq9yo8 costPerHr=$2.99
+[t=    1.4s 17:31:08Z] PROBE: pod created id=i3shfopmyq9yo8; waiting for publicIp+ssh_port
+[t=    2.1s 17:31:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.1s 17:31:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.2s 17:31:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   50.1s 17:31:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.1s 17:32:12Z] PROBE NO-GO: pod i3shfopmyq9yo8 not RUNNING+SSH within 60s; tearing down
+[t=   65.2s 17:32:12Z] DELETE pod i3shfopmyq9yo8
+[t=   66.1s 17:32:13Z] delete returned status=204 resp={}
+[t=   71.4s 17:32:18Z] pod i3shfopmyq9yo8 confirmed terminated (404)
+[t=   71.4s 17:32:18Z] PROBE: pod i3shfopmyq9yo8 torn down
+[t=    0.0s 17:32:19Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:32:19Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 17:32:19Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 17:32:19Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:32:20Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 17:32:20Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 17:32:20Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 17:32:20Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:32:45Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 17:32:45Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 17:32:46Z] create OK id=h2qozv14ublcvt costPerHr=$1.49
+[t=    1.3s 17:32:46Z] PROBE: pod created id=h2qozv14ublcvt; waiting for publicIp+ssh_port
+[t=    1.8s 17:32:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.6s 17:33:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.2s 17:33:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.7s 17:33:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.3s 17:33:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.0s 17:34:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.9s 17:34:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.4s 17:34:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.4s 17:34:51Z] PROBE NO-GO: pod h2qozv14ublcvt not RUNNING+SSH within 120s; tearing down
+[t=  126.4s 17:34:52Z] DELETE pod h2qozv14ublcvt
+[t=  127.0s 17:34:52Z] delete returned status=204 resp={}
+[t=  132.3s 17:34:57Z] pod h2qozv14ublcvt confirmed terminated (404)
+[t=  132.3s 17:34:57Z] PROBE: pod h2qozv14ublcvt torn down
+[t=    0.0s 17:34:58Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:34:58Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 17:34:59Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 17:34:59Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:34:59Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:34:59Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 17:35:00Z] create OK id=t80omjv6slvwmp costPerHr=$2.99
+[t=    1.3s 17:35:00Z] PROBE: pod created id=t80omjv6slvwmp; waiting for publicIp+ssh_port
+[t=    1.8s 17:35:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 17:35:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 17:35:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.5s 17:35:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.5s 17:36:02Z] PROBE NO-GO: pod t80omjv6slvwmp not RUNNING+SSH within 60s; tearing down
+[t=   63.5s 17:36:02Z] DELETE pod t80omjv6slvwmp
+[t=   64.4s 17:36:03Z] delete returned status=204 resp={}
+[t=   70.1s 17:36:09Z] pod t80omjv6slvwmp confirmed terminated (404)
+[t=   70.1s 17:36:09Z] PROBE: pod t80omjv6slvwmp torn down
+[t=    0.0s 17:36:10Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:36:10Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.9s 17:36:11Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.9s 17:36:11Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:36:13Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 17:36:13Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.8s 17:36:14Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.8s 17:36:14Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:36:31Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 17:36:31Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 17:36:33Z] create OK id=ykpqm3mjc8pr4p costPerHr=$1.49
+[t=    1.4s 17:36:33Z] PROBE: pod created id=ykpqm3mjc8pr4p; waiting for publicIp+ssh_port
+[t=    1.8s 17:36:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.6s 17:36:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.5s 17:37:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.2s 17:37:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.9s 17:37:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.5s 17:37:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   96.2s 17:38:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.8s 17:38:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.8s 17:38:38Z] PROBE NO-GO: pod ykpqm3mjc8pr4p not RUNNING+SSH within 120s; tearing down
+[t=  126.8s 17:38:38Z] DELETE pod ykpqm3mjc8pr4p
+[t=  127.4s 17:38:39Z] delete returned status=204 resp={}
+[t=  132.7s 17:38:44Z] pod ykpqm3mjc8pr4p confirmed terminated (404)
+[t=  132.7s 17:38:44Z] PROBE: pod ykpqm3mjc8pr4p torn down
+[t=    0.0s 17:38:45Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:38:45Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 17:38:45Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 17:38:45Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:38:45Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:38:45Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 17:38:47Z] create OK id=9o630th81kd152 costPerHr=$3.29
+[t=    1.5s 17:38:47Z] PROBE: pod created id=9o630th81kd152; waiting for publicIp+ssh_port
+[t=    2.2s 17:38:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.0s 17:39:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.7s 17:39:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   50.7s 17:39:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.7s 17:39:51Z] PROBE NO-GO: pod 9o630th81kd152 not RUNNING+SSH within 60s; tearing down
+[t=   65.7s 17:39:51Z] DELETE pod 9o630th81kd152
+[t=   66.4s 17:39:52Z] delete returned status=204 resp={}
+[t=   71.7s 17:39:57Z] pod 9o630th81kd152 confirmed terminated (404)
+[t=   71.7s 17:39:57Z] PROBE: pod 9o630th81kd152 torn down
+[t=    0.0s 17:39:57Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:39:57Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 17:39:58Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 17:39:58Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:39:58Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 17:39:58Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 17:39:58Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 17:39:58Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:40:15Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 17:40:15Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 17:40:16Z] create OK id=mgd7agobbodkav costPerHr=$1.49
+[t=    1.4s 17:40:16Z] PROBE: pod created id=mgd7agobbodkav; waiting for publicIp+ssh_port
+[t=    1.8s 17:40:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 17:40:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.0s 17:40:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.6s 17:41:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.2s 17:41:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.8s 17:41:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.7s 17:41:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.4s 17:42:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.4s 17:42:21Z] PROBE NO-GO: pod mgd7agobbodkav not RUNNING+SSH within 120s; tearing down
+[t=  126.4s 17:42:21Z] DELETE pod mgd7agobbodkav
+[t=  127.0s 17:42:22Z] delete returned status=204 resp={}
+[t=  132.3s 17:42:27Z] pod mgd7agobbodkav confirmed terminated (404)
+[t=  132.3s 17:42:27Z] PROBE: pod mgd7agobbodkav torn down
+[t=    0.0s 17:42:27Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:42:27Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 17:42:28Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 17:42:28Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:42:28Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:42:28Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 17:42:29Z] create OK id=qhps9hyio34lgl costPerHr=$3.29
+[t=    1.2s 17:42:29Z] PROBE: pod created id=qhps9hyio34lgl; waiting for publicIp+ssh_port
+[t=    1.7s 17:42:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 17:42:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 17:43:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.4s 17:43:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.4s 17:43:31Z] PROBE NO-GO: pod qhps9hyio34lgl not RUNNING+SSH within 60s; tearing down
+[t=   63.4s 17:43:31Z] DELETE pod qhps9hyio34lgl
+[t=   63.9s 17:43:32Z] delete returned status=204 resp={}
+[t=   69.2s 17:43:37Z] pod qhps9hyio34lgl confirmed terminated (404)
+[t=   69.2s 17:43:37Z] PROBE: pod qhps9hyio34lgl torn down
+[t=    0.0s 17:43:37Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:43:37Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 17:43:38Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 17:43:38Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:43:38Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 17:43:38Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 17:43:39Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 17:43:39Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:43:55Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 17:43:55Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    2.0s 17:43:57Z] create OK id=c2q1xo60klcne5 costPerHr=$1.49
+[t=    2.0s 17:43:57Z] PROBE: pod created id=c2q1xo60klcne5; waiting for publicIp+ssh_port
+[t=    2.3s 17:43:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 17:44:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.0s 17:44:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.5s 17:44:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.8s 17:44:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.2s 17:45:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.5s 17:45:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.0s 17:45:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.0s 17:46:00Z] PROBE NO-GO: pod c2q1xo60klcne5 not RUNNING+SSH within 120s; tearing down
+[t=  125.0s 17:46:00Z] DELETE pod c2q1xo60klcne5
+[t=  125.8s 17:46:01Z] delete returned status=204 resp={}
+[t=  131.1s 17:46:06Z] pod c2q1xo60klcne5 confirmed terminated (404)
+[t=  131.1s 17:46:06Z] PROBE: pod c2q1xo60klcne5 torn down
+[t=    0.0s 17:46:07Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:46:07Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 17:46:08Z] create OK id=bxb115jbs9efxu costPerHr=$1.39
+[t=    1.1s 17:46:08Z] PROBE: pod created id=bxb115jbs9efxu; waiting for publicIp+ssh_port
+[t=    1.5s 17:46:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 17:46:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 17:46:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.1s 17:46:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 17:47:10Z] PROBE NO-GO: pod bxb115jbs9efxu not RUNNING+SSH within 60s; tearing down
+[t=   63.1s 17:47:10Z] DELETE pod bxb115jbs9efxu
+[t=   63.6s 17:47:10Z] delete returned status=204 resp={}
+[t=   68.9s 17:47:16Z] pod bxb115jbs9efxu confirmed terminated (404)
+[t=   68.9s 17:47:16Z] PROBE: pod bxb115jbs9efxu torn down
+[t=    0.0s 17:47:16Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:47:16Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 17:47:17Z] create OK id=6rkhswab0awm6a costPerHr=$3.29
+[t=    1.2s 17:47:17Z] PROBE: pod created id=6rkhswab0awm6a; waiting for publicIp+ssh_port
+[t=    1.6s 17:47:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 17:47:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 17:47:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.4s 17:48:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.4s 17:48:19Z] PROBE NO-GO: pod 6rkhswab0awm6a not RUNNING+SSH within 60s; tearing down
+[t=   63.4s 17:48:19Z] DELETE pod 6rkhswab0awm6a
+[t=   64.0s 17:48:20Z] delete returned status=204 resp={}
+[t=   69.3s 17:48:25Z] pod 6rkhswab0awm6a confirmed terminated (404)
+[t=   69.3s 17:48:25Z] PROBE: pod 6rkhswab0awm6a torn down
+[t=    0.0s 17:48:25Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:48:25Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 17:48:26Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 17:48:26Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:48:26Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 17:48:26Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 17:48:27Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 17:48:27Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:48:46Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 17:48:46Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 17:48:47Z] create OK id=77g6uxmpa43f03 costPerHr=$1.49
+[t=    1.1s 17:48:47Z] PROBE: pod created id=77g6uxmpa43f03; waiting for publicIp+ssh_port
+[t=    1.4s 17:48:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 17:49:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 17:49:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 17:49:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 17:49:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.8s 17:50:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.3s 17:50:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.6s 17:50:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.6s 17:50:50Z] PROBE NO-GO: pod 77g6uxmpa43f03 not RUNNING+SSH within 120s; tearing down
+[t=  124.6s 17:50:50Z] DELETE pod 77g6uxmpa43f03
+[t=  125.2s 17:50:51Z] delete returned status=204 resp={}
+[t=  130.6s 17:50:56Z] pod 77g6uxmpa43f03 confirmed terminated (404)
+[t=  130.6s 17:50:56Z] PROBE: pod 77g6uxmpa43f03 torn down
+[t=    0.0s 17:50:57Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:50:57Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 17:50:58Z] create OK id=bpn3th20w6ejak costPerHr=$1.39
+[t=    1.0s 17:50:58Z] PROBE: pod created id=bpn3th20w6ejak; waiting for publicIp+ssh_port
+[t=    1.3s 17:50:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 17:51:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 17:51:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 17:51:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 17:52:00Z] PROBE NO-GO: pod bpn3th20w6ejak not RUNNING+SSH within 60s; tearing down
+[t=   63.3s 17:52:00Z] DELETE pod bpn3th20w6ejak
+[t=   63.8s 17:52:00Z] delete returned status=204 resp={}
+[t=   69.2s 17:52:06Z] pod bpn3th20w6ejak confirmed terminated (404)
+[t=   69.2s 17:52:06Z] PROBE: pod bpn3th20w6ejak torn down
+[t=    0.0s 17:52:06Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:52:06Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 17:52:08Z] create OK id=8tnixfigpbmz6o costPerHr=$3.29
+[t=    1.6s 17:52:08Z] PROBE: pod created id=8tnixfigpbmz6o; waiting for publicIp+ssh_port
+[t=    2.1s 17:52:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.0s 17:52:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.7s 17:52:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.4s 17:52:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.4s 17:53:11Z] PROBE NO-GO: pod 8tnixfigpbmz6o not RUNNING+SSH within 60s; tearing down
+[t=   64.4s 17:53:11Z] DELETE pod 8tnixfigpbmz6o
+[t=   65.0s 17:53:11Z] delete returned status=204 resp={}
+[t=   70.5s 17:53:17Z] pod 8tnixfigpbmz6o confirmed terminated (404)
+[t=   70.5s 17:53:17Z] PROBE: pod 8tnixfigpbmz6o torn down
+[t=    0.0s 17:53:17Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:53:17Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.8s 17:53:18Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.8s 17:53:18Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:53:18Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 17:53:18Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 17:53:19Z] create OK id=cl2g35n9qpxyt7 costPerHr=$1.39
+[t=    1.0s 17:53:19Z] PROBE: pod created id=cl2g35n9qpxyt7; waiting for publicIp+ssh_port
+[t=    1.4s 17:53:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 17:53:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 17:53:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 17:54:05Z] poll desiredStatus=EXITED publicIp= ssh_port=None
+[t=   62.6s 17:54:20Z] PROBE NO-GO: pod cl2g35n9qpxyt7 not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 17:54:20Z] DELETE pod cl2g35n9qpxyt7
+[t=   63.3s 17:54:21Z] delete returned status=204 resp={}
+[t=   68.8s 17:54:27Z] pod cl2g35n9qpxyt7 confirmed terminated (404)
+[t=   68.8s 17:54:27Z] PROBE: pod cl2g35n9qpxyt7 torn down
+[t=    0.0s 17:54:44Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 17:54:44Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 17:54:45Z] create OK id=9j89ua4ik94eej costPerHr=$1.49
+[t=    1.1s 17:54:45Z] PROBE: pod created id=9j89ua4ik94eej; waiting for publicIp+ssh_port
+[t=    1.4s 17:54:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 17:55:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 17:55:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 17:55:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 17:55:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.2s 17:56:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.6s 17:56:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  108.9s 17:56:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  123.9s 17:56:48Z] PROBE NO-GO: pod 9j89ua4ik94eej not RUNNING+SSH within 120s; tearing down
+[t=  123.9s 17:56:48Z] DELETE pod 9j89ua4ik94eej
+[t=  124.5s 17:56:48Z] delete returned status=204 resp={}
+[t=  129.8s 17:56:54Z] pod 9j89ua4ik94eej confirmed terminated (404)
+[t=  129.8s 17:56:54Z] PROBE: pod 9j89ua4ik94eej torn down
+[t=    0.0s 17:56:54Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:56:54Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 17:56:55Z] create OK id=w7ssk10gd4j8s4 costPerHr=$1.39
+[t=    1.0s 17:56:55Z] PROBE: pod created id=w7ssk10gd4j8s4; waiting for publicIp+ssh_port
+[t=    1.4s 17:56:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 17:57:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 17:57:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 17:57:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 17:57:57Z] PROBE NO-GO: pod w7ssk10gd4j8s4 not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 17:57:57Z] DELETE pod w7ssk10gd4j8s4
+[t=   63.3s 17:57:57Z] delete returned status=204 resp={}
+[t=   68.6s 17:58:03Z] pod w7ssk10gd4j8s4 confirmed terminated (404)
+[t=   68.6s 17:58:03Z] PROBE: pod w7ssk10gd4j8s4 torn down
+[t=    0.0s 17:58:03Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:58:03Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 17:58:04Z] create OK id=2lqjxxdaeo37dn costPerHr=$3.29
+[t=    1.5s 17:58:04Z] PROBE: pod created id=2lqjxxdaeo37dn; waiting for publicIp+ssh_port
+[t=    2.1s 17:58:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.0s 17:58:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.7s 17:58:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 17:58:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 17:59:07Z] PROBE NO-GO: pod 2lqjxxdaeo37dn not RUNNING+SSH within 60s; tearing down
+[t=   64.5s 17:59:07Z] DELETE pod 2lqjxxdaeo37dn
+[t=   65.1s 17:59:08Z] delete returned status=204 resp={}
+[t=   70.5s 17:59:13Z] pod 2lqjxxdaeo37dn confirmed terminated (404)
+[t=   70.5s 17:59:13Z] PROBE: pod 2lqjxxdaeo37dn torn down
+[t=    0.0s 17:59:13Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 17:59:13Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 17:59:15Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    1.3s 17:59:15Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:59:15Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 17:59:15Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.7s 17:59:16Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.7s 17:59:16Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 17:59:31Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 17:59:31Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 17:59:33Z] create OK id=amalvcx34txokp costPerHr=$1.49
+[t=    1.2s 17:59:33Z] PROBE: pod created id=amalvcx34txokp; waiting for publicIp+ssh_port
+[t=    2.5s 17:59:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 17:59:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.2s 18:00:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.6s 18:00:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.0s 18:00:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.4s 18:00:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.9s 18:01:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.3s 18:01:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.3s 18:01:37Z] PROBE NO-GO: pod amalvcx34txokp not RUNNING+SSH within 120s; tearing down
+[t=  125.3s 18:01:37Z] DELETE pod amalvcx34txokp
+[t=  125.8s 18:01:37Z] delete returned status=204 resp={}
+[t=  131.1s 18:01:43Z] pod amalvcx34txokp confirmed terminated (404)
+[t=  131.1s 18:01:43Z] PROBE: pod amalvcx34txokp torn down
+[t=    0.0s 18:01:43Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:01:43Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 18:01:44Z] create OK id=l14b21twsq6loe costPerHr=$1.39
+[t=    1.1s 18:01:44Z] PROBE: pod created id=l14b21twsq6loe; waiting for publicIp+ssh_port
+[t=    1.4s 18:01:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 18:02:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 18:02:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 18:02:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 18:02:46Z] PROBE NO-GO: pod l14b21twsq6loe not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 18:02:46Z] DELETE pod l14b21twsq6loe
+[t=   63.4s 18:02:46Z] delete returned status=204 resp={}
+[t=   68.7s 18:02:52Z] pod l14b21twsq6loe confirmed terminated (404)
+[t=   68.7s 18:02:52Z] PROBE: pod l14b21twsq6loe torn down
+[t=    0.0s 18:02:52Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:02:52Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 18:02:53Z] create OK id=searvssysmz7du costPerHr=$3.29
+[t=    1.4s 18:02:53Z] PROBE: pod created id=searvssysmz7du; waiting for publicIp+ssh_port
+[t=    1.9s 18:02:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 18:03:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.4s 18:03:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 18:03:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 18:03:56Z] PROBE NO-GO: pod searvssysmz7du not RUNNING+SSH within 60s; tearing down
+[t=   64.1s 18:03:56Z] DELETE pod searvssysmz7du
+[t=   64.7s 18:03:57Z] delete returned status=204 resp={}
+[t=   70.2s 18:04:02Z] pod searvssysmz7du confirmed terminated (404)
+[t=   70.2s 18:04:02Z] PROBE: pod searvssysmz7du torn down
+[t=    0.0s 18:04:02Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:04:02Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 18:04:03Z] create OK id=zzib8val6z685g costPerHr=$2.89
+[t=    1.2s 18:04:03Z] PROBE: pod created id=zzib8val6z685g; waiting for publicIp+ssh_port
+[t=    1.6s 18:04:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 18:04:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 18:04:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 18:04:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 18:05:05Z] PROBE NO-GO: pod zzib8val6z685g not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 18:05:05Z] DELETE pod zzib8val6z685g
+[t=   63.5s 18:05:06Z] delete returned status=204 resp={}
+[t=   69.0s 18:05:11Z] pod zzib8val6z685g confirmed terminated (404)
+[t=   69.0s 18:05:11Z] PROBE: pod zzib8val6z685g torn down
+[t=    0.0s 18:05:11Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 18:05:11Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.7s 18:05:12Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.7s 18:05:12Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:05:29Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 18:05:29Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 18:05:30Z] create OK id=egcewjl6xvg94x costPerHr=$1.49
+[t=    1.1s 18:05:30Z] PROBE: pod created id=egcewjl6xvg94x; waiting for publicIp+ssh_port
+[t=    1.4s 18:05:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 18:05:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 18:06:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 18:06:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 18:06:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.5s 18:06:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.9s 18:07:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.2s 18:07:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.2s 18:07:33Z] PROBE NO-GO: pod egcewjl6xvg94x not RUNNING+SSH within 120s; tearing down
+[t=  124.2s 18:07:33Z] DELETE pod egcewjl6xvg94x
+[t=  124.9s 18:07:34Z] delete returned status=204 resp={}
+[t=  130.4s 18:07:39Z] pod egcewjl6xvg94x confirmed terminated (404)
+[t=  130.4s 18:07:39Z] PROBE: pod egcewjl6xvg94x torn down
+[t=    0.0s 18:07:40Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:07:40Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 18:07:41Z] create OK id=3xgz64irfpn1dd costPerHr=$1.39
+[t=    1.1s 18:07:41Z] PROBE: pod created id=3xgz64irfpn1dd; waiting for publicIp+ssh_port
+[t=    1.7s 18:07:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 18:07:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 18:08:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 18:08:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 18:08:43Z] PROBE NO-GO: pod 3xgz64irfpn1dd not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 18:08:43Z] DELETE pod 3xgz64irfpn1dd
+[t=   63.5s 18:08:43Z] delete returned status=204 resp={}
+[t=   68.9s 18:08:48Z] pod 3xgz64irfpn1dd confirmed terminated (404)
+[t=   68.9s 18:08:48Z] PROBE: pod 3xgz64irfpn1dd torn down
+[t=    0.0s 18:08:49Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:08:49Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 18:08:50Z] create OK id=2j12kaay9dbk5t costPerHr=$3.29
+[t=    1.4s 18:08:50Z] PROBE: pod created id=2j12kaay9dbk5t; waiting for publicIp+ssh_port
+[t=    2.2s 18:08:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.0s 18:09:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.7s 18:09:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 18:09:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 18:09:53Z] PROBE NO-GO: pod 2j12kaay9dbk5t not RUNNING+SSH within 60s; tearing down
+[t=   64.5s 18:09:53Z] DELETE pod 2j12kaay9dbk5t
+[t=   65.1s 18:09:54Z] delete returned status=204 resp={}
+[t=   70.6s 18:09:59Z] pod 2j12kaay9dbk5t confirmed terminated (404)
+[t=   70.6s 18:09:59Z] PROBE: pod 2j12kaay9dbk5t torn down
+[t=    0.0s 18:09:59Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:09:59Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 18:10:01Z] create OK id=usaft26chytcdn costPerHr=$2.89
+[t=    1.2s 18:10:01Z] PROBE: pod created id=usaft26chytcdn; waiting for publicIp+ssh_port
+[t=    1.8s 18:10:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 18:10:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 18:10:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 18:10:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 18:11:02Z] PROBE NO-GO: pod usaft26chytcdn not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 18:11:02Z] DELETE pod usaft26chytcdn
+[t=   63.9s 18:11:03Z] delete returned status=204 resp={}
+[t=   69.4s 18:11:09Z] pod usaft26chytcdn confirmed terminated (404)
+[t=   69.4s 18:11:09Z] PROBE: pod usaft26chytcdn torn down
+[t=    0.0s 18:11:09Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 18:11:09Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.7s 18:11:10Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.7s 18:11:10Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:11:28Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 18:11:28Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 18:11:30Z] create OK id=xh2sldpntosnro costPerHr=$1.49
+[t=    1.2s 18:11:30Z] PROBE: pod created id=xh2sldpntosnro; waiting for publicIp+ssh_port
+[t=    1.5s 18:11:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 18:11:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 18:12:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 18:12:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.7s 18:12:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.2s 18:12:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.7s 18:13:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.1s 18:13:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.1s 18:13:33Z] PROBE NO-GO: pod xh2sldpntosnro not RUNNING+SSH within 120s; tearing down
+[t=  125.1s 18:13:33Z] DELETE pod xh2sldpntosnro
+[t=  125.7s 18:13:34Z] delete returned status=204 resp={}
+[t=  131.1s 18:13:39Z] pod xh2sldpntosnro confirmed terminated (404)
+[t=  131.1s 18:13:39Z] PROBE: pod xh2sldpntosnro torn down
+[t=    0.0s 18:13:40Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:13:40Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 18:13:40Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 18:13:40Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:13:40Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:13:40Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 18:13:42Z] create OK id=9juzeqlav4dqoc costPerHr=$3.29
+[t=    1.2s 18:13:42Z] PROBE: pod created id=9juzeqlav4dqoc; waiting for publicIp+ssh_port
+[t=    1.7s 18:13:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 18:13:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 18:14:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.7s 18:14:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.7s 18:14:44Z] PROBE NO-GO: pod 9juzeqlav4dqoc not RUNNING+SSH within 60s; tearing down
+[t=   63.7s 18:14:44Z] DELETE pod 9juzeqlav4dqoc
+[t=   64.3s 18:14:45Z] delete returned status=204 resp={}
+[t=   69.6s 18:14:50Z] pod 9juzeqlav4dqoc confirmed terminated (404)
+[t=   69.6s 18:14:50Z] PROBE: pod 9juzeqlav4dqoc torn down
+[t=    0.0s 18:14:50Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:14:50Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 18:14:51Z] create OK id=oh7a5na2wxqxux costPerHr=$2.89
+[t=    1.2s 18:14:51Z] PROBE: pod created id=oh7a5na2wxqxux; waiting for publicIp+ssh_port
+[t=    1.5s 18:14:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 18:15:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 18:15:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 18:15:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 18:15:53Z] PROBE NO-GO: pod oh7a5na2wxqxux not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 18:15:53Z] DELETE pod oh7a5na2wxqxux
+[t=   63.5s 18:15:54Z] delete returned status=204 resp={}
+[t=   68.8s 18:15:59Z] pod oh7a5na2wxqxux confirmed terminated (404)
+[t=   68.9s 18:15:59Z] PROBE: pod oh7a5na2wxqxux torn down
+[t=    0.0s 18:15:59Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 18:15:59Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 18:16:00Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 18:16:00Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:16:20Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 18:16:20Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 18:16:21Z] create OK id=h5oo9qmbze8o0r costPerHr=$1.49
+[t=    1.0s 18:16:21Z] PROBE: pod created id=h5oo9qmbze8o0r; waiting for publicIp+ssh_port
+[t=    1.3s 18:16:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 18:16:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 18:16:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 18:17:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 18:17:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.8s 18:17:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.1s 18:17:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.4s 18:18:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.4s 18:18:26Z] PROBE NO-GO: pod h5oo9qmbze8o0r not RUNNING+SSH within 120s; tearing down
+[t=  125.4s 18:18:26Z] DELETE pod h5oo9qmbze8o0r
+[t=  126.0s 18:18:26Z] delete returned status=204 resp={}
+[t=  131.4s 18:18:31Z] pod h5oo9qmbze8o0r confirmed terminated (404)
+[t=  131.4s 18:18:31Z] PROBE: pod h5oo9qmbze8o0r torn down
+[t=    0.0s 18:18:32Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:18:32Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 18:18:33Z] create OK id=q3wwb70ar1xqjw costPerHr=$1.39
+[t=    1.2s 18:18:33Z] PROBE: pod created id=q3wwb70ar1xqjw; waiting for publicIp+ssh_port
+[t=    1.6s 18:18:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 18:18:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 18:19:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 18:19:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 18:19:34Z] PROBE NO-GO: pod q3wwb70ar1xqjw not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 18:19:34Z] DELETE pod q3wwb70ar1xqjw
+[t=   63.3s 18:19:35Z] delete returned status=204 resp={}
+[t=   68.7s 18:19:40Z] pod q3wwb70ar1xqjw confirmed terminated (404)
+[t=   68.7s 18:19:40Z] PROBE: pod q3wwb70ar1xqjw torn down
+[t=    0.0s 18:19:41Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:19:41Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 18:19:42Z] create OK id=qbghs8ma9d0yd5 costPerHr=$3.29
+[t=    1.5s 18:19:42Z] PROBE: pod created id=qbghs8ma9d0yd5; waiting for publicIp+ssh_port
+[t=    2.1s 18:19:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 18:19:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 18:20:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 18:20:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.2s 18:20:45Z] PROBE NO-GO: pod qbghs8ma9d0yd5 not RUNNING+SSH within 60s; tearing down
+[t=   64.2s 18:20:45Z] DELETE pod qbghs8ma9d0yd5
+[t=   64.7s 18:20:45Z] delete returned status=204 resp={}
+[t=   70.1s 18:20:51Z] pod qbghs8ma9d0yd5 confirmed terminated (404)
+[t=   70.1s 18:20:51Z] PROBE: pod qbghs8ma9d0yd5 torn down
+[t=    0.0s 18:20:51Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:20:51Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 18:20:52Z] create OK id=4w8kbkqyf9pj8u costPerHr=$2.89
+[t=    1.3s 18:20:52Z] PROBE: pod created id=4w8kbkqyf9pj8u; waiting for publicIp+ssh_port
+[t=    1.7s 18:20:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 18:21:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 18:21:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 18:21:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 18:21:54Z] PROBE NO-GO: pod 4w8kbkqyf9pj8u not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 18:21:54Z] DELETE pod 4w8kbkqyf9pj8u
+[t=   63.6s 18:21:54Z] delete returned status=204 resp={}
+[t=   69.0s 18:22:00Z] pod 4w8kbkqyf9pj8u confirmed terminated (404)
+[t=   69.0s 18:22:00Z] PROBE: pod 4w8kbkqyf9pj8u torn down
+[t=    0.0s 18:22:00Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 18:22:00Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.7s 18:22:01Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.7s 18:22:01Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:22:16Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 18:22:16Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 18:22:17Z] create OK id=s75eui60qjruhz costPerHr=$1.49
+[t=    1.0s 18:22:17Z] PROBE: pod created id=s75eui60qjruhz; waiting for publicIp+ssh_port
+[t=    1.3s 18:22:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 18:22:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 18:22:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 18:23:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 18:23:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.2s 18:23:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.6s 18:23:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.1s 18:24:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.1s 18:24:20Z] PROBE NO-GO: pod s75eui60qjruhz not RUNNING+SSH within 120s; tearing down
+[t=  124.1s 18:24:20Z] DELETE pod s75eui60qjruhz
+[t=  124.7s 18:24:21Z] delete returned status=204 resp={}
+[t=  130.0s 18:24:26Z] pod s75eui60qjruhz confirmed terminated (404)
+[t=  130.0s 18:24:26Z] PROBE: pod s75eui60qjruhz torn down
+[t=    0.0s 18:24:26Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:24:26Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 18:24:27Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 18:24:27Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:24:27Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:24:27Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 18:24:28Z] create OK id=mx5fbal1ewcpt6 costPerHr=$3.29
+[t=    1.4s 18:24:28Z] PROBE: pod created id=mx5fbal1ewcpt6; waiting for publicIp+ssh_port
+[t=    1.9s 18:24:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 18:24:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.7s 18:25:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.4s 18:25:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 18:25:31Z] PROBE NO-GO: pod mx5fbal1ewcpt6 not RUNNING+SSH within 60s; tearing down
+[t=   64.5s 18:25:31Z] DELETE pod mx5fbal1ewcpt6
+[t=   65.0s 18:25:32Z] delete returned status=204 resp={}
+[t=   71.4s 18:25:38Z] pod mx5fbal1ewcpt6 confirmed terminated (404)
+[t=   71.4s 18:25:38Z] PROBE: pod mx5fbal1ewcpt6 torn down
+[t=    0.0s 18:25:38Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:25:38Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 18:25:40Z] create OK id=cgzm7c4ku2c7oz costPerHr=$2.89
+[t=    1.1s 18:25:40Z] PROBE: pod created id=cgzm7c4ku2c7oz; waiting for publicIp+ssh_port
+[t=    1.4s 18:25:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 18:25:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 18:26:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 18:26:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 18:26:41Z] PROBE NO-GO: pod cgzm7c4ku2c7oz not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 18:26:41Z] DELETE pod cgzm7c4ku2c7oz
+[t=   63.1s 18:26:42Z] delete returned status=204 resp={}
+[t=   68.6s 18:26:47Z] pod cgzm7c4ku2c7oz confirmed terminated (404)
+[t=   68.6s 18:26:47Z] PROBE: pod cgzm7c4ku2c7oz torn down
+[t=    0.0s 18:26:47Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 18:26:47Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 18:26:48Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 18:26:48Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:27:11Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 18:27:11Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 18:27:12Z] create OK id=nglxnsxdnuz66w costPerHr=$1.49
+[t=    1.0s 18:27:12Z] PROBE: pod created id=nglxnsxdnuz66w; waiting for publicIp+ssh_port
+[t=    1.6s 18:27:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 18:27:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 18:27:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 18:27:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 18:28:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.6s 18:28:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.0s 18:28:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.3s 18:29:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.3s 18:29:15Z] PROBE NO-GO: pod nglxnsxdnuz66w not RUNNING+SSH within 120s; tearing down
+[t=  124.3s 18:29:15Z] DELETE pod nglxnsxdnuz66w
+[t=  124.8s 18:29:16Z] delete returned status=204 resp={}
+[t=  130.2s 18:29:21Z] pod nglxnsxdnuz66w confirmed terminated (404)
+[t=  130.2s 18:29:21Z] PROBE: pod nglxnsxdnuz66w torn down
+[t=    0.0s 18:29:21Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:29:21Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 18:29:22Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 18:29:22Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:29:22Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:29:22Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 18:29:23Z] create OK id=i5qv2evmar1kq7 costPerHr=$3.29
+[t=    1.1s 18:29:23Z] PROBE: pod created id=i5qv2evmar1kq7; waiting for publicIp+ssh_port
+[t=    1.4s 18:29:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 18:29:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 18:29:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 18:30:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 18:30:25Z] PROBE NO-GO: pod i5qv2evmar1kq7 not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 18:30:25Z] DELETE pod i5qv2evmar1kq7
+[t=   63.2s 18:30:25Z] delete returned status=204 resp={}
+[t=   68.6s 18:30:31Z] pod i5qv2evmar1kq7 confirmed terminated (404)
+[t=   68.6s 18:30:31Z] PROBE: pod i5qv2evmar1kq7 torn down
+[t=    0.0s 18:30:31Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:30:31Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 18:30:32Z] create OK id=2r0h1ez4mecjef costPerHr=$2.89
+[t=    1.1s 18:30:32Z] PROBE: pod created id=2r0h1ez4mecjef; waiting for publicIp+ssh_port
+[t=    1.9s 18:30:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 18:30:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 18:31:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 18:31:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 18:31:34Z] PROBE NO-GO: pod 2r0h1ez4mecjef not RUNNING+SSH within 60s; tearing down
+[t=   63.3s 18:31:34Z] DELETE pod 2r0h1ez4mecjef
+[t=   63.9s 18:31:35Z] delete returned status=204 resp={}
+[t=   69.2s 18:31:40Z] pod 2r0h1ez4mecjef confirmed terminated (404)
+[t=   69.2s 18:31:40Z] PROBE: pod 2r0h1ez4mecjef torn down
+[t=    0.0s 18:31:40Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 18:31:40Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 18:31:41Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 18:31:41Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:31:57Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 18:31:57Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 18:31:58Z] create OK id=9zk0m4hyemrucy costPerHr=$1.49
+[t=    1.0s 18:31:58Z] PROBE: pod created id=9zk0m4hyemrucy; waiting for publicIp+ssh_port
+[t=    1.3s 18:31:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 18:32:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 18:32:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 18:32:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 18:33:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.5s 18:33:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.9s 18:33:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.2s 18:33:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.2s 18:34:01Z] PROBE NO-GO: pod 9zk0m4hyemrucy not RUNNING+SSH within 120s; tearing down
+[t=  124.2s 18:34:01Z] DELETE pod 9zk0m4hyemrucy
+[t=  125.0s 18:34:02Z] delete returned status=204 resp={}
+[t=  130.4s 18:34:07Z] pod 9zk0m4hyemrucy confirmed terminated (404)
+[t=  130.4s 18:34:07Z] PROBE: pod 9zk0m4hyemrucy torn down
+[t=    0.0s 18:34:08Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:34:08Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.8s 18:34:08Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.8s 18:34:08Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:34:09Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:34:09Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 18:34:10Z] create OK id=2pp19vgn1p2nlc costPerHr=$3.29
+[t=    1.4s 18:34:10Z] PROBE: pod created id=2pp19vgn1p2nlc; waiting for publicIp+ssh_port
+[t=    1.9s 18:34:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 18:34:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.2s 18:34:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.9s 18:34:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.9s 18:35:13Z] PROBE NO-GO: pod 2pp19vgn1p2nlc not RUNNING+SSH within 60s; tearing down
+[t=   63.9s 18:35:13Z] DELETE pod 2pp19vgn1p2nlc
+[t=   64.4s 18:35:13Z] delete returned status=204 resp={}
+[t=   69.8s 18:35:18Z] pod 2pp19vgn1p2nlc confirmed terminated (404)
+[t=   69.8s 18:35:18Z] PROBE: pod 2pp19vgn1p2nlc torn down
+[t=    0.0s 18:35:19Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:35:19Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 18:35:20Z] create OK id=8xbev5akfqpu4b costPerHr=$2.89
+[t=    1.1s 18:35:20Z] PROBE: pod created id=8xbev5akfqpu4b; waiting for publicIp+ssh_port
+[t=    1.4s 18:35:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 18:35:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 18:35:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 18:36:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 18:36:21Z] PROBE NO-GO: pod 8xbev5akfqpu4b not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 18:36:21Z] DELETE pod 8xbev5akfqpu4b
+[t=   63.3s 18:36:22Z] delete returned status=204 resp={}
+[t=   68.6s 18:36:27Z] pod 8xbev5akfqpu4b confirmed terminated (404)
+[t=   68.6s 18:36:27Z] PROBE: pod 8xbev5akfqpu4b torn down
+[t=    0.0s 18:36:27Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 18:36:27Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 18:36:28Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 18:36:28Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:36:45Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 18:36:45Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 18:36:47Z] create OK id=i6usmsy6rmvnxp costPerHr=$1.49
+[t=    1.1s 18:36:47Z] PROBE: pod created id=i6usmsy6rmvnxp; waiting for publicIp+ssh_port
+[t=    1.4s 18:36:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 18:37:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.2s 18:37:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.8s 18:37:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 18:37:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.5s 18:38:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.9s 18:38:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.2s 18:38:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.2s 18:38:51Z] PROBE NO-GO: pod i6usmsy6rmvnxp not RUNNING+SSH within 120s; tearing down
+[t=  125.2s 18:38:51Z] DELETE pod i6usmsy6rmvnxp
+[t=  125.8s 18:38:51Z] delete returned status=204 resp={}
+[t=  131.2s 18:38:57Z] pod i6usmsy6rmvnxp confirmed terminated (404)
+[t=  131.2s 18:38:57Z] PROBE: pod i6usmsy6rmvnxp torn down
+[t=    0.0s 18:38:57Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:38:57Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 18:38:58Z] create OK id=tkbykzmpsx0neq costPerHr=$1.39
+[t=    1.1s 18:38:58Z] PROBE: pod created id=tkbykzmpsx0neq; waiting for publicIp+ssh_port
+[t=    1.4s 18:38:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 18:39:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 18:39:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 18:39:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 18:40:00Z] PROBE NO-GO: pod tkbykzmpsx0neq not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 18:40:00Z] DELETE pod tkbykzmpsx0neq
+[t=   63.1s 18:40:00Z] delete returned status=204 resp={}
+[t=   68.6s 18:40:06Z] pod tkbykzmpsx0neq confirmed terminated (404)
+[t=   68.6s 18:40:06Z] PROBE: pod tkbykzmpsx0neq torn down
+[t=    0.0s 18:40:06Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:40:06Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 18:40:07Z] create OK id=zpkv2h5qaz9172 costPerHr=$3.29
+[t=    1.4s 18:40:07Z] PROBE: pod created id=zpkv2h5qaz9172; waiting for publicIp+ssh_port
+[t=    2.0s 18:40:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 18:40:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.5s 18:40:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 18:40:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 18:41:10Z] PROBE NO-GO: pod zpkv2h5qaz9172 not RUNNING+SSH within 60s; tearing down
+[t=   64.1s 18:41:10Z] DELETE pod zpkv2h5qaz9172
+[t=   64.7s 18:41:11Z] delete returned status=204 resp={}
+[t=   70.0s 18:41:16Z] pod zpkv2h5qaz9172 confirmed terminated (404)
+[t=   70.0s 18:41:16Z] PROBE: pod zpkv2h5qaz9172 torn down
+[t=    0.0s 18:41:16Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:41:16Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.8s 18:41:18Z] create OK id=leh5xdveimi7r7 costPerHr=$2.89
+[t=    1.8s 18:41:18Z] PROBE: pod created id=leh5xdveimi7r7; waiting for publicIp+ssh_port
+[t=    2.1s 18:41:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.6s 18:41:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.0s 18:41:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.4s 18:42:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.4s 18:42:19Z] PROBE NO-GO: pod leh5xdveimi7r7 not RUNNING+SSH within 60s; tearing down
+[t=   63.4s 18:42:19Z] DELETE pod leh5xdveimi7r7
+[t=   64.1s 18:42:20Z] delete returned status=204 resp={}
+[t=   69.4s 18:42:25Z] pod leh5xdveimi7r7 confirmed terminated (404)
+[t=   69.4s 18:42:25Z] PROBE: pod leh5xdveimi7r7 torn down
+[t=    0.0s 18:42:26Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 18:42:26Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 18:42:26Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 18:42:26Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:42:44Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 18:42:44Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 18:42:45Z] create OK id=vkbiyurlqq8zet costPerHr=$1.49
+[t=    1.1s 18:42:45Z] PROBE: pod created id=vkbiyurlqq8zet; waiting for publicIp+ssh_port
+[t=    1.4s 18:42:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 18:43:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 18:43:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 18:43:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 18:43:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.5s 18:44:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.8s 18:44:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.2s 18:44:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.2s 18:44:48Z] PROBE NO-GO: pod vkbiyurlqq8zet not RUNNING+SSH within 120s; tearing down
+[t=  124.2s 18:44:48Z] DELETE pod vkbiyurlqq8zet
+[t=  124.8s 18:44:49Z] delete returned status=204 resp={}
+[t=  130.1s 18:44:54Z] pod vkbiyurlqq8zet confirmed terminated (404)
+[t=  130.1s 18:44:54Z] PROBE: pod vkbiyurlqq8zet torn down
+[t=    0.0s 18:44:54Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:44:54Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 18:44:55Z] create OK id=2ge5ikk6dbbagw costPerHr=$1.39
+[t=    1.0s 18:44:55Z] PROBE: pod created id=2ge5ikk6dbbagw; waiting for publicIp+ssh_port
+[t=    1.3s 18:44:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 18:45:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 18:45:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 18:45:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 18:45:57Z] PROBE NO-GO: pod 2ge5ikk6dbbagw not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 18:45:57Z] DELETE pod 2ge5ikk6dbbagw
+[t=   63.2s 18:45:58Z] delete returned status=204 resp={}
+[t=   68.5s 18:46:03Z] pod 2ge5ikk6dbbagw confirmed terminated (404)
+[t=   68.5s 18:46:03Z] PROBE: pod 2ge5ikk6dbbagw torn down
+[t=    0.0s 18:46:03Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:46:03Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 18:46:05Z] create OK id=iqjray3bsheuw0 costPerHr=$3.29
+[t=    1.5s 18:46:05Z] PROBE: pod created id=iqjray3bsheuw0; waiting for publicIp+ssh_port
+[t=    2.0s 18:46:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 18:46:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 18:46:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.0s 18:46:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.0s 18:47:07Z] PROBE NO-GO: pod iqjray3bsheuw0 not RUNNING+SSH within 60s; tearing down
+[t=   64.0s 18:47:07Z] DELETE pod iqjray3bsheuw0
+[t=   64.6s 18:47:08Z] delete returned status=204 resp={}
+[t=   70.0s 18:47:13Z] pod iqjray3bsheuw0 confirmed terminated (404)
+[t=   70.0s 18:47:13Z] PROBE: pod iqjray3bsheuw0 torn down
+[t=    0.0s 18:47:13Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:47:13Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 18:47:14Z] create OK id=4tnubhh91awsap costPerHr=$2.89
+[t=    1.1s 18:47:14Z] PROBE: pod created id=4tnubhh91awsap; waiting for publicIp+ssh_port
+[t=    1.5s 18:47:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 18:47:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 18:47:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 18:48:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 18:48:16Z] PROBE NO-GO: pod 4tnubhh91awsap not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 18:48:16Z] DELETE pod 4tnubhh91awsap
+[t=   63.2s 18:48:17Z] delete returned status=204 resp={}
+[t=   68.6s 18:48:22Z] pod 4tnubhh91awsap confirmed terminated (404)
+[t=   68.6s 18:48:22Z] PROBE: pod 4tnubhh91awsap torn down
+[t=    0.0s 18:48:22Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 18:48:22Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 18:48:23Z] create OK id=xev0lrg76d2lmf costPerHr=$1.39
+[t=    0.9s 18:48:23Z] PROBE: pod created id=xev0lrg76d2lmf; waiting for publicIp+ssh_port
+[t=    1.2s 18:48:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 18:48:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 18:48:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 18:49:10Z] poll desiredStatus=EXITED publicIp= ssh_port=None
+[t=   62.4s 18:49:25Z] PROBE NO-GO: pod xev0lrg76d2lmf not RUNNING+SSH within 60s; tearing down
+[t=   62.4s 18:49:25Z] DELETE pod xev0lrg76d2lmf
+[t=   63.0s 18:49:25Z] delete returned status=204 resp={}
+[t=   68.4s 18:49:31Z] pod xev0lrg76d2lmf confirmed terminated (404)
+[t=   68.4s 18:49:31Z] PROBE: pod xev0lrg76d2lmf torn down
+[t=    0.0s 18:49:48Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 18:49:48Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 18:49:49Z] create OK id=8bnml7se0lmuw7 costPerHr=$1.49
+[t=    1.1s 18:49:49Z] PROBE: pod created id=8bnml7se0lmuw7; waiting for publicIp+ssh_port
+[t=    1.4s 18:49:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 18:50:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 18:50:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 18:50:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 18:50:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.3s 18:51:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.6s 18:51:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.0s 18:51:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.0s 18:51:52Z] PROBE NO-GO: pod 8bnml7se0lmuw7 not RUNNING+SSH within 120s; tearing down
+[t=  124.0s 18:51:52Z] DELETE pod 8bnml7se0lmuw7
+[t=  124.5s 18:51:53Z] delete returned status=204 resp={}
+[t=  129.9s 18:51:58Z] pod 8bnml7se0lmuw7 confirmed terminated (404)
+[t=  129.9s 18:51:58Z] PROBE: pod 8bnml7se0lmuw7 torn down
+[t=    0.0s 18:51:58Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:51:58Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 18:51:59Z] create OK id=tyyw1exgoosii7 costPerHr=$1.39
+[t=    1.1s 18:51:59Z] PROBE: pod created id=tyyw1exgoosii7; waiting for publicIp+ssh_port
+[t=    1.4s 18:52:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 18:52:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 18:52:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 18:52:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 18:53:01Z] PROBE NO-GO: pod tyyw1exgoosii7 not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 18:53:01Z] DELETE pod tyyw1exgoosii7
+[t=   63.3s 18:53:02Z] delete returned status=204 resp={}
+[t=   68.7s 18:53:07Z] pod tyyw1exgoosii7 confirmed terminated (404)
+[t=   68.7s 18:53:07Z] PROBE: pod tyyw1exgoosii7 torn down
+[t=    0.0s 18:53:07Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:53:07Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 18:53:08Z] create OK id=r8lf4mqf02xocs costPerHr=$3.29
+[t=    1.0s 18:53:08Z] PROBE: pod created id=r8lf4mqf02xocs; waiting for publicIp+ssh_port
+[t=    1.3s 18:53:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 18:53:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 18:53:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 18:53:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 18:54:10Z] PROBE NO-GO: pod r8lf4mqf02xocs not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 18:54:10Z] DELETE pod r8lf4mqf02xocs
+[t=   63.4s 18:54:11Z] delete returned status=204 resp={}
+[t=   69.2s 18:54:16Z] pod r8lf4mqf02xocs confirmed terminated (404)
+[t=   69.2s 18:54:16Z] PROBE: pod r8lf4mqf02xocs torn down
+[t=    0.0s 18:54:17Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:54:17Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 18:54:18Z] create OK id=lgcx327xbmjcs1 costPerHr=$2.89
+[t=    1.0s 18:54:18Z] PROBE: pod created id=lgcx327xbmjcs1; waiting for publicIp+ssh_port
+[t=    1.3s 18:54:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 18:54:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 18:54:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 18:55:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 18:55:19Z] PROBE NO-GO: pod lgcx327xbmjcs1 not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 18:55:19Z] DELETE pod lgcx327xbmjcs1
+[t=   63.4s 18:55:20Z] delete returned status=204 resp={}
+[t=   68.7s 18:55:25Z] pod lgcx327xbmjcs1 confirmed terminated (404)
+[t=   68.7s 18:55:25Z] PROBE: pod lgcx327xbmjcs1 torn down
+[t=    0.0s 18:55:25Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 18:55:25Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 18:55:26Z] create OK id=pq9wajppwqodji costPerHr=$1.39
+[t=    0.9s 18:55:26Z] PROBE: pod created id=pq9wajppwqodji; waiting for publicIp+ssh_port
+[t=    1.2s 18:55:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.6s 18:55:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 18:55:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.3s 18:56:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.3s 18:56:28Z] PROBE NO-GO: pod pq9wajppwqodji not RUNNING+SSH within 60s; tearing down
+[t=   62.3s 18:56:28Z] DELETE pod pq9wajppwqodji
+[t=   62.9s 18:56:28Z] delete returned status=204 resp={}
+[t=   68.2s 18:56:34Z] pod pq9wajppwqodji confirmed terminated (404)
+[t=   68.2s 18:56:34Z] PROBE: pod pq9wajppwqodji torn down
+[t=    0.0s 18:56:49Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 18:56:49Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 18:56:50Z] create OK id=88a7ghoh81srxz costPerHr=$1.49
+[t=    1.1s 18:56:50Z] PROBE: pod created id=88a7ghoh81srxz; waiting for publicIp+ssh_port
+[t=    1.4s 18:56:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 18:57:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 18:57:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 18:57:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 18:57:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.6s 18:58:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.2s 18:58:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.5s 18:58:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.5s 18:58:53Z] PROBE NO-GO: pod 88a7ghoh81srxz not RUNNING+SSH within 120s; tearing down
+[t=  124.5s 18:58:53Z] DELETE pod 88a7ghoh81srxz
+[t=  125.0s 18:58:54Z] delete returned status=204 resp={}
+[t=  130.4s 18:58:59Z] pod 88a7ghoh81srxz confirmed terminated (404)
+[t=  130.4s 18:58:59Z] PROBE: pod 88a7ghoh81srxz torn down
+[t=    0.0s 18:58:59Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:58:59Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 18:59:00Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 18:59:00Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 18:59:00Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 18:59:00Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 18:59:02Z] create OK id=wro3f0iugm8udg costPerHr=$3.29
+[t=    1.6s 18:59:02Z] PROBE: pod created id=wro3f0iugm8udg; waiting for publicIp+ssh_port
+[t=    2.1s 18:59:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.1s 18:59:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.9s 18:59:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.6s 18:59:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.6s 19:00:05Z] PROBE NO-GO: pod wro3f0iugm8udg not RUNNING+SSH within 60s; tearing down
+[t=   64.6s 19:00:05Z] DELETE pod wro3f0iugm8udg
+[t=   65.2s 19:00:05Z] delete returned status=204 resp={}
+[t=   70.7s 19:00:11Z] pod wro3f0iugm8udg confirmed terminated (404)
+[t=   70.7s 19:00:11Z] PROBE: pod wro3f0iugm8udg torn down
+[t=    0.0s 19:00:11Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:00:11Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 19:00:12Z] create OK id=m18hxoiqq5vn6e costPerHr=$2.89
+[t=    1.3s 19:00:12Z] PROBE: pod created id=m18hxoiqq5vn6e; waiting for publicIp+ssh_port
+[t=    2.2s 19:00:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 19:00:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.1s 19:00:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.5s 19:01:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.6s 19:01:15Z] PROBE NO-GO: pod m18hxoiqq5vn6e not RUNNING+SSH within 60s; tearing down
+[t=   63.6s 19:01:15Z] DELETE pod m18hxoiqq5vn6e
+[t=   64.1s 19:01:15Z] delete returned status=204 resp={}
+[t=   69.5s 19:01:21Z] pod m18hxoiqq5vn6e confirmed terminated (404)
+[t=   69.5s 19:01:21Z] PROBE: pod m18hxoiqq5vn6e torn down
+[t=    0.0s 19:01:21Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 19:01:21Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.8s 19:01:22Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.8s 19:01:22Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:01:40Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 19:01:40Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 19:01:41Z] create OK id=7sywd02lvq8ej4 costPerHr=$1.49
+[t=    1.0s 19:01:41Z] PROBE: pod created id=7sywd02lvq8ej4; waiting for publicIp+ssh_port
+[t=    1.2s 19:01:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 19:01:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 19:02:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.3s 19:02:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 19:02:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.0s 19:02:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.4s 19:03:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  108.7s 19:03:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  123.8s 19:03:44Z] PROBE NO-GO: pod 7sywd02lvq8ej4 not RUNNING+SSH within 120s; tearing down
+[t=  123.8s 19:03:44Z] DELETE pod 7sywd02lvq8ej4
+[t=  124.3s 19:03:45Z] delete returned status=204 resp={}
+[t=  129.8s 19:03:50Z] pod 7sywd02lvq8ej4 confirmed terminated (404)
+[t=  129.8s 19:03:50Z] PROBE: pod 7sywd02lvq8ej4 torn down
+[t=    0.0s 19:03:50Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:03:50Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 19:03:51Z] create OK id=nkvcv2ysrf10ez costPerHr=$1.39
+[t=    1.2s 19:03:51Z] PROBE: pod created id=nkvcv2ysrf10ez; waiting for publicIp+ssh_port
+[t=    1.5s 19:03:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 19:04:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 19:04:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 19:04:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 19:04:53Z] PROBE NO-GO: pod nkvcv2ysrf10ez not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 19:04:53Z] DELETE pod nkvcv2ysrf10ez
+[t=   63.3s 19:04:54Z] delete returned status=204 resp={}
+[t=   68.7s 19:04:59Z] pod nkvcv2ysrf10ez confirmed terminated (404)
+[t=   68.7s 19:04:59Z] PROBE: pod nkvcv2ysrf10ez torn down
+[t=    0.0s 19:04:59Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:04:59Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 19:05:00Z] create OK id=9znwl6w1qhv7dg costPerHr=$3.29
+[t=    1.3s 19:05:00Z] PROBE: pod created id=9znwl6w1qhv7dg; waiting for publicIp+ssh_port
+[t=    1.8s 19:05:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 19:05:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 19:05:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.1s 19:05:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 19:06:02Z] PROBE NO-GO: pod 9znwl6w1qhv7dg not RUNNING+SSH within 60s; tearing down
+[t=   63.1s 19:06:02Z] DELETE pod 9znwl6w1qhv7dg
+[t=   63.7s 19:06:03Z] delete returned status=204 resp={}
+[t=   69.2s 19:06:08Z] pod 9znwl6w1qhv7dg confirmed terminated (404)
+[t=   69.2s 19:06:08Z] PROBE: pod 9znwl6w1qhv7dg torn down
+[t=    0.0s 19:06:09Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:06:09Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 19:06:10Z] create OK id=t948lty2jm0l8m costPerHr=$2.89
+[t=    1.2s 19:06:10Z] PROBE: pod created id=t948lty2jm0l8m; waiting for publicIp+ssh_port
+[t=    1.5s 19:06:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 19:06:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 19:06:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 19:06:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 19:07:11Z] PROBE NO-GO: pod t948lty2jm0l8m not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 19:07:11Z] DELETE pod t948lty2jm0l8m
+[t=   63.4s 19:07:12Z] delete returned status=204 resp={}
+[t=   68.8s 19:07:17Z] pod t948lty2jm0l8m confirmed terminated (404)
+[t=   68.8s 19:07:17Z] PROBE: pod t948lty2jm0l8m torn down
+[t=    0.0s 19:07:18Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 19:07:18Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 19:07:18Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 19:07:18Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:07:36Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 19:07:36Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 19:07:37Z] create OK id=reelqrujsc7j2e costPerHr=$1.49
+[t=    1.1s 19:07:37Z] PROBE: pod created id=reelqrujsc7j2e; waiting for publicIp+ssh_port
+[t=    1.4s 19:07:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 19:07:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 19:08:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 19:08:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 19:08:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.5s 19:08:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.9s 19:09:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.2s 19:09:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.2s 19:09:40Z] PROBE NO-GO: pod reelqrujsc7j2e not RUNNING+SSH within 120s; tearing down
+[t=  124.2s 19:09:40Z] DELETE pod reelqrujsc7j2e
+[t=  124.8s 19:09:41Z] delete returned status=204 resp={}
+[t=  130.1s 19:09:46Z] pod reelqrujsc7j2e confirmed terminated (404)
+[t=  130.1s 19:09:46Z] PROBE: pod reelqrujsc7j2e torn down
+[t=    0.0s 19:09:46Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:09:46Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 19:09:47Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.8s 19:09:47Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:09:47Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:09:47Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 19:09:48Z] create OK id=93hmv46psnawbd costPerHr=$3.29
+[t=    1.4s 19:09:48Z] PROBE: pod created id=93hmv46psnawbd; waiting for publicIp+ssh_port
+[t=    1.9s 19:09:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 19:10:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 19:10:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 19:10:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 19:10:50Z] PROBE NO-GO: pod 93hmv46psnawbd not RUNNING+SSH within 60s; tearing down
+[t=   63.2s 19:10:50Z] DELETE pod 93hmv46psnawbd
+[t=   63.9s 19:10:51Z] delete returned status=204 resp={}
+[t=   69.5s 19:10:56Z] pod 93hmv46psnawbd confirmed terminated (404)
+[t=   69.5s 19:10:56Z] PROBE: pod 93hmv46psnawbd torn down
+[t=    0.0s 19:10:57Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:10:57Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 19:10:58Z] create OK id=flleqbdcmzpf8u costPerHr=$2.89
+[t=    1.2s 19:10:58Z] PROBE: pod created id=flleqbdcmzpf8u; waiting for publicIp+ssh_port
+[t=    1.5s 19:10:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 19:11:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 19:11:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 19:11:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 19:11:59Z] PROBE NO-GO: pod flleqbdcmzpf8u not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 19:11:59Z] DELETE pod flleqbdcmzpf8u
+[t=   63.3s 19:12:00Z] delete returned status=204 resp={}
+[t=   68.7s 19:12:05Z] pod flleqbdcmzpf8u confirmed terminated (404)
+[t=   68.7s 19:12:05Z] PROBE: pod flleqbdcmzpf8u torn down
+[t=    0.0s 19:12:06Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 19:12:06Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 19:12:07Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    1.0s 19:12:07Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:12:23Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 19:12:23Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 19:12:24Z] create OK id=ce8k1smali0pxm costPerHr=$1.49
+[t=    1.3s 19:12:24Z] PROBE: pod created id=ce8k1smali0pxm; waiting for publicIp+ssh_port
+[t=    1.6s 19:12:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 19:12:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 19:12:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 19:13:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 19:13:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.6s 19:13:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.9s 19:13:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.3s 19:14:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.3s 19:14:27Z] PROBE NO-GO: pod ce8k1smali0pxm not RUNNING+SSH within 120s; tearing down
+[t=  124.3s 19:14:27Z] DELETE pod ce8k1smali0pxm
+[t=  124.8s 19:14:28Z] delete returned status=204 resp={}
+[t=  130.1s 19:14:33Z] pod ce8k1smali0pxm confirmed terminated (404)
+[t=  130.1s 19:14:33Z] PROBE: pod ce8k1smali0pxm torn down
+[t=    0.0s 19:14:33Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:14:33Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 19:14:34Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 19:14:34Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:14:34Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:14:34Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 19:14:35Z] create OK id=mok6y8eeiovsy7 costPerHr=$3.29
+[t=    1.3s 19:14:35Z] PROBE: pod created id=mok6y8eeiovsy7; waiting for publicIp+ssh_port
+[t=    1.8s 19:14:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 19:14:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 19:15:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.6s 19:15:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.6s 19:15:38Z] PROBE NO-GO: pod mok6y8eeiovsy7 not RUNNING+SSH within 60s; tearing down
+[t=   63.6s 19:15:38Z] DELETE pod mok6y8eeiovsy7
+[t=   64.2s 19:15:38Z] delete returned status=204 resp={}
+[t=   69.5s 19:15:44Z] pod mok6y8eeiovsy7 confirmed terminated (404)
+[t=   69.5s 19:15:44Z] PROBE: pod mok6y8eeiovsy7 torn down
+[t=    0.0s 19:15:44Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:15:44Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 19:15:45Z] create OK id=85h4bx5bdett80 costPerHr=$2.89
+[t=    1.3s 19:15:45Z] PROBE: pod created id=85h4bx5bdett80; waiting for publicIp+ssh_port
+[t=    1.7s 19:15:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 19:16:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 19:16:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 19:16:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 19:16:47Z] PROBE NO-GO: pod 85h4bx5bdett80 not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 19:16:47Z] DELETE pod 85h4bx5bdett80
+[t=   63.5s 19:16:47Z] delete returned status=204 resp={}
+[t=   68.9s 19:16:53Z] pod 85h4bx5bdett80 confirmed terminated (404)
+[t=   68.9s 19:16:53Z] PROBE: pod 85h4bx5bdett80 torn down
+[t=    0.0s 19:16:53Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 19:16:53Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.7s 19:16:54Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.7s 19:16:54Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:17:12Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 19:17:12Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 19:17:13Z] create OK id=9hhyhmrmh7bczk costPerHr=$1.49
+[t=    1.1s 19:17:13Z] PROBE: pod created id=9hhyhmrmh7bczk; waiting for publicIp+ssh_port
+[t=    1.4s 19:17:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 19:17:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 19:17:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 19:18:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 19:18:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.6s 19:18:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.0s 19:18:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.3s 19:19:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.3s 19:19:16Z] PROBE NO-GO: pod 9hhyhmrmh7bczk not RUNNING+SSH within 120s; tearing down
+[t=  124.3s 19:19:16Z] DELETE pod 9hhyhmrmh7bczk
+[t=  124.9s 19:19:17Z] delete returned status=204 resp={}
+[t=  130.3s 19:19:22Z] pod 9hhyhmrmh7bczk confirmed terminated (404)
+[t=  130.3s 19:19:22Z] PROBE: pod 9hhyhmrmh7bczk torn down
+[t=    0.0s 19:19:23Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:19:23Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 19:19:24Z] create OK id=jf6c32c8vqbtqr costPerHr=$1.39
+[t=    1.2s 19:19:24Z] PROBE: pod created id=jf6c32c8vqbtqr; waiting for publicIp+ssh_port
+[t=    1.5s 19:19:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 19:19:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 19:19:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 19:20:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 19:20:25Z] PROBE NO-GO: pod jf6c32c8vqbtqr not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 19:20:25Z] DELETE pod jf6c32c8vqbtqr
+[t=   63.4s 19:20:26Z] delete returned status=204 resp={}
+[t=   68.7s 19:20:31Z] pod jf6c32c8vqbtqr confirmed terminated (404)
+[t=   68.7s 19:20:31Z] PROBE: pod jf6c32c8vqbtqr torn down
+[t=    0.0s 19:20:32Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:20:32Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 19:20:33Z] create OK id=zblt9723zvjbp3 costPerHr=$3.29
+[t=    1.6s 19:20:33Z] PROBE: pod created id=zblt9723zvjbp3; waiting for publicIp+ssh_port
+[t=    2.0s 19:20:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 19:20:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 19:21:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 19:21:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 19:21:35Z] PROBE NO-GO: pod zblt9723zvjbp3 not RUNNING+SSH within 60s; tearing down
+[t=   63.3s 19:21:35Z] DELETE pod zblt9723zvjbp3
+[t=   63.8s 19:21:35Z] delete returned status=204 resp={}
+[t=   69.2s 19:21:41Z] pod zblt9723zvjbp3 confirmed terminated (404)
+[t=   69.2s 19:21:41Z] PROBE: pod zblt9723zvjbp3 torn down
+[t=    0.0s 19:21:41Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:21:41Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 19:21:42Z] create OK id=dm2prmeb2s38v4 costPerHr=$2.89
+[t=    1.3s 19:21:42Z] PROBE: pod created id=dm2prmeb2s38v4; waiting for publicIp+ssh_port
+[t=    1.7s 19:21:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 19:21:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 19:22:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 19:22:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 19:22:44Z] PROBE NO-GO: pod dm2prmeb2s38v4 not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 19:22:44Z] DELETE pod dm2prmeb2s38v4
+[t=   63.5s 19:22:44Z] delete returned status=204 resp={}
+[t=   69.0s 19:22:50Z] pod dm2prmeb2s38v4 confirmed terminated (404)
+[t=   69.0s 19:22:50Z] PROBE: pod dm2prmeb2s38v4 torn down
+[t=    0.0s 19:22:50Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 19:22:50Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 19:22:51Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 19:22:51Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:23:06Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 19:23:06Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.9s 19:23:07Z] create OK id=jipw5ohon22hp6 costPerHr=$1.49
+[t=    0.9s 19:23:07Z] PROBE: pod created id=jipw5ohon22hp6; waiting for publicIp+ssh_port
+[t=    1.2s 19:23:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.6s 19:23:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 19:23:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 19:23:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 19:24:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.2s 19:24:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.6s 19:24:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  108.9s 19:24:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  123.9s 19:25:10Z] PROBE NO-GO: pod jipw5ohon22hp6 not RUNNING+SSH within 120s; tearing down
+[t=  123.9s 19:25:10Z] DELETE pod jipw5ohon22hp6
+[t=  124.5s 19:25:11Z] delete returned status=204 resp={}
+[t=  129.9s 19:25:16Z] pod jipw5ohon22hp6 confirmed terminated (404)
+[t=  129.9s 19:25:16Z] PROBE: pod jipw5ohon22hp6 torn down
+[t=    0.0s 19:25:16Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:25:16Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 19:25:17Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 19:25:17Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:25:17Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:25:17Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 19:25:18Z] create OK id=nsbbc3sszndydf costPerHr=$3.29
+[t=    1.1s 19:25:18Z] PROBE: pod created id=nsbbc3sszndydf; waiting for publicIp+ssh_port
+[t=    1.5s 19:25:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 19:25:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 19:25:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 19:26:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 19:26:20Z] PROBE NO-GO: pod nsbbc3sszndydf not RUNNING+SSH within 60s; tearing down
+[t=   63.3s 19:26:20Z] DELETE pod nsbbc3sszndydf
+[t=   63.8s 19:26:21Z] delete returned status=204 resp={}
+[t=   69.1s 19:26:26Z] pod nsbbc3sszndydf confirmed terminated (404)
+[t=   69.1s 19:26:26Z] PROBE: pod nsbbc3sszndydf torn down
+[t=    0.0s 19:26:27Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:26:27Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 19:26:28Z] create OK id=d57vzm5h3mxkvl costPerHr=$2.89
+[t=    1.0s 19:26:28Z] PROBE: pod created id=d57vzm5h3mxkvl; waiting for publicIp+ssh_port
+[t=    1.4s 19:26:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 19:26:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 19:26:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 19:27:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 19:27:29Z] PROBE NO-GO: pod d57vzm5h3mxkvl not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 19:27:29Z] DELETE pod d57vzm5h3mxkvl
+[t=   63.4s 19:27:30Z] delete returned status=204 resp={}
+[t=   68.7s 19:27:35Z] pod d57vzm5h3mxkvl confirmed terminated (404)
+[t=   68.7s 19:27:35Z] PROBE: pod d57vzm5h3mxkvl torn down
+[t=    0.0s 19:27:35Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 19:27:35Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 19:27:36Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 19:27:36Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:27:51Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 19:27:51Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 19:27:53Z] create OK id=u971t0ebyxgjx4 costPerHr=$1.49
+[t=    1.3s 19:27:53Z] PROBE: pod created id=u971t0ebyxgjx4; waiting for publicIp+ssh_port
+[t=    1.6s 19:27:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 19:28:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 19:28:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 19:28:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 19:28:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.5s 19:29:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.9s 19:29:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.4s 19:29:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.4s 19:29:56Z] PROBE NO-GO: pod u971t0ebyxgjx4 not RUNNING+SSH within 120s; tearing down
+[t=  124.4s 19:29:56Z] DELETE pod u971t0ebyxgjx4
+[t=  125.0s 19:29:57Z] delete returned status=204 resp={}
+[t=  130.3s 19:30:02Z] pod u971t0ebyxgjx4 confirmed terminated (404)
+[t=  130.3s 19:30:02Z] PROBE: pod u971t0ebyxgjx4 torn down
+[t=    0.0s 19:30:02Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:30:02Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 19:30:03Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 19:30:03Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:30:03Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:30:03Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 19:30:04Z] create OK id=hlmpzgopi9q3wg costPerHr=$3.29
+[t=    1.4s 19:30:04Z] PROBE: pod created id=hlmpzgopi9q3wg; waiting for publicIp+ssh_port
+[t=    1.8s 19:30:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 19:30:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.1s 19:30:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.8s 19:30:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.8s 19:31:07Z] PROBE NO-GO: pod hlmpzgopi9q3wg not RUNNING+SSH within 60s; tearing down
+[t=   63.8s 19:31:07Z] DELETE pod hlmpzgopi9q3wg
+[t=   64.4s 19:31:07Z] delete returned status=204 resp={}
+[t=   69.7s 19:31:13Z] pod hlmpzgopi9q3wg confirmed terminated (404)
+[t=   69.7s 19:31:13Z] PROBE: pod hlmpzgopi9q3wg torn down
+[t=    0.0s 19:31:13Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:31:13Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 19:31:14Z] create OK id=ddczd54m1wkvov costPerHr=$2.89
+[t=    1.1s 19:31:14Z] PROBE: pod created id=ddczd54m1wkvov; waiting for publicIp+ssh_port
+[t=    1.5s 19:31:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 19:31:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 19:31:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 19:32:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 19:32:16Z] PROBE NO-GO: pod ddczd54m1wkvov not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 19:32:16Z] DELETE pod ddczd54m1wkvov
+[t=   63.5s 19:32:16Z] delete returned status=204 resp={}
+[t=   68.9s 19:32:22Z] pod ddczd54m1wkvov confirmed terminated (404)
+[t=   68.9s 19:32:22Z] PROBE: pod ddczd54m1wkvov torn down
+[t=    0.0s 19:32:22Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 19:32:22Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 19:32:22Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 19:32:22Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:32:38Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 19:32:38Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 19:32:39Z] create OK id=nxuxgc1ar0su19 costPerHr=$1.49
+[t=    1.3s 19:32:39Z] PROBE: pod created id=nxuxgc1ar0su19; waiting for publicIp+ssh_port
+[t=    1.6s 19:32:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 19:32:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 19:33:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 19:33:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 19:33:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.5s 19:33:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.8s 19:34:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.2s 19:34:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.2s 19:34:42Z] PROBE NO-GO: pod nxuxgc1ar0su19 not RUNNING+SSH within 120s; tearing down
+[t=  124.2s 19:34:42Z] DELETE pod nxuxgc1ar0su19
+[t=  124.8s 19:34:43Z] delete returned status=204 resp={}
+[t=  130.3s 19:34:48Z] pod nxuxgc1ar0su19 confirmed terminated (404)
+[t=  130.3s 19:34:48Z] PROBE: pod nxuxgc1ar0su19 torn down
+[t=    0.0s 19:34:49Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:34:49Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 19:34:49Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 19:34:49Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:34:49Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:34:49Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 19:34:50Z] create OK id=w4wqcu7emhhl93 costPerHr=$3.29
+[t=    1.2s 19:34:50Z] PROBE: pod created id=w4wqcu7emhhl93; waiting for publicIp+ssh_port
+[t=    1.7s 19:34:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 19:35:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 19:35:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.4s 19:35:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.4s 19:35:53Z] PROBE NO-GO: pod w4wqcu7emhhl93 not RUNNING+SSH within 60s; tearing down
+[t=   63.4s 19:35:53Z] DELETE pod w4wqcu7emhhl93
+[t=   64.1s 19:35:53Z] delete returned status=204 resp={}
+[t=   69.4s 19:35:59Z] pod w4wqcu7emhhl93 confirmed terminated (404)
+[t=   69.4s 19:35:59Z] PROBE: pod w4wqcu7emhhl93 torn down
+[t=    0.0s 19:35:59Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:35:59Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 19:36:00Z] create OK id=jzoaijeig2w39e costPerHr=$2.89
+[t=    1.1s 19:36:00Z] PROBE: pod created id=jzoaijeig2w39e; waiting for publicIp+ssh_port
+[t=    1.4s 19:36:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 19:36:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 19:36:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 19:36:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 19:37:02Z] PROBE NO-GO: pod jzoaijeig2w39e not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 19:37:02Z] DELETE pod jzoaijeig2w39e
+[t=   63.5s 19:37:02Z] delete returned status=204 resp={}
+[t=   68.8s 19:37:08Z] pod jzoaijeig2w39e confirmed terminated (404)
+[t=   68.8s 19:37:08Z] PROBE: pod jzoaijeig2w39e torn down
+[t=    0.0s 19:37:08Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 19:37:08Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 19:37:08Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 19:37:08Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 19:37:31Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 19:37:31Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.7s 19:37:33Z] create OK id=wg2h07x3c9peu4 costPerHr=$1.49
+[t=    1.7s 19:37:33Z] PROBE: pod created id=wg2h07x3c9peu4; waiting for publicIp+ssh_port
+[t=    2.2s 19:37:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 19:37:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 19:38:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.8s 19:38:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.6s 19:38:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.3s 19:38:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.9s 19:39:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  112.4s 19:39:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  127.4s 19:39:38Z] PROBE NO-GO: pod wg2h07x3c9peu4 not RUNNING+SSH within 120s; tearing down
+[t=  127.4s 19:39:38Z] DELETE pod wg2h07x3c9peu4
+[t=  128.0s 19:39:39Z] delete returned status=204 resp={}
+[t=  133.3s 19:39:44Z] pod wg2h07x3c9peu4 confirmed terminated (404)
+[t=  133.3s 19:39:44Z] PROBE: pod wg2h07x3c9peu4 torn down
+[t=    0.0s 19:39:45Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:39:45Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 19:39:46Z] create OK id=7w7eacbymfgs93 costPerHr=$1.39
+[t=    1.2s 19:39:46Z] PROBE: pod created id=7w7eacbymfgs93; waiting for publicIp+ssh_port
+[t=    1.5s 19:39:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 19:40:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 19:40:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.9s 19:40:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.9s 19:40:48Z] PROBE NO-GO: pod 7w7eacbymfgs93 not RUNNING+SSH within 60s; tearing down
+[t=   63.9s 19:40:48Z] DELETE pod 7w7eacbymfgs93
+[t=   64.5s 19:40:49Z] delete returned status=204 resp={}
+[t=   69.9s 19:40:54Z] pod 7w7eacbymfgs93 confirmed terminated (404)
+[t=   69.9s 19:40:54Z] PROBE: pod 7w7eacbymfgs93 torn down
+[t=    0.0s 19:40:55Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:40:55Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 19:40:56Z] create OK id=adr2rxl5z5imfc costPerHr=$3.29
+[t=    1.5s 19:40:56Z] PROBE: pod created id=adr2rxl5z5imfc; waiting for publicIp+ssh_port
+[t=    2.0s 19:40:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 19:41:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 19:41:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.3s 19:41:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.3s 19:41:59Z] PROBE NO-GO: pod adr2rxl5z5imfc not RUNNING+SSH within 60s; tearing down
+[t=   64.3s 19:41:59Z] DELETE pod adr2rxl5z5imfc
+[t=   64.9s 19:41:59Z] delete returned status=204 resp={}
+[t=   70.2s 19:42:05Z] pod adr2rxl5z5imfc confirmed terminated (404)
+[t=   70.2s 19:42:05Z] PROBE: pod adr2rxl5z5imfc torn down
+[t=    0.0s 19:42:05Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:42:05Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 19:42:06Z] create OK id=662waby1b8fzag costPerHr=$2.89
+[t=    1.0s 19:42:06Z] PROBE: pod created id=662waby1b8fzag; waiting for publicIp+ssh_port
+[t=    1.3s 19:42:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 19:42:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 19:42:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 19:42:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 19:43:08Z] PROBE NO-GO: pod 662waby1b8fzag not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 19:43:08Z] DELETE pod 662waby1b8fzag
+[t=   63.3s 19:43:08Z] delete returned status=204 resp={}
+[t=   68.9s 19:43:14Z] pod 662waby1b8fzag confirmed terminated (404)
+[t=   68.9s 19:43:14Z] PROBE: pod 662waby1b8fzag torn down
+[t=    0.0s 19:43:14Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 19:43:14Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.8s 19:43:15Z] create OK id=9k9heiy9hbsl9z costPerHr=$1.39
+[t=    0.8s 19:43:15Z] PROBE: pod created id=9k9heiy9hbsl9z; waiting for publicIp+ssh_port
+[t=    1.2s 19:43:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.6s 19:43:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 19:43:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.3s 19:44:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.3s 19:44:16Z] PROBE NO-GO: pod 9k9heiy9hbsl9z not RUNNING+SSH within 60s; tearing down
+[t=   62.3s 19:44:16Z] DELETE pod 9k9heiy9hbsl9z
+[t=   62.9s 19:44:17Z] delete returned status=204 resp={}
+[t=   68.2s 19:44:22Z] pod 9k9heiy9hbsl9z confirmed terminated (404)
+[t=   68.2s 19:44:22Z] PROBE: pod 9k9heiy9hbsl9z torn down
+[t=    0.0s 19:44:37Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 19:44:37Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 19:44:39Z] create OK id=p20aq01mguw5tw costPerHr=$1.49
+[t=    1.2s 19:44:39Z] PROBE: pod created id=p20aq01mguw5tw; waiting for publicIp+ssh_port
+[t=    1.5s 19:44:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 19:44:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 19:45:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 19:45:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.6s 19:45:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.2s 19:45:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.7s 19:46:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.1s 19:46:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.1s 19:46:43Z] PROBE NO-GO: pod p20aq01mguw5tw not RUNNING+SSH within 120s; tearing down
+[t=  125.1s 19:46:43Z] DELETE pod p20aq01mguw5tw
+[t=  125.8s 19:46:43Z] delete returned status=204 resp={}
+[t=  131.1s 19:46:49Z] pod p20aq01mguw5tw confirmed terminated (404)
+[t=  131.1s 19:46:49Z] PROBE: pod p20aq01mguw5tw torn down
+[t=    0.0s 19:46:49Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:46:49Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 19:46:50Z] create OK id=6dbjgj12986mz7 costPerHr=$1.39
+[t=    1.0s 19:46:50Z] PROBE: pod created id=6dbjgj12986mz7; waiting for publicIp+ssh_port
+[t=    1.5s 19:46:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 19:47:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 19:47:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 19:47:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 19:47:52Z] PROBE NO-GO: pod 6dbjgj12986mz7 not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 19:47:52Z] DELETE pod 6dbjgj12986mz7
+[t=   63.2s 19:47:52Z] delete returned status=204 resp={}
+[t=   68.5s 19:47:57Z] pod 6dbjgj12986mz7 confirmed terminated (404)
+[t=   68.5s 19:47:57Z] PROBE: pod 6dbjgj12986mz7 torn down
+[t=    0.0s 19:47:58Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:47:58Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 19:47:59Z] create OK id=e3h1d21hrn38qm costPerHr=$3.29
+[t=    1.3s 19:47:59Z] PROBE: pod created id=e3h1d21hrn38qm; waiting for publicIp+ssh_port
+[t=    2.0s 19:47:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.6s 19:48:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.2s 19:48:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.7s 19:48:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.7s 19:49:01Z] PROBE NO-GO: pod e3h1d21hrn38qm not RUNNING+SSH within 60s; tearing down
+[t=   63.7s 19:49:01Z] DELETE pod e3h1d21hrn38qm
+[t=   64.3s 19:49:02Z] delete returned status=204 resp={}
+[t=   69.9s 19:49:07Z] pod e3h1d21hrn38qm confirmed terminated (404)
+[t=   69.9s 19:49:07Z] PROBE: pod e3h1d21hrn38qm torn down
+[t=    0.0s 19:49:08Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:49:08Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 19:49:09Z] create OK id=a9cgpxgn4kvqun costPerHr=$2.89
+[t=    1.2s 19:49:09Z] PROBE: pod created id=a9cgpxgn4kvqun; waiting for publicIp+ssh_port
+[t=    1.5s 19:49:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 19:49:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 19:49:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 19:49:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 19:50:10Z] PROBE NO-GO: pod a9cgpxgn4kvqun not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 19:50:10Z] DELETE pod a9cgpxgn4kvqun
+[t=   63.3s 19:50:11Z] delete returned status=204 resp={}
+[t=   68.9s 19:50:16Z] pod a9cgpxgn4kvqun confirmed terminated (404)
+[t=   68.9s 19:50:16Z] PROBE: pod a9cgpxgn4kvqun torn down
+[t=    0.0s 19:50:17Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 19:50:17Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 19:50:18Z] create OK id=kv48joel8k3fe5 costPerHr=$1.39
+[t=    0.9s 19:50:18Z] PROBE: pod created id=kv48joel8k3fe5; waiting for publicIp+ssh_port
+[t=    1.3s 19:50:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 19:50:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 19:50:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 19:51:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 19:51:19Z] PROBE NO-GO: pod kv48joel8k3fe5 not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 19:51:19Z] DELETE pod kv48joel8k3fe5
+[t=   63.2s 19:51:20Z] delete returned status=204 resp={}
+[t=   68.6s 19:51:25Z] pod kv48joel8k3fe5 confirmed terminated (404)
+[t=   68.6s 19:51:25Z] PROBE: pod kv48joel8k3fe5 torn down
+[t=    0.0s 19:51:44Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 19:51:44Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 19:51:45Z] create OK id=27o51t4a8tptcy costPerHr=$1.49
+[t=    1.0s 19:51:45Z] PROBE: pod created id=27o51t4a8tptcy; waiting for publicIp+ssh_port
+[t=    1.3s 19:51:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 19:52:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 19:52:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 19:52:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 19:52:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.2s 19:53:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.6s 19:53:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.0s 19:53:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.0s 19:53:47Z] PROBE NO-GO: pod 27o51t4a8tptcy not RUNNING+SSH within 120s; tearing down
+[t=  124.0s 19:53:47Z] DELETE pod 27o51t4a8tptcy
+[t=  124.5s 19:53:48Z] delete returned status=204 resp={}
+[t=  129.8s 19:53:53Z] pod 27o51t4a8tptcy confirmed terminated (404)
+[t=  129.8s 19:53:53Z] PROBE: pod 27o51t4a8tptcy torn down
+[t=    0.0s 19:53:54Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:53:54Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 19:53:55Z] create OK id=5g62rcfcqe4xh2 costPerHr=$1.39
+[t=    1.2s 19:53:55Z] PROBE: pod created id=5g62rcfcqe4xh2; waiting for publicIp+ssh_port
+[t=    1.6s 19:53:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 19:54:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 19:54:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 19:54:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 19:54:57Z] PROBE NO-GO: pod 5g62rcfcqe4xh2 not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 19:54:57Z] DELETE pod 5g62rcfcqe4xh2
+[t=   63.6s 19:54:57Z] delete returned status=204 resp={}
+[t=   68.9s 19:55:02Z] pod 5g62rcfcqe4xh2 confirmed terminated (404)
+[t=   68.9s 19:55:02Z] PROBE: pod 5g62rcfcqe4xh2 torn down
+[t=    0.0s 19:55:03Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:55:03Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 19:55:04Z] create OK id=m32abchbbjc2xe costPerHr=$3.29
+[t=    1.4s 19:55:04Z] PROBE: pod created id=m32abchbbjc2xe; waiting for publicIp+ssh_port
+[t=    2.1s 19:55:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 19:55:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 19:55:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.3s 19:55:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.4s 19:56:07Z] PROBE NO-GO: pod m32abchbbjc2xe not RUNNING+SSH within 60s; tearing down
+[t=   64.4s 19:56:07Z] DELETE pod m32abchbbjc2xe
+[t=   64.9s 19:56:08Z] delete returned status=204 resp={}
+[t=   70.4s 19:56:13Z] pod m32abchbbjc2xe confirmed terminated (404)
+[t=   70.4s 19:56:13Z] PROBE: pod m32abchbbjc2xe torn down
+[t=    0.0s 19:56:13Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 19:56:13Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 19:56:14Z] create OK id=s8xsrxpmywe142 costPerHr=$2.89
+[t=    1.2s 19:56:14Z] PROBE: pod created id=s8xsrxpmywe142; waiting for publicIp+ssh_port
+[t=    1.4s 19:56:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 19:56:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 19:56:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 19:57:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 19:57:16Z] PROBE NO-GO: pod s8xsrxpmywe142 not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 19:57:16Z] DELETE pod s8xsrxpmywe142
+[t=   63.4s 19:57:17Z] delete returned status=204 resp={}
+[t=   68.9s 19:57:22Z] pod s8xsrxpmywe142 confirmed terminated (404)
+[t=   68.9s 19:57:22Z] PROBE: pod s8xsrxpmywe142 torn down
+[t=    0.0s 19:57:22Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 19:57:22Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 19:57:23Z] create OK id=066fp7ftp8bilt costPerHr=$1.39
+[t=    0.9s 19:57:23Z] PROBE: pod created id=066fp7ftp8bilt; waiting for publicIp+ssh_port
+[t=    1.2s 19:57:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.6s 19:57:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 19:57:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 19:58:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.4s 19:58:25Z] PROBE NO-GO: pod 066fp7ftp8bilt not RUNNING+SSH within 60s; tearing down
+[t=   62.4s 19:58:25Z] DELETE pod 066fp7ftp8bilt
+[t=   62.9s 19:58:25Z] delete returned status=204 resp={}
+[t=   68.3s 19:58:31Z] pod 066fp7ftp8bilt confirmed terminated (404)
+[t=   68.3s 19:58:31Z] PROBE: pod 066fp7ftp8bilt torn down
+[t=    0.0s 19:58:48Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 19:58:48Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 19:58:49Z] create OK id=knqcr3hv6fw9f6 costPerHr=$1.49
+[t=    1.5s 19:58:49Z] PROBE: pod created id=knqcr3hv6fw9f6; waiting for publicIp+ssh_port
+[t=    1.9s 19:58:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 19:59:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 19:59:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 19:59:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.8s 19:59:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.4s 20:00:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.1s 20:00:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.6s 20:00:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.6s 20:00:53Z] PROBE NO-GO: pod knqcr3hv6fw9f6 not RUNNING+SSH within 120s; tearing down
+[t=  125.6s 20:00:53Z] DELETE pod knqcr3hv6fw9f6
+[t=  126.2s 20:00:54Z] delete returned status=204 resp={}
+[t=  131.5s 20:00:59Z] pod knqcr3hv6fw9f6 confirmed terminated (404)
+[t=  131.5s 20:00:59Z] PROBE: pod knqcr3hv6fw9f6 torn down
+[t=    0.0s 20:00:59Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:00:59Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 20:01:00Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 20:01:00Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:01:00Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:01:00Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 20:01:01Z] create OK id=zr8zuu3unkfi2f costPerHr=$3.29
+[t=    1.2s 20:01:01Z] PROBE: pod created id=zr8zuu3unkfi2f; waiting for publicIp+ssh_port
+[t=    1.5s 20:01:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 20:01:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 20:01:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 20:01:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 20:02:03Z] PROBE NO-GO: pod zr8zuu3unkfi2f not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 20:02:03Z] DELETE pod zr8zuu3unkfi2f
+[t=   63.5s 20:02:04Z] delete returned status=204 resp={}
+[t=   68.9s 20:02:09Z] pod zr8zuu3unkfi2f confirmed terminated (404)
+[t=   68.9s 20:02:09Z] PROBE: pod zr8zuu3unkfi2f torn down
+[t=    0.0s 20:02:09Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:02:09Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.9s 20:02:10Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.9s 20:02:10Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:02:10Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 20:02:10Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.7s 20:02:11Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.7s 20:02:11Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:02:31Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 20:02:31Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 20:02:32Z] create OK id=6dtfcnqjxikjem costPerHr=$1.49
+[t=    1.1s 20:02:32Z] PROBE: pod created id=6dtfcnqjxikjem; waiting for publicIp+ssh_port
+[t=    1.5s 20:02:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 20:02:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 20:03:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 20:03:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 20:03:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.8s 20:03:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.2s 20:04:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.6s 20:04:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.6s 20:04:35Z] PROBE NO-GO: pod 6dtfcnqjxikjem not RUNNING+SSH within 120s; tearing down
+[t=  124.6s 20:04:35Z] DELETE pod 6dtfcnqjxikjem
+[t=  125.2s 20:04:36Z] delete returned status=204 resp={}
+[t=  130.6s 20:04:41Z] pod 6dtfcnqjxikjem confirmed terminated (404)
+[t=  130.6s 20:04:41Z] PROBE: pod 6dtfcnqjxikjem torn down
+[t=    0.0s 20:04:41Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:04:41Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 20:04:43Z] create OK id=8xq6agd7hw8ach costPerHr=$1.39
+[t=    1.2s 20:04:43Z] PROBE: pod created id=8xq6agd7hw8ach; waiting for publicIp+ssh_port
+[t=    1.5s 20:04:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 20:04:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 20:05:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 20:05:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 20:05:44Z] PROBE NO-GO: pod 8xq6agd7hw8ach not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 20:05:44Z] DELETE pod 8xq6agd7hw8ach
+[t=   63.5s 20:05:45Z] delete returned status=204 resp={}
+[t=   69.0s 20:05:50Z] pod 8xq6agd7hw8ach confirmed terminated (404)
+[t=   69.0s 20:05:50Z] PROBE: pod 8xq6agd7hw8ach torn down
+[t=    0.0s 20:05:51Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:05:51Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 20:05:52Z] create OK id=xdcs1j23g7pjet costPerHr=$3.29
+[t=    1.5s 20:05:52Z] PROBE: pod created id=xdcs1j23g7pjet; waiting for publicIp+ssh_port
+[t=    2.1s 20:05:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 20:06:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.4s 20:06:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.2s 20:06:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.2s 20:06:55Z] PROBE NO-GO: pod xdcs1j23g7pjet not RUNNING+SSH within 60s; tearing down
+[t=   64.2s 20:06:55Z] DELETE pod xdcs1j23g7pjet
+[t=   64.7s 20:06:55Z] delete returned status=204 resp={}
+[t=   70.0s 20:07:01Z] pod xdcs1j23g7pjet confirmed terminated (404)
+[t=   70.0s 20:07:01Z] PROBE: pod xdcs1j23g7pjet torn down
+[t=    0.0s 20:07:01Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:07:01Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 20:07:02Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 20:07:02Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:07:02Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 20:07:02Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 20:07:02Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 20:07:02Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:07:27Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 20:07:27Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 20:07:29Z] create OK id=8dtitl3hx4r0vm costPerHr=$1.49
+[t=    1.3s 20:07:29Z] PROBE: pod created id=8dtitl3hx4r0vm; waiting for publicIp+ssh_port
+[t=    1.6s 20:07:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 20:07:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 20:08:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.4s 20:08:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.0s 20:08:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.6s 20:08:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.7s 20:09:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.2s 20:09:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.2s 20:09:34Z] PROBE NO-GO: pod 8dtitl3hx4r0vm not RUNNING+SSH within 120s; tearing down
+[t=  126.2s 20:09:34Z] DELETE pod 8dtitl3hx4r0vm
+[t=  126.8s 20:09:34Z] delete returned status=204 resp={}
+[t=  132.1s 20:09:39Z] pod 8dtitl3hx4r0vm confirmed terminated (404)
+[t=  132.1s 20:09:40Z] PROBE: pod 8dtitl3hx4r0vm torn down
+[t=    0.0s 20:09:40Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:09:40Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 20:09:40Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 20:09:40Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:09:40Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:09:40Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 20:09:42Z] create OK id=f39df33y239m0u costPerHr=$3.29
+[t=    1.4s 20:09:42Z] PROBE: pod created id=f39df33y239m0u; waiting for publicIp+ssh_port
+[t=    2.2s 20:09:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.0s 20:09:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.8s 20:10:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 20:10:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 20:10:45Z] PROBE NO-GO: pod f39df33y239m0u not RUNNING+SSH within 60s; tearing down
+[t=   64.5s 20:10:45Z] DELETE pod f39df33y239m0u
+[t=   65.1s 20:10:45Z] delete returned status=204 resp={}
+[t=   70.5s 20:10:51Z] pod f39df33y239m0u confirmed terminated (404)
+[t=   70.5s 20:10:51Z] PROBE: pod f39df33y239m0u torn down
+[t=    0.0s 20:10:51Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:10:51Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 20:10:53Z] create OK id=01gea13ipq4vhx costPerHr=$2.89
+[t=    1.4s 20:10:53Z] PROBE: pod created id=01gea13ipq4vhx; waiting for publicIp+ssh_port
+[t=    1.7s 20:10:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 20:11:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 20:11:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 20:11:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 20:11:54Z] PROBE NO-GO: pod 01gea13ipq4vhx not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 20:11:54Z] DELETE pod 01gea13ipq4vhx
+[t=   63.6s 20:11:55Z] delete returned status=204 resp={}
+[t=   69.0s 20:12:00Z] pod 01gea13ipq4vhx confirmed terminated (404)
+[t=   69.0s 20:12:00Z] PROBE: pod 01gea13ipq4vhx torn down
+[t=    0.0s 20:12:00Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 20:12:00Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 20:12:01Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 20:12:01Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:12:15Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 20:12:15Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 20:12:17Z] create OK id=ab35ncpmtnfe9r costPerHr=$1.49
+[t=    1.4s 20:12:17Z] PROBE: pod created id=ab35ncpmtnfe9r; waiting for publicIp+ssh_port
+[t=    1.8s 20:12:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 20:12:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.2s 20:12:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.7s 20:13:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.3s 20:13:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.0s 20:13:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.6s 20:13:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.2s 20:14:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.2s 20:14:21Z] PROBE NO-GO: pod ab35ncpmtnfe9r not RUNNING+SSH within 120s; tearing down
+[t=  126.2s 20:14:21Z] DELETE pod ab35ncpmtnfe9r
+[t=  126.7s 20:14:22Z] delete returned status=204 resp={}
+[t=  132.0s 20:14:27Z] pod ab35ncpmtnfe9r confirmed terminated (404)
+[t=  132.0s 20:14:27Z] PROBE: pod ab35ncpmtnfe9r torn down
+[t=    0.0s 20:14:27Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:14:27Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 20:14:28Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 20:14:28Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:14:28Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:14:28Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 20:14:30Z] create OK id=fghdegywdm5dw3 costPerHr=$3.29
+[t=    1.5s 20:14:30Z] PROBE: pod created id=fghdegywdm5dw3; waiting for publicIp+ssh_port
+[t=    2.0s 20:14:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 20:14:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.7s 20:15:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.2s 20:15:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.2s 20:15:32Z] PROBE NO-GO: pod fghdegywdm5dw3 not RUNNING+SSH within 60s; tearing down
+[t=   64.2s 20:15:32Z] DELETE pod fghdegywdm5dw3
+[t=   64.8s 20:15:33Z] delete returned status=204 resp={}
+[t=   70.3s 20:15:38Z] pod fghdegywdm5dw3 confirmed terminated (404)
+[t=   70.3s 20:15:38Z] PROBE: pod fghdegywdm5dw3 torn down
+[t=    0.0s 20:15:39Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:15:39Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 20:15:39Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 20:15:39Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:15:39Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 20:15:39Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.7s 20:15:40Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.7s 20:15:40Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:15:58Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 20:15:58Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 20:16:00Z] create OK id=4tcjejbqx55o5y costPerHr=$1.49
+[t=    1.2s 20:16:00Z] PROBE: pod created id=4tcjejbqx55o5y; waiting for publicIp+ssh_port
+[t=    1.6s 20:16:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 20:16:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.0s 20:16:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.6s 20:16:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.2s 20:17:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.7s 20:17:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   96.4s 20:17:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.9s 20:17:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.9s 20:18:05Z] PROBE NO-GO: pod 4tcjejbqx55o5y not RUNNING+SSH within 120s; tearing down
+[t=  126.9s 20:18:05Z] DELETE pod 4tcjejbqx55o5y
+[t=  127.5s 20:18:06Z] delete returned status=204 resp={}
+[t=  132.9s 20:18:11Z] pod 4tcjejbqx55o5y confirmed terminated (404)
+[t=  132.9s 20:18:11Z] PROBE: pod 4tcjejbqx55o5y torn down
+[t=    0.0s 20:18:12Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:18:12Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 20:18:13Z] create OK id=viu3xl0qp40y3y costPerHr=$1.39
+[t=    1.3s 20:18:13Z] PROBE: pod created id=viu3xl0qp40y3y; waiting for publicIp+ssh_port
+[t=    1.6s 20:18:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 20:18:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 20:18:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 20:18:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 20:19:14Z] PROBE NO-GO: pod viu3xl0qp40y3y not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 20:19:14Z] DELETE pod viu3xl0qp40y3y
+[t=   63.4s 20:19:15Z] delete returned status=204 resp={}
+[t=   68.9s 20:19:20Z] pod viu3xl0qp40y3y confirmed terminated (404)
+[t=   68.9s 20:19:20Z] PROBE: pod viu3xl0qp40y3y torn down
+[t=    0.0s 20:19:21Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:19:21Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 20:19:22Z] create OK id=9u0add2whqjv39 costPerHr=$3.29
+[t=    1.4s 20:19:22Z] PROBE: pod created id=9u0add2whqjv39; waiting for publicIp+ssh_port
+[t=    1.9s 20:19:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 20:19:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.4s 20:19:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.2s 20:20:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.2s 20:20:25Z] PROBE NO-GO: pod 9u0add2whqjv39 not RUNNING+SSH within 60s; tearing down
+[t=   64.2s 20:20:25Z] DELETE pod 9u0add2whqjv39
+[t=   64.7s 20:20:25Z] delete returned status=204 resp={}
+[t=   70.1s 20:20:31Z] pod 9u0add2whqjv39 confirmed terminated (404)
+[t=   70.1s 20:20:31Z] PROBE: pod 9u0add2whqjv39 torn down
+[t=    0.0s 20:20:31Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:20:31Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 20:20:32Z] create OK id=k64qy72owx3tl1 costPerHr=$2.89
+[t=    1.2s 20:20:32Z] PROBE: pod created id=k64qy72owx3tl1; waiting for publicIp+ssh_port
+[t=    2.4s 20:20:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 20:20:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 20:21:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.6s 20:21:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.6s 20:21:35Z] PROBE NO-GO: pod k64qy72owx3tl1 not RUNNING+SSH within 60s; tearing down
+[t=   63.6s 20:21:35Z] DELETE pod k64qy72owx3tl1
+[t=   64.2s 20:21:35Z] delete returned status=204 resp={}
+[t=   69.5s 20:21:40Z] pod k64qy72owx3tl1 confirmed terminated (404)
+[t=   69.5s 20:21:40Z] PROBE: pod k64qy72owx3tl1 torn down
+[t=    0.0s 20:21:41Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 20:21:41Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 20:21:41Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 20:21:41Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:21:57Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 20:21:57Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 20:21:58Z] create OK id=vsbuptx54dyvb9 costPerHr=$1.49
+[t=    1.1s 20:21:58Z] PROBE: pod created id=vsbuptx54dyvb9; waiting for publicIp+ssh_port
+[t=    1.4s 20:21:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 20:22:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 20:22:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 20:22:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 20:23:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.6s 20:23:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.0s 20:23:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.7s 20:23:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.7s 20:24:02Z] PROBE NO-GO: pod vsbuptx54dyvb9 not RUNNING+SSH within 120s; tearing down
+[t=  124.7s 20:24:02Z] DELETE pod vsbuptx54dyvb9
+[t=  125.3s 20:24:02Z] delete returned status=204 resp={}
+[t=  130.8s 20:24:08Z] pod vsbuptx54dyvb9 confirmed terminated (404)
+[t=  130.8s 20:24:08Z] PROBE: pod vsbuptx54dyvb9 torn down
+[t=    0.0s 20:24:08Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:24:08Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 20:24:08Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 20:24:08Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:24:09Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:24:09Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 20:24:10Z] create OK id=4x03kt95omllbk costPerHr=$3.29
+[t=    1.6s 20:24:10Z] PROBE: pod created id=4x03kt95omllbk; waiting for publicIp+ssh_port
+[t=    2.1s 20:24:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 20:24:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 20:24:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.3s 20:24:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.3s 20:25:13Z] PROBE NO-GO: pod 4x03kt95omllbk not RUNNING+SSH within 60s; tearing down
+[t=   64.3s 20:25:13Z] DELETE pod 4x03kt95omllbk
+[t=   65.1s 20:25:14Z] delete returned status=204 resp={}
+[t=   70.5s 20:25:19Z] pod 4x03kt95omllbk confirmed terminated (404)
+[t=   70.5s 20:25:19Z] PROBE: pod 4x03kt95omllbk torn down
+[t=    0.0s 20:25:19Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:25:19Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 20:25:21Z] create OK id=6l85dw1q9lk3c2 costPerHr=$2.89
+[t=    1.2s 20:25:21Z] PROBE: pod created id=6l85dw1q9lk3c2; waiting for publicIp+ssh_port
+[t=    1.5s 20:25:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 20:25:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 20:25:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 20:26:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 20:26:22Z] PROBE NO-GO: pod 6l85dw1q9lk3c2 not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 20:26:22Z] DELETE pod 6l85dw1q9lk3c2
+[t=   63.6s 20:26:23Z] delete returned status=204 resp={}
+[t=   68.9s 20:26:28Z] pod 6l85dw1q9lk3c2 confirmed terminated (404)
+[t=   68.9s 20:26:28Z] PROBE: pod 6l85dw1q9lk3c2 torn down
+[t=    0.0s 20:26:29Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 20:26:29Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 20:26:29Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 20:26:29Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:26:48Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 20:26:48Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 20:26:49Z] create OK id=x5012ds3rt2gvq costPerHr=$1.49
+[t=    1.2s 20:26:49Z] PROBE: pod created id=x5012ds3rt2gvq; waiting for publicIp+ssh_port
+[t=    1.5s 20:26:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 20:27:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 20:27:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 20:27:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.4s 20:27:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.8s 20:28:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.2s 20:28:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.7s 20:28:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.7s 20:28:52Z] PROBE NO-GO: pod x5012ds3rt2gvq not RUNNING+SSH within 120s; tearing down
+[t=  124.7s 20:28:52Z] DELETE pod x5012ds3rt2gvq
+[t=  125.3s 20:28:53Z] delete returned status=204 resp={}
+[t=  130.6s 20:28:58Z] pod x5012ds3rt2gvq confirmed terminated (404)
+[t=  130.6s 20:28:58Z] PROBE: pod x5012ds3rt2gvq torn down
+[t=    0.0s 20:28:58Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:28:58Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 20:28:59Z] create OK id=0oy7o5h238okgf costPerHr=$1.39
+[t=    1.0s 20:28:59Z] PROBE: pod created id=0oy7o5h238okgf; waiting for publicIp+ssh_port
+[t=    1.4s 20:29:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 20:29:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 20:29:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 20:29:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.5s 20:30:01Z] PROBE NO-GO: pod 0oy7o5h238okgf not RUNNING+SSH within 60s; tearing down
+[t=   62.5s 20:30:01Z] DELETE pod 0oy7o5h238okgf
+[t=   63.1s 20:30:01Z] delete returned status=204 resp={}
+[t=   68.5s 20:30:07Z] pod 0oy7o5h238okgf confirmed terminated (404)
+[t=   68.5s 20:30:07Z] PROBE: pod 0oy7o5h238okgf torn down
+[t=    0.0s 20:30:07Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:30:07Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 20:30:08Z] create OK id=o47zsc66w18846 costPerHr=$3.29
+[t=    1.1s 20:30:08Z] PROBE: pod created id=o47zsc66w18846; waiting for publicIp+ssh_port
+[t=    1.4s 20:30:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 20:30:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 20:30:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 20:30:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 20:31:10Z] PROBE NO-GO: pod o47zsc66w18846 not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 20:31:10Z] DELETE pod o47zsc66w18846
+[t=   63.6s 20:31:11Z] delete returned status=204 resp={}
+[t=   68.9s 20:31:16Z] pod o47zsc66w18846 confirmed terminated (404)
+[t=   68.9s 20:31:16Z] PROBE: pod o47zsc66w18846 torn down
+[t=    0.0s 20:31:16Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:31:16Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.7s 20:31:18Z] create OK id=vzp32zz15n5lmt costPerHr=$2.89
+[t=    1.7s 20:31:18Z] PROBE: pod created id=vzp32zz15n5lmt; waiting for publicIp+ssh_port
+[t=    2.1s 20:31:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 20:31:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 20:31:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 20:32:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 20:32:19Z] PROBE NO-GO: pod vzp32zz15n5lmt not RUNNING+SSH within 60s; tearing down
+[t=   63.3s 20:32:19Z] DELETE pod vzp32zz15n5lmt
+[t=   64.0s 20:32:20Z] delete returned status=204 resp={}
+[t=   69.3s 20:32:25Z] pod vzp32zz15n5lmt confirmed terminated (404)
+[t=   69.3s 20:32:25Z] PROBE: pod vzp32zz15n5lmt torn down
+[t=    0.0s 20:32:26Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 20:32:26Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 20:32:26Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 20:32:26Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:32:42Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 20:32:42Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 20:32:43Z] create OK id=dy4dg1oabud0h3 costPerHr=$1.49
+[t=    1.0s 20:32:43Z] PROBE: pod created id=dy4dg1oabud0h3; waiting for publicIp+ssh_port
+[t=    1.3s 20:32:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.6s 20:32:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 20:33:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 20:33:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 20:33:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.4s 20:34:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.7s 20:34:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.1s 20:34:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.1s 20:34:46Z] PROBE NO-GO: pod dy4dg1oabud0h3 not RUNNING+SSH within 120s; tearing down
+[t=  124.1s 20:34:46Z] DELETE pod dy4dg1oabud0h3
+[t=  124.7s 20:34:47Z] delete returned status=204 resp={}
+[t=  130.0s 20:34:52Z] pod dy4dg1oabud0h3 confirmed terminated (404)
+[t=  130.0s 20:34:52Z] PROBE: pod dy4dg1oabud0h3 torn down
+[t=    0.0s 20:34:52Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:34:52Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 20:34:54Z] create OK id=kkgrnt2a4uhqsm costPerHr=$1.39
+[t=    1.1s 20:34:54Z] PROBE: pod created id=kkgrnt2a4uhqsm; waiting for publicIp+ssh_port
+[t=    1.5s 20:34:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 20:35:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 20:35:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 20:35:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 20:35:55Z] PROBE NO-GO: pod kkgrnt2a4uhqsm not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 20:35:55Z] DELETE pod kkgrnt2a4uhqsm
+[t=   63.3s 20:35:56Z] delete returned status=204 resp={}
+[t=   68.7s 20:36:01Z] pod kkgrnt2a4uhqsm confirmed terminated (404)
+[t=   68.7s 20:36:01Z] PROBE: pod kkgrnt2a4uhqsm torn down
+[t=    0.0s 20:36:01Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:36:01Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.7s 20:36:03Z] create OK id=5lay16u8vuo118 costPerHr=$3.29
+[t=    1.7s 20:36:03Z] PROBE: pod created id=5lay16u8vuo118; waiting for publicIp+ssh_port
+[t=    2.2s 20:36:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.0s 20:36:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.7s 20:36:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.3s 20:36:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.3s 20:37:06Z] PROBE NO-GO: pod 5lay16u8vuo118 not RUNNING+SSH within 60s; tearing down
+[t=   64.3s 20:37:06Z] DELETE pod 5lay16u8vuo118
+[t=   65.0s 20:37:06Z] delete returned status=204 resp={}
+[t=   70.3s 20:37:12Z] pod 5lay16u8vuo118 confirmed terminated (404)
+[t=   70.3s 20:37:12Z] PROBE: pod 5lay16u8vuo118 torn down
+[t=    0.0s 20:37:12Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:37:12Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 20:37:12Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 20:37:12Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:37:13Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 20:37:13Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 20:37:14Z] create OK id=5yg2ao170ol1dn costPerHr=$1.39
+[t=    1.0s 20:37:14Z] PROBE: pod created id=5yg2ao170ol1dn; waiting for publicIp+ssh_port
+[t=    1.3s 20:37:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 20:37:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 20:37:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 20:38:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.5s 20:38:15Z] PROBE NO-GO: pod 5yg2ao170ol1dn not RUNNING+SSH within 60s; tearing down
+[t=   62.5s 20:38:15Z] DELETE pod 5yg2ao170ol1dn
+[t=   63.1s 20:38:16Z] delete returned status=204 resp={}
+[t=   68.4s 20:38:21Z] pod 5yg2ao170ol1dn confirmed terminated (404)
+[t=   68.4s 20:38:21Z] PROBE: pod 5yg2ao170ol1dn torn down
+[t=    0.0s 20:38:38Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 20:38:38Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 20:38:39Z] create OK id=aa05wbxpj3zqr7 costPerHr=$1.49
+[t=    1.0s 20:38:39Z] PROBE: pod created id=aa05wbxpj3zqr7; waiting for publicIp+ssh_port
+[t=    1.3s 20:38:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 20:38:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 20:39:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 20:39:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 20:39:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.6s 20:39:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.9s 20:40:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.2s 20:40:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.2s 20:40:43Z] PROBE NO-GO: pod aa05wbxpj3zqr7 not RUNNING+SSH within 120s; tearing down
+[t=  125.2s 20:40:43Z] DELETE pod aa05wbxpj3zqr7
+[t=  125.8s 20:40:44Z] delete returned status=204 resp={}
+[t=  131.3s 20:40:49Z] pod aa05wbxpj3zqr7 confirmed terminated (404)
+[t=  131.3s 20:40:49Z] PROBE: pod aa05wbxpj3zqr7 torn down
+[t=    0.0s 20:40:49Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:40:49Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 20:40:50Z] create OK id=x919flbj7ttycp costPerHr=$1.39
+[t=    1.1s 20:40:50Z] PROBE: pod created id=x919flbj7ttycp; waiting for publicIp+ssh_port
+[t=    1.5s 20:40:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 20:41:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 20:41:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 20:41:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 20:41:52Z] PROBE NO-GO: pod x919flbj7ttycp not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 20:41:52Z] DELETE pod x919flbj7ttycp
+[t=   63.7s 20:41:53Z] delete returned status=204 resp={}
+[t=   69.0s 20:41:58Z] pod x919flbj7ttycp confirmed terminated (404)
+[t=   69.0s 20:41:58Z] PROBE: pod x919flbj7ttycp torn down
+[t=    0.0s 20:41:59Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:41:59Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 20:42:00Z] create OK id=3u2sw5uycmr3u3 costPerHr=$3.29
+[t=    1.5s 20:42:00Z] PROBE: pod created id=3u2sw5uycmr3u3; waiting for publicIp+ssh_port
+[t=    2.0s 20:42:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 20:42:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 20:42:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.3s 20:42:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.4s 20:43:03Z] PROBE NO-GO: pod 3u2sw5uycmr3u3 not RUNNING+SSH within 60s; tearing down
+[t=   64.4s 20:43:03Z] DELETE pod 3u2sw5uycmr3u3
+[t=   64.9s 20:43:04Z] delete returned status=204 resp={}
+[t=   70.2s 20:43:09Z] pod 3u2sw5uycmr3u3 confirmed terminated (404)
+[t=   70.2s 20:43:09Z] PROBE: pod 3u2sw5uycmr3u3 torn down
+[t=    0.0s 20:43:09Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:43:09Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 20:43:10Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 20:43:10Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:43:10Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 20:43:10Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 20:43:11Z] create OK id=isp559t1ht2nfv costPerHr=$1.39
+[t=    0.9s 20:43:11Z] PROBE: pod created id=isp559t1ht2nfv; waiting for publicIp+ssh_port
+[t=    1.3s 20:43:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 20:43:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 20:43:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 20:43:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 20:44:12Z] PROBE NO-GO: pod isp559t1ht2nfv not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 20:44:12Z] DELETE pod isp559t1ht2nfv
+[t=   63.1s 20:44:13Z] delete returned status=204 resp={}
+[t=   68.5s 20:44:18Z] pod isp559t1ht2nfv confirmed terminated (404)
+[t=   68.5s 20:44:18Z] PROBE: pod isp559t1ht2nfv torn down
+[t=    0.0s 20:44:41Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 20:44:41Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 20:44:42Z] create OK id=tq4lblxxh2uzdv costPerHr=$1.49
+[t=    1.1s 20:44:42Z] PROBE: pod created id=tq4lblxxh2uzdv; waiting for publicIp+ssh_port
+[t=    1.4s 20:44:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 20:44:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 20:45:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 20:45:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 20:45:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.2s 20:45:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.6s 20:46:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.0s 20:46:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.0s 20:46:45Z] PROBE NO-GO: pod tq4lblxxh2uzdv not RUNNING+SSH within 120s; tearing down
+[t=  124.0s 20:46:45Z] DELETE pod tq4lblxxh2uzdv
+[t=  124.7s 20:46:45Z] delete returned status=204 resp={}
+[t=  130.1s 20:46:51Z] pod tq4lblxxh2uzdv confirmed terminated (404)
+[t=  130.1s 20:46:51Z] PROBE: pod tq4lblxxh2uzdv torn down
+[t=    0.0s 20:46:51Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:46:51Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 20:46:52Z] create OK id=iudbsl90ho9dza costPerHr=$1.39
+[t=    1.4s 20:46:52Z] PROBE: pod created id=iudbsl90ho9dza; waiting for publicIp+ssh_port
+[t=    2.0s 20:46:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 20:47:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 20:47:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.0s 20:47:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.0s 20:47:55Z] PROBE NO-GO: pod iudbsl90ho9dza not RUNNING+SSH within 60s; tearing down
+[t=   64.0s 20:47:55Z] DELETE pod iudbsl90ho9dza
+[t=   64.9s 20:47:56Z] delete returned status=204 resp={}
+[t=   70.1s 20:48:01Z] pod iudbsl90ho9dza confirmed terminated (404)
+[t=   70.1s 20:48:01Z] PROBE: pod iudbsl90ho9dza torn down
+[t=    0.0s 20:48:01Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:48:01Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 20:48:03Z] create OK id=snd00ug7xdbakv costPerHr=$3.29
+[t=    1.6s 20:48:03Z] PROBE: pod created id=snd00ug7xdbakv; waiting for publicIp+ssh_port
+[t=    2.1s 20:48:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 20:48:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.0s 20:48:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.8s 20:48:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.8s 20:49:06Z] PROBE NO-GO: pod snd00ug7xdbakv not RUNNING+SSH within 60s; tearing down
+[t=   64.8s 20:49:06Z] DELETE pod snd00ug7xdbakv
+[t=   65.3s 20:49:07Z] delete returned status=204 resp={}
+[t=   70.6s 20:49:12Z] pod snd00ug7xdbakv confirmed terminated (404)
+[t=   70.6s 20:49:12Z] PROBE: pod snd00ug7xdbakv torn down
+[t=    0.0s 20:49:12Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:49:12Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 20:49:13Z] create OK id=r8sdk59nhyl298 costPerHr=$2.89
+[t=    1.0s 20:49:13Z] PROBE: pod created id=r8sdk59nhyl298; waiting for publicIp+ssh_port
+[t=    1.3s 20:49:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 20:49:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 20:49:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 20:50:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 20:50:15Z] PROBE NO-GO: pod r8sdk59nhyl298 not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 20:50:15Z] DELETE pod r8sdk59nhyl298
+[t=   63.2s 20:50:15Z] delete returned status=204 resp={}
+[t=   68.6s 20:50:21Z] pod r8sdk59nhyl298 confirmed terminated (404)
+[t=   68.6s 20:50:21Z] PROBE: pod r8sdk59nhyl298 torn down
+[t=    0.0s 20:50:21Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 20:50:21Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.8s 20:50:22Z] create OK id=dj0xojd6dafg0x costPerHr=$1.39
+[t=    0.8s 20:50:22Z] PROBE: pod created id=dj0xojd6dafg0x; waiting for publicIp+ssh_port
+[t=    1.1s 20:50:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 20:50:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 20:50:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 20:51:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.5s 20:51:24Z] PROBE NO-GO: pod dj0xojd6dafg0x not RUNNING+SSH within 60s; tearing down
+[t=   62.5s 20:51:24Z] DELETE pod dj0xojd6dafg0x
+[t=   63.0s 20:51:24Z] delete returned status=204 resp={}
+[t=   68.4s 20:51:29Z] pod dj0xojd6dafg0x confirmed terminated (404)
+[t=   68.4s 20:51:29Z] PROBE: pod dj0xojd6dafg0x torn down
+[t=    0.0s 20:51:49Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 20:51:49Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 20:51:50Z] create OK id=wvzs279tkoiqqm costPerHr=$1.49
+[t=    1.1s 20:51:50Z] PROBE: pod created id=wvzs279tkoiqqm; waiting for publicIp+ssh_port
+[t=    1.4s 20:51:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 20:52:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 20:52:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 20:52:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 20:52:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.4s 20:53:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.9s 20:53:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.5s 20:53:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.5s 20:53:53Z] PROBE NO-GO: pod wvzs279tkoiqqm not RUNNING+SSH within 120s; tearing down
+[t=  124.5s 20:53:53Z] DELETE pod wvzs279tkoiqqm
+[t=  125.1s 20:53:54Z] delete returned status=204 resp={}
+[t=  130.4s 20:53:59Z] pod wvzs279tkoiqqm confirmed terminated (404)
+[t=  130.4s 20:53:59Z] PROBE: pod wvzs279tkoiqqm torn down
+[t=    0.0s 20:54:00Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:54:00Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 20:54:00Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 20:54:00Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 20:54:00Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:54:00Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 20:54:02Z] create OK id=8y00mb542ttjkr costPerHr=$3.29
+[t=    1.3s 20:54:02Z] PROBE: pod created id=8y00mb542ttjkr; waiting for publicIp+ssh_port
+[t=    1.8s 20:54:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.6s 20:54:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.4s 20:54:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 20:54:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 20:55:04Z] PROBE NO-GO: pod 8y00mb542ttjkr not RUNNING+SSH within 60s; tearing down
+[t=   64.1s 20:55:04Z] DELETE pod 8y00mb542ttjkr
+[t=   64.5s 20:55:05Z] delete returned status=204 resp={}
+[t=   69.9s 20:55:10Z] pod 8y00mb542ttjkr confirmed terminated (404)
+[t=   69.9s 20:55:10Z] PROBE: pod 8y00mb542ttjkr torn down
+[t=    0.0s 20:55:10Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:55:10Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 20:55:11Z] create OK id=cz9ual1s788x4s costPerHr=$2.89
+[t=    1.0s 20:55:11Z] PROBE: pod created id=cz9ual1s788x4s; waiting for publicIp+ssh_port
+[t=    1.4s 20:55:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 20:55:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 20:55:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 20:55:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 20:56:13Z] PROBE NO-GO: pod cz9ual1s788x4s not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 20:56:13Z] DELETE pod cz9ual1s788x4s
+[t=   63.3s 20:56:14Z] delete returned status=204 resp={}
+[t=   68.6s 20:56:19Z] pod cz9ual1s788x4s confirmed terminated (404)
+[t=   68.6s 20:56:19Z] PROBE: pod cz9ual1s788x4s torn down
+[t=    0.0s 20:56:19Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 20:56:19Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 20:56:20Z] create OK id=vt3v8qgoc26ra0 costPerHr=$1.39
+[t=    0.9s 20:56:20Z] PROBE: pod created id=vt3v8qgoc26ra0; waiting for publicIp+ssh_port
+[t=    1.2s 20:56:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 20:56:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 20:56:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 20:57:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 20:57:22Z] PROBE NO-GO: pod vt3v8qgoc26ra0 not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 20:57:22Z] DELETE pod vt3v8qgoc26ra0
+[t=   63.1s 20:57:22Z] delete returned status=204 resp={}
+[t=   68.4s 20:57:28Z] pod vt3v8qgoc26ra0 confirmed terminated (404)
+[t=   68.4s 20:57:28Z] PROBE: pod vt3v8qgoc26ra0 torn down
+[t=    0.0s 20:57:44Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 20:57:44Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 20:57:45Z] create OK id=qsfm5qsiff62n1 costPerHr=$1.49
+[t=    1.3s 20:57:45Z] PROBE: pod created id=qsfm5qsiff62n1; waiting for publicIp+ssh_port
+[t=    1.6s 20:57:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 20:58:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 20:58:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 20:58:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 20:58:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.0s 20:59:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.4s 20:59:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.8s 20:59:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.8s 20:59:48Z] PROBE NO-GO: pod qsfm5qsiff62n1 not RUNNING+SSH within 120s; tearing down
+[t=  124.8s 20:59:48Z] DELETE pod qsfm5qsiff62n1
+[t=  125.3s 20:59:49Z] delete returned status=204 resp={}
+[t=  130.6s 20:59:54Z] pod qsfm5qsiff62n1 confirmed terminated (404)
+[t=  130.7s 20:59:54Z] PROBE: pod qsfm5qsiff62n1 torn down
+[t=    0.0s 20:59:55Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 20:59:55Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 20:59:56Z] create OK id=sn00if9mkgwp8k costPerHr=$1.39
+[t=    1.0s 20:59:56Z] PROBE: pod created id=sn00if9mkgwp8k; waiting for publicIp+ssh_port
+[t=    1.3s 20:59:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 21:00:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 21:00:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 21:00:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.5s 21:00:57Z] PROBE NO-GO: pod sn00if9mkgwp8k not RUNNING+SSH within 60s; tearing down
+[t=   62.5s 21:00:57Z] DELETE pod sn00if9mkgwp8k
+[t=   63.1s 21:00:58Z] delete returned status=204 resp={}
+[t=   68.5s 21:01:03Z] pod sn00if9mkgwp8k confirmed terminated (404)
+[t=   68.5s 21:01:03Z] PROBE: pod sn00if9mkgwp8k torn down
+[t=    0.0s 21:01:03Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:01:03Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 21:01:05Z] create OK id=7a4o32tm4dd0zy costPerHr=$3.29
+[t=    1.5s 21:01:05Z] PROBE: pod created id=7a4o32tm4dd0zy; waiting for publicIp+ssh_port
+[t=    2.0s 21:01:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 21:01:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.5s 21:01:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.2s 21:01:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.2s 21:02:08Z] PROBE NO-GO: pod 7a4o32tm4dd0zy not RUNNING+SSH within 60s; tearing down
+[t=   64.2s 21:02:08Z] DELETE pod 7a4o32tm4dd0zy
+[t=   64.8s 21:02:08Z] delete returned status=204 resp={}
+[t=   70.1s 21:02:13Z] pod 7a4o32tm4dd0zy confirmed terminated (404)
+[t=   70.1s 21:02:13Z] PROBE: pod 7a4o32tm4dd0zy torn down
+[t=    0.0s 21:02:14Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:02:14Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 21:02:14Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 21:02:14Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:02:14Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 21:02:14Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 21:02:15Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 21:02:15Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:02:32Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 21:02:32Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 21:02:33Z] create OK id=r8r5q1ucd2g2yt costPerHr=$1.49
+[t=    1.0s 21:02:33Z] PROBE: pod created id=r8r5q1ucd2g2yt; waiting for publicIp+ssh_port
+[t=    1.4s 21:02:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 21:02:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 21:03:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 21:03:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 21:03:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.4s 21:03:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.8s 21:04:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.3s 21:04:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.3s 21:04:36Z] PROBE NO-GO: pod r8r5q1ucd2g2yt not RUNNING+SSH within 120s; tearing down
+[t=  124.3s 21:04:36Z] DELETE pod r8r5q1ucd2g2yt
+[t=  124.8s 21:04:37Z] delete returned status=204 resp={}
+[t=  130.1s 21:04:42Z] pod r8r5q1ucd2g2yt confirmed terminated (404)
+[t=  130.1s 21:04:42Z] PROBE: pod r8r5q1ucd2g2yt torn down
+[t=    0.0s 21:04:42Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:04:42Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 21:04:44Z] create OK id=skd4l6kc1anvr1 costPerHr=$1.39
+[t=    1.4s 21:04:44Z] PROBE: pod created id=skd4l6kc1anvr1; waiting for publicIp+ssh_port
+[t=    1.8s 21:04:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 21:05:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.0s 21:05:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.5s 21:05:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.5s 21:05:46Z] PROBE NO-GO: pod skd4l6kc1anvr1 not RUNNING+SSH within 60s; tearing down
+[t=   63.5s 21:05:46Z] DELETE pod skd4l6kc1anvr1
+[t=   64.1s 21:05:46Z] delete returned status=204 resp={}
+[t=   69.4s 21:05:52Z] pod skd4l6kc1anvr1 confirmed terminated (404)
+[t=   69.4s 21:05:52Z] PROBE: pod skd4l6kc1anvr1 torn down
+[t=    0.0s 21:05:52Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:05:52Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 21:05:53Z] create OK id=bubkginpi0l31e costPerHr=$3.29
+[t=    1.5s 21:05:53Z] PROBE: pod created id=bubkginpi0l31e; waiting for publicIp+ssh_port
+[t=    2.0s 21:05:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 21:06:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.7s 21:06:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.3s 21:06:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.4s 21:06:56Z] PROBE NO-GO: pod bubkginpi0l31e not RUNNING+SSH within 60s; tearing down
+[t=   64.4s 21:06:56Z] DELETE pod bubkginpi0l31e
+[t=   64.9s 21:06:57Z] delete returned status=204 resp={}
+[t=   70.2s 21:07:02Z] pod bubkginpi0l31e confirmed terminated (404)
+[t=   70.2s 21:07:02Z] PROBE: pod bubkginpi0l31e torn down
+[t=    0.0s 21:07:02Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:07:02Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:07:03Z] create OK id=wsbmu30u4uew67 costPerHr=$2.89
+[t=    1.1s 21:07:03Z] PROBE: pod created id=wsbmu30u4uew67; waiting for publicIp+ssh_port
+[t=    1.4s 21:07:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 21:07:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 21:07:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 21:07:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 21:08:05Z] PROBE NO-GO: pod wsbmu30u4uew67 not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 21:08:05Z] DELETE pod wsbmu30u4uew67
+[t=   63.1s 21:08:05Z] delete returned status=204 resp={}
+[t=   68.5s 21:08:11Z] pod wsbmu30u4uew67 confirmed terminated (404)
+[t=   68.5s 21:08:11Z] PROBE: pod wsbmu30u4uew67 torn down
+[t=    0.0s 21:08:11Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 21:08:11Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.7s 21:08:12Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.7s 21:08:12Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:08:28Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 21:08:28Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 21:08:29Z] create OK id=2k82ep2f89k5q2 costPerHr=$1.49
+[t=    1.2s 21:08:29Z] PROBE: pod created id=2k82ep2f89k5q2; waiting for publicIp+ssh_port
+[t=    1.4s 21:08:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 21:08:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 21:09:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 21:09:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 21:09:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.2s 21:09:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.6s 21:10:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.0s 21:10:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.0s 21:10:32Z] PROBE NO-GO: pod 2k82ep2f89k5q2 not RUNNING+SSH within 120s; tearing down
+[t=  124.0s 21:10:32Z] DELETE pod 2k82ep2f89k5q2
+[t=  124.5s 21:10:32Z] delete returned status=204 resp={}
+[t=  130.0s 21:10:38Z] pod 2k82ep2f89k5q2 confirmed terminated (404)
+[t=  130.0s 21:10:38Z] PROBE: pod 2k82ep2f89k5q2 torn down
+[t=    0.0s 21:10:38Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:10:38Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 21:10:38Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 21:10:38Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:10:39Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:10:39Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 21:10:40Z] create OK id=2yp4lgob9wgtec costPerHr=$3.29
+[t=    1.6s 21:10:40Z] PROBE: pod created id=2yp4lgob9wgtec; waiting for publicIp+ssh_port
+[t=    2.2s 21:10:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 21:10:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.9s 21:11:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.6s 21:11:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.6s 21:11:43Z] PROBE NO-GO: pod 2yp4lgob9wgtec not RUNNING+SSH within 60s; tearing down
+[t=   64.6s 21:11:43Z] DELETE pod 2yp4lgob9wgtec
+[t=   65.2s 21:11:44Z] delete returned status=204 resp={}
+[t=   70.4s 21:11:49Z] pod 2yp4lgob9wgtec confirmed terminated (404)
+[t=   70.5s 21:11:49Z] PROBE: pod 2yp4lgob9wgtec torn down
+[t=    0.0s 21:11:49Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:11:49Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:11:50Z] create OK id=l4k4p0mb6tlia8 costPerHr=$2.89
+[t=    1.1s 21:11:50Z] PROBE: pod created id=l4k4p0mb6tlia8; waiting for publicIp+ssh_port
+[t=    1.4s 21:11:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 21:12:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 21:12:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 21:12:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 21:12:52Z] PROBE NO-GO: pod l4k4p0mb6tlia8 not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 21:12:52Z] DELETE pod l4k4p0mb6tlia8
+[t=   63.2s 21:12:52Z] delete returned status=204 resp={}
+[t=   68.5s 21:12:58Z] pod l4k4p0mb6tlia8 confirmed terminated (404)
+[t=   68.5s 21:12:58Z] PROBE: pod l4k4p0mb6tlia8 torn down
+[t=    0.0s 21:12:58Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 21:12:58Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 21:12:58Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 21:12:58Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:13:18Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 21:13:18Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 21:13:19Z] create OK id=ronwxctd3mgwht costPerHr=$1.49
+[t=    1.3s 21:13:19Z] PROBE: pod created id=ronwxctd3mgwht; waiting for publicIp+ssh_port
+[t=    1.7s 21:13:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 21:13:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 21:13:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.5s 21:14:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 21:14:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.6s 21:14:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.2s 21:14:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.7s 21:15:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.7s 21:15:24Z] PROBE NO-GO: pod ronwxctd3mgwht not RUNNING+SSH within 120s; tearing down
+[t=  125.7s 21:15:24Z] DELETE pod ronwxctd3mgwht
+[t=  126.3s 21:15:24Z] delete returned status=204 resp={}
+[t=  131.6s 21:15:29Z] pod ronwxctd3mgwht confirmed terminated (404)
+[t=  131.6s 21:15:29Z] PROBE: pod ronwxctd3mgwht torn down
+[t=    0.0s 21:15:30Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:15:30Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 21:15:30Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 21:15:30Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:15:30Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:15:30Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:15:31Z] create OK id=4j1q9nghjqc9f8 costPerHr=$3.29
+[t=    1.1s 21:15:31Z] PROBE: pod created id=4j1q9nghjqc9f8; waiting for publicIp+ssh_port
+[t=    1.4s 21:15:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 21:15:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 21:16:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 21:16:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 21:16:33Z] PROBE NO-GO: pod 4j1q9nghjqc9f8 not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 21:16:33Z] DELETE pod 4j1q9nghjqc9f8
+[t=   63.5s 21:16:34Z] delete returned status=204 resp={}
+[t=   68.8s 21:16:39Z] pod 4j1q9nghjqc9f8 confirmed terminated (404)
+[t=   68.8s 21:16:39Z] PROBE: pod 4j1q9nghjqc9f8 torn down
+[t=    0.0s 21:16:39Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:16:39Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:16:40Z] create OK id=dl4m3wsawfm1ds costPerHr=$2.89
+[t=    1.1s 21:16:40Z] PROBE: pod created id=dl4m3wsawfm1ds; waiting for publicIp+ssh_port
+[t=    1.5s 21:16:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 21:16:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 21:17:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 21:17:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 21:17:42Z] PROBE NO-GO: pod dl4m3wsawfm1ds not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 21:17:42Z] DELETE pod dl4m3wsawfm1ds
+[t=   63.5s 21:17:43Z] delete returned status=204 resp={}
+[t=   68.8s 21:17:48Z] pod dl4m3wsawfm1ds confirmed terminated (404)
+[t=   68.8s 21:17:48Z] PROBE: pod dl4m3wsawfm1ds torn down
+[t=    0.0s 21:17:48Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 21:17:48Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 21:17:49Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 21:17:49Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:18:10Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 21:18:10Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:18:11Z] create OK id=h6oraixzpagol4 costPerHr=$1.49
+[t=    1.1s 21:18:11Z] PROBE: pod created id=h6oraixzpagol4; waiting for publicIp+ssh_port
+[t=    1.4s 21:18:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 21:18:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 21:18:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 21:18:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 21:19:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.2s 21:19:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.5s 21:19:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  108.8s 21:19:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  123.8s 21:20:14Z] PROBE NO-GO: pod h6oraixzpagol4 not RUNNING+SSH within 120s; tearing down
+[t=  123.8s 21:20:14Z] DELETE pod h6oraixzpagol4
+[t=  124.4s 21:20:14Z] delete returned status=204 resp={}
+[t=  129.7s 21:20:19Z] pod h6oraixzpagol4 confirmed terminated (404)
+[t=  129.7s 21:20:19Z] PROBE: pod h6oraixzpagol4 torn down
+[t=    0.0s 21:20:20Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:20:20Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 21:20:20Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 21:20:20Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:20:20Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:20:20Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:20:21Z] create OK id=v9un6tdzd7m7el costPerHr=$3.29
+[t=    1.1s 21:20:21Z] PROBE: pod created id=v9un6tdzd7m7el; waiting for publicIp+ssh_port
+[t=    1.4s 21:20:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 21:20:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 21:20:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 21:21:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 21:21:23Z] PROBE NO-GO: pod v9un6tdzd7m7el not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 21:21:23Z] DELETE pod v9un6tdzd7m7el
+[t=   63.2s 21:21:24Z] delete returned status=204 resp={}
+[t=   68.6s 21:21:29Z] pod v9un6tdzd7m7el confirmed terminated (404)
+[t=   68.6s 21:21:29Z] PROBE: pod v9un6tdzd7m7el torn down
+[t=    0.0s 21:21:29Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:21:29Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:21:30Z] create OK id=vz5c5zg1swhopa costPerHr=$2.89
+[t=    1.1s 21:21:30Z] PROBE: pod created id=vz5c5zg1swhopa; waiting for publicIp+ssh_port
+[t=    1.4s 21:21:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 21:21:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 21:22:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 21:22:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 21:22:32Z] PROBE NO-GO: pod vz5c5zg1swhopa not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 21:22:32Z] DELETE pod vz5c5zg1swhopa
+[t=   63.3s 21:22:32Z] delete returned status=204 resp={}
+[t=   68.6s 21:22:38Z] pod vz5c5zg1swhopa confirmed terminated (404)
+[t=   68.6s 21:22:38Z] PROBE: pod vz5c5zg1swhopa torn down
+[t=    0.0s 21:22:38Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 21:22:38Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 21:22:39Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 21:22:39Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:22:54Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 21:22:54Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:22:55Z] create OK id=epqwl5xmcr37i6 costPerHr=$1.49
+[t=    1.1s 21:22:55Z] PROBE: pod created id=epqwl5xmcr37i6; waiting for publicIp+ssh_port
+[t=    1.4s 21:22:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 21:23:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 21:23:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 21:23:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 21:23:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.4s 21:24:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.8s 21:24:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.2s 21:24:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.2s 21:24:58Z] PROBE NO-GO: pod epqwl5xmcr37i6 not RUNNING+SSH within 120s; tearing down
+[t=  124.2s 21:24:58Z] DELETE pod epqwl5xmcr37i6
+[t=  124.6s 21:24:58Z] delete returned status=204 resp={}
+[t=  129.9s 21:25:04Z] pod epqwl5xmcr37i6 confirmed terminated (404)
+[t=  129.9s 21:25:04Z] PROBE: pod epqwl5xmcr37i6 torn down
+[t=    0.0s 21:25:04Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:25:04Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:25:05Z] create OK id=8bh9jrpty63os7 costPerHr=$1.39
+[t=    1.1s 21:25:05Z] PROBE: pod created id=8bh9jrpty63os7; waiting for publicIp+ssh_port
+[t=    1.5s 21:25:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 21:25:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 21:25:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 21:25:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 21:26:06Z] PROBE NO-GO: pod 8bh9jrpty63os7 not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 21:26:06Z] DELETE pod 8bh9jrpty63os7
+[t=   63.2s 21:26:07Z] delete returned status=204 resp={}
+[t=   68.5s 21:26:12Z] pod 8bh9jrpty63os7 confirmed terminated (404)
+[t=   68.5s 21:26:12Z] PROBE: pod 8bh9jrpty63os7 torn down
+[t=    0.0s 21:26:12Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:26:12Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 21:26:14Z] create OK id=7f5ezfcmguq14z costPerHr=$3.29
+[t=    1.3s 21:26:14Z] PROBE: pod created id=7f5ezfcmguq14z; waiting for publicIp+ssh_port
+[t=    1.6s 21:26:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 21:26:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 21:26:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.0s 21:27:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.0s 21:27:16Z] PROBE NO-GO: pod 7f5ezfcmguq14z not RUNNING+SSH within 60s; tearing down
+[t=   64.0s 21:27:16Z] DELETE pod 7f5ezfcmguq14z
+[t=   64.5s 21:27:17Z] delete returned status=204 resp={}
+[t=   69.8s 21:27:22Z] pod 7f5ezfcmguq14z confirmed terminated (404)
+[t=   69.8s 21:27:22Z] PROBE: pod 7f5ezfcmguq14z torn down
+[t=    0.0s 21:27:22Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:27:22Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.7s 21:27:24Z] create OK id=z5q430pa3qnk11 costPerHr=$2.89
+[t=    1.7s 21:27:24Z] PROBE: pod created id=z5q430pa3qnk11; waiting for publicIp+ssh_port
+[t=    2.1s 21:27:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 21:27:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 21:27:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 21:28:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 21:28:26Z] PROBE NO-GO: pod z5q430pa3qnk11 not RUNNING+SSH within 60s; tearing down
+[t=   63.3s 21:28:26Z] DELETE pod z5q430pa3qnk11
+[t=   63.9s 21:28:26Z] delete returned status=204 resp={}
+[t=   69.2s 21:28:32Z] pod z5q430pa3qnk11 confirmed terminated (404)
+[t=   69.2s 21:28:32Z] PROBE: pod z5q430pa3qnk11 torn down
+[t=    0.0s 21:28:32Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 21:28:32Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 21:28:32Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 21:28:32Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:28:50Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 21:28:50Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:28:51Z] create OK id=gxu8e2ei4of34q costPerHr=$1.49
+[t=    1.1s 21:28:51Z] PROBE: pod created id=gxu8e2ei4of34q; waiting for publicIp+ssh_port
+[t=    1.4s 21:28:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 21:29:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 21:29:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.6s 21:29:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.3s 21:29:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.7s 21:30:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.0s 21:30:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.5s 21:30:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.5s 21:30:56Z] PROBE NO-GO: pod gxu8e2ei4of34q not RUNNING+SSH within 120s; tearing down
+[t=  125.5s 21:30:56Z] DELETE pod gxu8e2ei4of34q
+[t=  126.0s 21:30:56Z] delete returned status=204 resp={}
+[t=  131.3s 21:31:01Z] pod gxu8e2ei4of34q confirmed terminated (404)
+[t=  131.3s 21:31:01Z] PROBE: pod gxu8e2ei4of34q torn down
+[t=    0.0s 21:31:02Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:31:02Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:31:03Z] create OK id=thcqjzs4dozamo costPerHr=$1.39
+[t=    1.1s 21:31:03Z] PROBE: pod created id=thcqjzs4dozamo; waiting for publicIp+ssh_port
+[t=    1.4s 21:31:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 21:31:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 21:31:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 21:31:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 21:32:04Z] PROBE NO-GO: pod thcqjzs4dozamo not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 21:32:04Z] DELETE pod thcqjzs4dozamo
+[t=   63.1s 21:32:05Z] delete returned status=204 resp={}
+[t=   68.5s 21:32:10Z] pod thcqjzs4dozamo confirmed terminated (404)
+[t=   68.5s 21:32:10Z] PROBE: pod thcqjzs4dozamo torn down
+[t=    0.0s 21:32:10Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:32:10Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 21:32:12Z] create OK id=8idoljm6p9a69c costPerHr=$3.29
+[t=    1.5s 21:32:12Z] PROBE: pod created id=8idoljm6p9a69c; waiting for publicIp+ssh_port
+[t=    2.7s 21:32:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.4s 21:32:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.1s 21:32:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.9s 21:33:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.9s 21:33:15Z] PROBE NO-GO: pod 8idoljm6p9a69c not RUNNING+SSH within 60s; tearing down
+[t=   64.9s 21:33:15Z] DELETE pod 8idoljm6p9a69c
+[t=   65.5s 21:33:16Z] delete returned status=204 resp={}
+[t=   70.8s 21:33:21Z] pod 8idoljm6p9a69c confirmed terminated (404)
+[t=   70.8s 21:33:21Z] PROBE: pod 8idoljm6p9a69c torn down
+[t=    0.0s 21:33:21Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:33:21Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 21:33:23Z] create OK id=3pgrmsbqyn2zpu costPerHr=$2.89
+[t=    1.2s 21:33:23Z] PROBE: pod created id=3pgrmsbqyn2zpu; waiting for publicIp+ssh_port
+[t=    1.5s 21:33:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 21:33:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 21:33:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 21:34:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 21:34:24Z] PROBE NO-GO: pod 3pgrmsbqyn2zpu not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 21:34:24Z] DELETE pod 3pgrmsbqyn2zpu
+[t=   63.4s 21:34:25Z] delete returned status=204 resp={}
+[t=   68.7s 21:34:30Z] pod 3pgrmsbqyn2zpu confirmed terminated (404)
+[t=   68.7s 21:34:30Z] PROBE: pod 3pgrmsbqyn2zpu torn down
+[t=    0.0s 21:34:30Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 21:34:30Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 21:34:31Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 21:34:31Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:34:47Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 21:34:47Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:34:48Z] create OK id=9rj6w546tk9bnt costPerHr=$1.49
+[t=    1.1s 21:34:48Z] PROBE: pod created id=9rj6w546tk9bnt; waiting for publicIp+ssh_port
+[t=    1.4s 21:34:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 21:35:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 21:35:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 21:35:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 21:35:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.4s 21:36:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.8s 21:36:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.2s 21:36:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.2s 21:36:51Z] PROBE NO-GO: pod 9rj6w546tk9bnt not RUNNING+SSH within 120s; tearing down
+[t=  124.2s 21:36:51Z] DELETE pod 9rj6w546tk9bnt
+[t=  124.7s 21:36:52Z] delete returned status=204 resp={}
+[t=  130.1s 21:36:57Z] pod 9rj6w546tk9bnt confirmed terminated (404)
+[t=  130.1s 21:36:57Z] PROBE: pod 9rj6w546tk9bnt torn down
+[t=    0.0s 21:36:57Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:36:57Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.8s 21:36:58Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.8s 21:36:58Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:36:58Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:36:58Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 21:37:00Z] create OK id=2540rieb5lhiz9 costPerHr=$3.29
+[t=    1.4s 21:37:00Z] PROBE: pod created id=2540rieb5lhiz9; waiting for publicIp+ssh_port
+[t=    2.1s 21:37:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 21:37:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 21:37:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.3s 21:37:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.3s 21:38:03Z] PROBE NO-GO: pod 2540rieb5lhiz9 not RUNNING+SSH within 60s; tearing down
+[t=   64.3s 21:38:03Z] DELETE pod 2540rieb5lhiz9
+[t=   64.9s 21:38:03Z] delete returned status=204 resp={}
+[t=   70.2s 21:38:09Z] pod 2540rieb5lhiz9 confirmed terminated (404)
+[t=   70.2s 21:38:09Z] PROBE: pod 2540rieb5lhiz9 torn down
+[t=    0.0s 21:38:09Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:38:09Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:38:10Z] create OK id=thsmheyjcb308q costPerHr=$2.89
+[t=    1.1s 21:38:10Z] PROBE: pod created id=thsmheyjcb308q; waiting for publicIp+ssh_port
+[t=    1.4s 21:38:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 21:38:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 21:38:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 21:38:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 21:39:11Z] PROBE NO-GO: pod thsmheyjcb308q not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 21:39:11Z] DELETE pod thsmheyjcb308q
+[t=   63.2s 21:39:12Z] delete returned status=204 resp={}
+[t=   68.5s 21:39:17Z] pod thsmheyjcb308q confirmed terminated (404)
+[t=   68.5s 21:39:17Z] PROBE: pod thsmheyjcb308q torn down
+[t=    0.0s 21:39:18Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 21:39:18Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 21:39:18Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 21:39:18Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:39:35Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 21:39:35Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 21:39:36Z] create OK id=2fkjgr4r2jxt7c costPerHr=$1.49
+[t=    1.0s 21:39:36Z] PROBE: pod created id=2fkjgr4r2jxt7c; waiting for publicIp+ssh_port
+[t=    1.4s 21:39:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 21:39:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 21:40:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.7s 21:40:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 21:40:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.6s 21:40:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.0s 21:41:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.3s 21:41:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.3s 21:41:40Z] PROBE NO-GO: pod 2fkjgr4r2jxt7c not RUNNING+SSH within 120s; tearing down
+[t=  125.4s 21:41:40Z] DELETE pod 2fkjgr4r2jxt7c
+[t=  126.0s 21:41:41Z] delete returned status=204 resp={}
+[t=  131.3s 21:41:46Z] pod 2fkjgr4r2jxt7c confirmed terminated (404)
+[t=  131.3s 21:41:46Z] PROBE: pod 2fkjgr4r2jxt7c torn down
+[t=    0.0s 21:41:46Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:41:46Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:41:47Z] create OK id=ftzcxsas9e8m3r costPerHr=$1.39
+[t=    1.1s 21:41:47Z] PROBE: pod created id=ftzcxsas9e8m3r; waiting for publicIp+ssh_port
+[t=    1.4s 21:41:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 21:42:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 21:42:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 21:42:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 21:42:49Z] PROBE NO-GO: pod ftzcxsas9e8m3r not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 21:42:49Z] DELETE pod ftzcxsas9e8m3r
+[t=   63.2s 21:42:50Z] delete returned status=204 resp={}
+[t=   68.5s 21:42:55Z] pod ftzcxsas9e8m3r confirmed terminated (404)
+[t=   68.5s 21:42:55Z] PROBE: pod ftzcxsas9e8m3r torn down
+[t=    0.0s 21:42:55Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:42:55Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 21:42:56Z] create OK id=99b7qf3euvql2m costPerHr=$3.29
+[t=    1.4s 21:42:56Z] PROBE: pod created id=99b7qf3euvql2m; waiting for publicIp+ssh_port
+[t=    1.9s 21:42:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.6s 21:43:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.3s 21:43:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   50.0s 21:43:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.0s 21:44:00Z] PROBE NO-GO: pod 99b7qf3euvql2m not RUNNING+SSH within 60s; tearing down
+[t=   65.0s 21:44:00Z] DELETE pod 99b7qf3euvql2m
+[t=   65.6s 21:44:01Z] delete returned status=204 resp={}
+[t=   71.4s 21:44:06Z] pod 99b7qf3euvql2m confirmed terminated (404)
+[t=   71.4s 21:44:06Z] PROBE: pod 99b7qf3euvql2m torn down
+[t=    0.0s 21:44:07Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:44:07Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 21:44:07Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 21:44:07Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:44:07Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 21:44:07Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 21:44:08Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 21:44:08Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:44:23Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 21:44:23Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    2.7s 21:44:26Z] create OK id=7h78yabx5hj8iu costPerHr=$1.49
+[t=    2.7s 21:44:26Z] PROBE: pod created id=7h78yabx5hj8iu; waiting for publicIp+ssh_port
+[t=    3.0s 21:44:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.5s 21:44:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.9s 21:44:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.6s 21:45:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.1s 21:45:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.5s 21:45:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.9s 21:45:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.3s 21:46:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.3s 21:46:29Z] PROBE NO-GO: pod 7h78yabx5hj8iu not RUNNING+SSH within 120s; tearing down
+[t=  126.3s 21:46:29Z] DELETE pod 7h78yabx5hj8iu
+[t=  126.9s 21:46:30Z] delete returned status=204 resp={}
+[t=  132.2s 21:46:35Z] pod 7h78yabx5hj8iu confirmed terminated (404)
+[t=  132.2s 21:46:35Z] PROBE: pod 7h78yabx5hj8iu torn down
+[t=    0.0s 21:46:35Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:46:35Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 21:46:37Z] create OK id=tedwwest7pm4k4 costPerHr=$1.39
+[t=    1.3s 21:46:37Z] PROBE: pod created id=tedwwest7pm4k4; waiting for publicIp+ssh_port
+[t=    1.6s 21:46:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 21:46:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 21:47:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 21:47:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 21:47:38Z] PROBE NO-GO: pod tedwwest7pm4k4 not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 21:47:38Z] DELETE pod tedwwest7pm4k4
+[t=   63.5s 21:47:39Z] delete returned status=204 resp={}
+[t=   68.9s 21:47:44Z] pod tedwwest7pm4k4 confirmed terminated (404)
+[t=   68.9s 21:47:44Z] PROBE: pod tedwwest7pm4k4 torn down
+[t=    0.0s 21:47:45Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:47:45Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 21:47:46Z] create OK id=iyurtubzfaixfs costPerHr=$3.29
+[t=    1.3s 21:47:46Z] PROBE: pod created id=iyurtubzfaixfs; waiting for publicIp+ssh_port
+[t=    1.9s 21:47:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.1s 21:48:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.8s 21:48:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 21:48:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 21:48:49Z] PROBE NO-GO: pod iyurtubzfaixfs not RUNNING+SSH within 60s; tearing down
+[t=   64.5s 21:48:49Z] DELETE pod iyurtubzfaixfs
+[t=   65.1s 21:48:50Z] delete returned status=204 resp={}
+[t=   70.4s 21:48:55Z] pod iyurtubzfaixfs confirmed terminated (404)
+[t=   70.4s 21:48:55Z] PROBE: pod iyurtubzfaixfs torn down
+[t=    0.0s 21:48:55Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:48:55Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:48:56Z] create OK id=0x29oh3b00gtd1 costPerHr=$2.89
+[t=    1.1s 21:48:56Z] PROBE: pod created id=0x29oh3b00gtd1; waiting for publicIp+ssh_port
+[t=    1.4s 21:48:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 21:49:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 21:49:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 21:49:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 21:49:58Z] PROBE NO-GO: pod 0x29oh3b00gtd1 not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 21:49:58Z] DELETE pod 0x29oh3b00gtd1
+[t=   63.2s 21:49:58Z] delete returned status=204 resp={}
+[t=   68.6s 21:50:04Z] pod 0x29oh3b00gtd1 confirmed terminated (404)
+[t=   68.6s 21:50:04Z] PROBE: pod 0x29oh3b00gtd1 torn down
+[t=    0.0s 21:50:04Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 21:50:04Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 21:50:04Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 21:50:04Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:50:28Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 21:50:28Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 21:50:29Z] create OK id=8fh6wcmwmau5ny costPerHr=$1.49
+[t=    1.0s 21:50:29Z] PROBE: pod created id=8fh6wcmwmau5ny; waiting for publicIp+ssh_port
+[t=    1.3s 21:50:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.6s 21:50:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 21:51:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 21:51:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 21:51:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.0s 21:51:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.4s 21:52:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  108.8s 21:52:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  123.8s 21:52:32Z] PROBE NO-GO: pod 8fh6wcmwmau5ny not RUNNING+SSH within 120s; tearing down
+[t=  123.8s 21:52:32Z] DELETE pod 8fh6wcmwmau5ny
+[t=  124.5s 21:52:33Z] delete returned status=204 resp={}
+[t=  129.8s 21:52:38Z] pod 8fh6wcmwmau5ny confirmed terminated (404)
+[t=  129.8s 21:52:38Z] PROBE: pod 8fh6wcmwmau5ny torn down
+[t=    0.0s 21:52:38Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:52:38Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 21:52:39Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 21:52:39Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:52:39Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:52:39Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 21:52:41Z] create OK id=6972dtoqecbfz5 costPerHr=$3.29
+[t=    1.5s 21:52:41Z] PROBE: pod created id=6972dtoqecbfz5; waiting for publicIp+ssh_port
+[t=    2.1s 21:52:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 21:52:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.1s 21:53:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.9s 21:53:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.9s 21:53:44Z] PROBE NO-GO: pod 6972dtoqecbfz5 not RUNNING+SSH within 60s; tearing down
+[t=   64.9s 21:53:44Z] DELETE pod 6972dtoqecbfz5
+[t=   65.5s 21:53:45Z] delete returned status=204 resp={}
+[t=   70.8s 21:53:50Z] pod 6972dtoqecbfz5 confirmed terminated (404)
+[t=   70.8s 21:53:50Z] PROBE: pod 6972dtoqecbfz5 torn down
+[t=    0.0s 21:53:50Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:53:50Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 21:53:51Z] create OK id=73desznlk3zh3h costPerHr=$2.89
+[t=    1.3s 21:53:51Z] PROBE: pod created id=73desznlk3zh3h; waiting for publicIp+ssh_port
+[t=    1.6s 21:53:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 21:54:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.4s 21:54:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.8s 21:54:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.8s 21:54:54Z] PROBE NO-GO: pod 73desznlk3zh3h not RUNNING+SSH within 60s; tearing down
+[t=   63.8s 21:54:54Z] DELETE pod 73desznlk3zh3h
+[t=   64.4s 21:54:54Z] delete returned status=204 resp={}
+[t=   69.7s 21:55:00Z] pod 73desznlk3zh3h confirmed terminated (404)
+[t=   69.7s 21:55:00Z] PROBE: pod 73desznlk3zh3h torn down
+[t=    0.0s 21:55:00Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 21:55:00Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 21:55:00Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 21:55:00Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 21:55:19Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 21:55:19Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:55:20Z] create OK id=w5ozrysmhupp8e costPerHr=$1.49
+[t=    1.1s 21:55:20Z] PROBE: pod created id=w5ozrysmhupp8e; waiting for publicIp+ssh_port
+[t=    1.4s 21:55:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 21:55:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 21:55:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 21:56:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 21:56:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.3s 21:56:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.7s 21:56:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.0s 21:57:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.1s 21:57:24Z] PROBE NO-GO: pod w5ozrysmhupp8e not RUNNING+SSH within 120s; tearing down
+[t=  125.1s 21:57:24Z] DELETE pod w5ozrysmhupp8e
+[t=  125.6s 21:57:24Z] delete returned status=204 resp={}
+[t=  130.9s 21:57:29Z] pod w5ozrysmhupp8e confirmed terminated (404)
+[t=  130.9s 21:57:29Z] PROBE: pod w5ozrysmhupp8e torn down
+[t=    0.0s 21:57:30Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:57:30Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 21:57:31Z] create OK id=6cx57bxydn5cvn costPerHr=$1.39
+[t=    1.2s 21:57:31Z] PROBE: pod created id=6cx57bxydn5cvn; waiting for publicIp+ssh_port
+[t=    1.6s 21:57:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 21:57:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.8s 21:58:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.3s 21:58:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.4s 21:58:34Z] PROBE NO-GO: pod 6cx57bxydn5cvn not RUNNING+SSH within 60s; tearing down
+[t=   64.4s 21:58:34Z] DELETE pod 6cx57bxydn5cvn
+[t=   64.8s 21:58:35Z] delete returned status=204 resp={}
+[t=   70.2s 21:58:40Z] pod 6cx57bxydn5cvn confirmed terminated (404)
+[t=   70.2s 21:58:40Z] PROBE: pod 6cx57bxydn5cvn torn down
+[t=    0.0s 21:58:40Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:58:40Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 21:58:41Z] create OK id=pxa530ns72zv8i costPerHr=$3.29
+[t=    1.2s 21:58:41Z] PROBE: pod created id=pxa530ns72zv8i; waiting for publicIp+ssh_port
+[t=    1.5s 21:58:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 21:58:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 21:59:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 21:59:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 21:59:43Z] PROBE NO-GO: pod pxa530ns72zv8i not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 21:59:43Z] DELETE pod pxa530ns72zv8i
+[t=   63.5s 21:59:44Z] delete returned status=204 resp={}
+[t=   68.9s 21:59:49Z] pod pxa530ns72zv8i confirmed terminated (404)
+[t=   68.9s 21:59:49Z] PROBE: pod pxa530ns72zv8i torn down
+[t=    0.0s 21:59:49Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 21:59:49Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 21:59:50Z] create OK id=8zga7qau09xz0j costPerHr=$2.89
+[t=    1.1s 21:59:50Z] PROBE: pod created id=8zga7qau09xz0j; waiting for publicIp+ssh_port
+[t=    1.5s 21:59:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 22:00:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 22:00:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 22:00:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 22:00:52Z] PROBE NO-GO: pod 8zga7qau09xz0j not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 22:00:52Z] DELETE pod 8zga7qau09xz0j
+[t=   63.3s 22:00:53Z] delete returned status=204 resp={}
+[t=   68.6s 22:00:58Z] pod 8zga7qau09xz0j confirmed terminated (404)
+[t=   68.6s 22:00:58Z] PROBE: pod 8zga7qau09xz0j torn down
+[t=    0.0s 22:00:58Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 22:00:58Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 22:00:59Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 22:00:59Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:01:25Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:01:25Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:01:26Z] create OK id=kxp4tzjuvtxxe1 costPerHr=$1.49
+[t=    1.1s 22:01:26Z] PROBE: pod created id=kxp4tzjuvtxxe1; waiting for publicIp+ssh_port
+[t=    1.4s 22:01:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 22:01:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 22:01:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 22:02:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 22:02:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.2s 22:02:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.6s 22:02:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  108.9s 22:03:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  123.9s 22:03:29Z] PROBE NO-GO: pod kxp4tzjuvtxxe1 not RUNNING+SSH within 120s; tearing down
+[t=  123.9s 22:03:29Z] DELETE pod kxp4tzjuvtxxe1
+[t=  124.5s 22:03:30Z] delete returned status=204 resp={}
+[t=  129.8s 22:03:35Z] pod kxp4tzjuvtxxe1 confirmed terminated (404)
+[t=  129.8s 22:03:35Z] PROBE: pod kxp4tzjuvtxxe1 torn down
+[t=    0.0s 22:03:35Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:03:35Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 22:03:36Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 22:03:36Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:03:36Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:03:36Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 22:03:37Z] create OK id=dy3e6g66hsx84b costPerHr=$3.29
+[t=    1.5s 22:03:37Z] PROBE: pod created id=dy3e6g66hsx84b; waiting for publicIp+ssh_port
+[t=    2.1s 22:03:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.1s 22:03:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.8s 22:04:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 22:04:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 22:04:40Z] PROBE NO-GO: pod dy3e6g66hsx84b not RUNNING+SSH within 60s; tearing down
+[t=   64.5s 22:04:40Z] DELETE pod dy3e6g66hsx84b
+[t=   65.1s 22:04:41Z] delete returned status=204 resp={}
+[t=   70.4s 22:04:46Z] pod dy3e6g66hsx84b confirmed terminated (404)
+[t=   70.4s 22:04:46Z] PROBE: pod dy3e6g66hsx84b torn down
+[t=    0.0s 22:04:46Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:04:46Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 22:04:47Z] create OK id=g7hyoupcc4ahke costPerHr=$2.89
+[t=    1.0s 22:04:47Z] PROBE: pod created id=g7hyoupcc4ahke; waiting for publicIp+ssh_port
+[t=    1.4s 22:04:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 22:05:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 22:05:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 22:05:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 22:05:49Z] PROBE NO-GO: pod g7hyoupcc4ahke not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 22:05:49Z] DELETE pod g7hyoupcc4ahke
+[t=   63.3s 22:05:50Z] delete returned status=204 resp={}
+[t=   68.6s 22:05:55Z] pod g7hyoupcc4ahke confirmed terminated (404)
+[t=   68.6s 22:05:55Z] PROBE: pod g7hyoupcc4ahke torn down
+[t=    0.0s 22:05:55Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 22:05:55Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 22:05:56Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 22:05:56Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:06:13Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:06:13Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 22:06:14Z] create OK id=ymvqbbjq6ul6hg costPerHr=$1.49
+[t=    1.0s 22:06:14Z] PROBE: pod created id=ymvqbbjq6ul6hg; waiting for publicIp+ssh_port
+[t=    1.4s 22:06:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 22:06:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 22:06:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 22:07:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 22:07:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.3s 22:07:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.6s 22:07:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.0s 22:08:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.0s 22:08:17Z] PROBE NO-GO: pod ymvqbbjq6ul6hg not RUNNING+SSH within 120s; tearing down
+[t=  124.0s 22:08:17Z] DELETE pod ymvqbbjq6ul6hg
+[t=  124.5s 22:08:17Z] delete returned status=204 resp={}
+[t=  129.9s 22:08:23Z] pod ymvqbbjq6ul6hg confirmed terminated (404)
+[t=  129.9s 22:08:23Z] PROBE: pod ymvqbbjq6ul6hg torn down
+[t=    0.0s 22:08:23Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:08:23Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 22:08:23Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 22:08:23Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:08:24Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:08:24Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 22:08:25Z] create OK id=teubv0fwy6ujn8 costPerHr=$3.29
+[t=    1.3s 22:08:25Z] PROBE: pod created id=teubv0fwy6ujn8; waiting for publicIp+ssh_port
+[t=    1.7s 22:08:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 22:08:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 22:08:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.4s 22:09:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.4s 22:09:27Z] PROBE NO-GO: pod teubv0fwy6ujn8 not RUNNING+SSH within 60s; tearing down
+[t=   63.4s 22:09:27Z] DELETE pod teubv0fwy6ujn8
+[t=   64.0s 22:09:28Z] delete returned status=204 resp={}
+[t=   69.3s 22:09:33Z] pod teubv0fwy6ujn8 confirmed terminated (404)
+[t=   69.3s 22:09:33Z] PROBE: pod teubv0fwy6ujn8 torn down
+[t=    0.0s 22:09:33Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:09:33Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:09:34Z] create OK id=h66f7834bxi8li costPerHr=$2.89
+[t=    1.1s 22:09:34Z] PROBE: pod created id=h66f7834bxi8li; waiting for publicIp+ssh_port
+[t=    1.4s 22:09:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 22:09:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 22:10:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 22:10:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 22:10:36Z] PROBE NO-GO: pod h66f7834bxi8li not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 22:10:36Z] DELETE pod h66f7834bxi8li
+[t=   63.2s 22:10:36Z] delete returned status=204 resp={}
+[t=   68.5s 22:10:42Z] pod h66f7834bxi8li confirmed terminated (404)
+[t=   68.5s 22:10:42Z] PROBE: pod h66f7834bxi8li torn down
+[t=    0.0s 22:10:42Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 22:10:42Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 22:10:42Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 22:10:42Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:10:58Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:10:58Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:10:59Z] create OK id=etfptix8avsq8v costPerHr=$1.49
+[t=    1.1s 22:10:59Z] PROBE: pod created id=etfptix8avsq8v; waiting for publicIp+ssh_port
+[t=    1.5s 22:11:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 22:11:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 22:11:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 22:11:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 22:12:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.4s 22:12:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.7s 22:12:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.3s 22:12:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.3s 22:13:03Z] PROBE NO-GO: pod etfptix8avsq8v not RUNNING+SSH within 120s; tearing down
+[t=  124.3s 22:13:03Z] DELETE pod etfptix8avsq8v
+[t=  124.9s 22:13:03Z] delete returned status=204 resp={}
+[t=  130.2s 22:13:08Z] pod etfptix8avsq8v confirmed terminated (404)
+[t=  130.2s 22:13:08Z] PROBE: pod etfptix8avsq8v torn down
+[t=    0.0s 22:13:09Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:13:09Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 22:13:10Z] create OK id=807zzwlmap71ia costPerHr=$1.39
+[t=    1.2s 22:13:10Z] PROBE: pod created id=807zzwlmap71ia; waiting for publicIp+ssh_port
+[t=    1.6s 22:13:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 22:13:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 22:13:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 22:13:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 22:14:11Z] PROBE NO-GO: pod 807zzwlmap71ia not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 22:14:11Z] DELETE pod 807zzwlmap71ia
+[t=   63.4s 22:14:12Z] delete returned status=204 resp={}
+[t=   68.7s 22:14:17Z] pod 807zzwlmap71ia confirmed terminated (404)
+[t=   68.7s 22:14:17Z] PROBE: pod 807zzwlmap71ia torn down
+[t=    0.0s 22:14:18Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:14:18Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 22:14:19Z] create OK id=x5zl964xprm1wu costPerHr=$3.29
+[t=    1.5s 22:14:19Z] PROBE: pod created id=x5zl964xprm1wu; waiting for publicIp+ssh_port
+[t=    2.0s 22:14:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 22:14:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.5s 22:14:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.2s 22:15:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.2s 22:15:22Z] PROBE NO-GO: pod x5zl964xprm1wu not RUNNING+SSH within 60s; tearing down
+[t=   64.2s 22:15:22Z] DELETE pod x5zl964xprm1wu
+[t=   64.8s 22:15:22Z] delete returned status=204 resp={}
+[t=   70.1s 22:15:28Z] pod x5zl964xprm1wu confirmed terminated (404)
+[t=   70.1s 22:15:28Z] PROBE: pod x5zl964xprm1wu torn down
+[t=    0.0s 22:15:28Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:15:28Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:15:29Z] create OK id=7ipb29pcwupqe2 costPerHr=$2.89
+[t=    1.1s 22:15:29Z] PROBE: pod created id=7ipb29pcwupqe2; waiting for publicIp+ssh_port
+[t=    1.4s 22:15:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 22:15:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 22:16:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 22:16:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 22:16:30Z] PROBE NO-GO: pod 7ipb29pcwupqe2 not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 22:16:30Z] DELETE pod 7ipb29pcwupqe2
+[t=   63.2s 22:16:31Z] delete returned status=204 resp={}
+[t=   68.5s 22:16:36Z] pod 7ipb29pcwupqe2 confirmed terminated (404)
+[t=   68.5s 22:16:36Z] PROBE: pod 7ipb29pcwupqe2 torn down
+[t=    0.0s 22:16:37Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 22:16:37Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 22:16:37Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 22:16:37Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:16:56Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:16:56Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:16:58Z] create OK id=hveyiiemxrknqv costPerHr=$1.49
+[t=    1.1s 22:16:58Z] PROBE: pod created id=hveyiiemxrknqv; waiting for publicIp+ssh_port
+[t=    1.4s 22:16:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 22:17:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 22:17:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 22:17:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 22:18:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.5s 22:18:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.9s 22:18:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.2s 22:18:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.2s 22:19:01Z] PROBE NO-GO: pod hveyiiemxrknqv not RUNNING+SSH within 120s; tearing down
+[t=  124.2s 22:19:01Z] DELETE pod hveyiiemxrknqv
+[t=  124.9s 22:19:01Z] delete returned status=204 resp={}
+[t=  130.2s 22:19:07Z] pod hveyiiemxrknqv confirmed terminated (404)
+[t=  130.2s 22:19:07Z] PROBE: pod hveyiiemxrknqv torn down
+[t=    0.0s 22:19:07Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:19:07Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:19:08Z] create OK id=4z8f7mvz806dnt costPerHr=$1.39
+[t=    1.1s 22:19:08Z] PROBE: pod created id=4z8f7mvz806dnt; waiting for publicIp+ssh_port
+[t=    1.4s 22:19:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 22:19:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 22:19:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 22:19:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 22:20:10Z] PROBE NO-GO: pod 4z8f7mvz806dnt not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 22:20:10Z] DELETE pod 4z8f7mvz806dnt
+[t=   63.1s 22:20:10Z] delete returned status=204 resp={}
+[t=   68.4s 22:20:15Z] pod 4z8f7mvz806dnt confirmed terminated (404)
+[t=   68.4s 22:20:15Z] PROBE: pod 4z8f7mvz806dnt torn down
+[t=    0.0s 22:20:16Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:20:16Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 22:20:17Z] create OK id=az8r2589zrdm9y costPerHr=$3.29
+[t=    1.5s 22:20:17Z] PROBE: pod created id=az8r2589zrdm9y; waiting for publicIp+ssh_port
+[t=    1.9s 22:20:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 22:20:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.4s 22:20:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 22:21:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 22:21:20Z] PROBE NO-GO: pod az8r2589zrdm9y not RUNNING+SSH within 60s; tearing down
+[t=   64.1s 22:21:20Z] DELETE pod az8r2589zrdm9y
+[t=   64.7s 22:21:20Z] delete returned status=204 resp={}
+[t=   70.0s 22:21:26Z] pod az8r2589zrdm9y confirmed terminated (404)
+[t=   70.0s 22:21:26Z] PROBE: pod az8r2589zrdm9y torn down
+[t=    0.0s 22:21:26Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:21:26Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:21:27Z] create OK id=r9fvuiqrby06z9 costPerHr=$2.89
+[t=    1.1s 22:21:27Z] PROBE: pod created id=r9fvuiqrby06z9; waiting for publicIp+ssh_port
+[t=    1.4s 22:21:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 22:21:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 22:21:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 22:22:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 22:22:29Z] PROBE NO-GO: pod r9fvuiqrby06z9 not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 22:22:29Z] DELETE pod r9fvuiqrby06z9
+[t=   63.2s 22:22:29Z] delete returned status=204 resp={}
+[t=   68.6s 22:22:34Z] pod r9fvuiqrby06z9 confirmed terminated (404)
+[t=   68.6s 22:22:34Z] PROBE: pod r9fvuiqrby06z9 torn down
+[t=    0.0s 22:22:35Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 22:22:35Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 22:22:35Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 22:22:35Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:22:53Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:22:53Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 22:22:55Z] create OK id=9fea7nsfnwyej6 costPerHr=$1.49
+[t=    1.0s 22:22:55Z] PROBE: pod created id=9fea7nsfnwyej6; waiting for publicIp+ssh_port
+[t=    1.3s 22:22:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 22:23:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 22:23:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 22:23:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 22:23:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.2s 22:24:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.6s 22:24:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.0s 22:24:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.0s 22:24:57Z] PROBE NO-GO: pod 9fea7nsfnwyej6 not RUNNING+SSH within 120s; tearing down
+[t=  124.0s 22:24:57Z] DELETE pod 9fea7nsfnwyej6
+[t=  124.5s 22:24:58Z] delete returned status=204 resp={}
+[t=  129.9s 22:25:03Z] pod 9fea7nsfnwyej6 confirmed terminated (404)
+[t=  129.9s 22:25:03Z] PROBE: pod 9fea7nsfnwyej6 torn down
+[t=    0.0s 22:25:04Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:25:04Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:25:05Z] create OK id=zqghhurib2a7bf costPerHr=$1.39
+[t=    1.1s 22:25:05Z] PROBE: pod created id=zqghhurib2a7bf; waiting for publicIp+ssh_port
+[t=    1.5s 22:25:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 22:25:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 22:25:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 22:25:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 22:26:06Z] PROBE NO-GO: pod zqghhurib2a7bf not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 22:26:06Z] DELETE pod zqghhurib2a7bf
+[t=   63.4s 22:26:07Z] delete returned status=204 resp={}
+[t=   68.7s 22:26:12Z] pod zqghhurib2a7bf confirmed terminated (404)
+[t=   68.7s 22:26:12Z] PROBE: pod zqghhurib2a7bf torn down
+[t=    0.0s 22:26:13Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:26:13Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:26:14Z] create OK id=in21tk7wsyk4ko costPerHr=$3.29
+[t=    1.1s 22:26:14Z] PROBE: pod created id=in21tk7wsyk4ko; waiting for publicIp+ssh_port
+[t=    1.4s 22:26:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 22:26:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 22:26:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 22:27:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 22:27:15Z] PROBE NO-GO: pod in21tk7wsyk4ko not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 22:27:15Z] DELETE pod in21tk7wsyk4ko
+[t=   63.3s 22:27:16Z] delete returned status=204 resp={}
+[t=   68.6s 22:27:21Z] pod in21tk7wsyk4ko confirmed terminated (404)
+[t=   68.6s 22:27:21Z] PROBE: pod in21tk7wsyk4ko torn down
+[t=    0.0s 22:27:21Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:27:21Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 22:27:23Z] create OK id=e6n1loz5uttfin costPerHr=$2.89
+[t=    1.3s 22:27:23Z] PROBE: pod created id=e6n1loz5uttfin; waiting for publicIp+ssh_port
+[t=    1.6s 22:27:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 22:27:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 22:27:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 22:28:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 22:28:24Z] PROBE NO-GO: pod e6n1loz5uttfin not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 22:28:24Z] DELETE pod e6n1loz5uttfin
+[t=   63.4s 22:28:25Z] delete returned status=204 resp={}
+[t=   68.7s 22:28:30Z] pod e6n1loz5uttfin confirmed terminated (404)
+[t=   68.7s 22:28:30Z] PROBE: pod e6n1loz5uttfin torn down
+[t=    0.0s 22:28:30Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 22:28:30Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 22:28:31Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 22:28:31Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:28:55Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:28:55Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 22:28:56Z] create OK id=lj18mtkiscjktn costPerHr=$1.49
+[t=    1.0s 22:28:56Z] PROBE: pod created id=lj18mtkiscjktn; waiting for publicIp+ssh_port
+[t=    1.3s 22:28:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 22:29:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 22:29:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 22:29:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 22:29:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.6s 22:30:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.0s 22:30:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.4s 22:30:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.4s 22:30:59Z] PROBE NO-GO: pod lj18mtkiscjktn not RUNNING+SSH within 120s; tearing down
+[t=  124.4s 22:30:59Z] DELETE pod lj18mtkiscjktn
+[t=  125.0s 22:30:59Z] delete returned status=204 resp={}
+[t=  130.3s 22:31:05Z] pod lj18mtkiscjktn confirmed terminated (404)
+[t=  130.3s 22:31:05Z] PROBE: pod lj18mtkiscjktn torn down
+[t=    0.0s 22:31:05Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:31:05Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:31:06Z] create OK id=z713txmoc0y59h costPerHr=$1.39
+[t=    1.1s 22:31:06Z] PROBE: pod created id=z713txmoc0y59h; waiting for publicIp+ssh_port
+[t=    1.4s 22:31:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 22:31:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 22:31:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 22:31:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 22:32:08Z] PROBE NO-GO: pod z713txmoc0y59h not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 22:32:08Z] DELETE pod z713txmoc0y59h
+[t=   63.3s 22:32:08Z] delete returned status=204 resp={}
+[t=   68.6s 22:32:14Z] pod z713txmoc0y59h confirmed terminated (404)
+[t=   68.6s 22:32:14Z] PROBE: pod z713txmoc0y59h torn down
+[t=    0.0s 22:32:14Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:32:14Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 22:32:15Z] create OK id=0salmzruh262tj costPerHr=$3.29
+[t=    1.3s 22:32:15Z] PROBE: pod created id=0salmzruh262tj; waiting for publicIp+ssh_port
+[t=    1.9s 22:32:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.6s 22:32:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 22:32:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 22:33:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 22:33:18Z] PROBE NO-GO: pod 0salmzruh262tj not RUNNING+SSH within 60s; tearing down
+[t=   64.1s 22:33:18Z] DELETE pod 0salmzruh262tj
+[t=   64.7s 22:33:18Z] delete returned status=204 resp={}
+[t=   70.0s 22:33:24Z] pod 0salmzruh262tj confirmed terminated (404)
+[t=   70.0s 22:33:24Z] PROBE: pod 0salmzruh262tj torn down
+[t=    0.0s 22:33:24Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:33:24Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:33:25Z] create OK id=l7r8y52h41xaft costPerHr=$2.89
+[t=    1.1s 22:33:25Z] PROBE: pod created id=l7r8y52h41xaft; waiting for publicIp+ssh_port
+[t=    1.5s 22:33:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 22:33:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 22:33:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 22:34:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 22:34:27Z] PROBE NO-GO: pod l7r8y52h41xaft not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 22:34:27Z] DELETE pod l7r8y52h41xaft
+[t=   63.3s 22:34:27Z] delete returned status=204 resp={}
+[t=   68.6s 22:34:33Z] pod l7r8y52h41xaft confirmed terminated (404)
+[t=   68.6s 22:34:33Z] PROBE: pod l7r8y52h41xaft torn down
+[t=    0.0s 22:34:33Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 22:34:33Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 22:34:33Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 22:34:33Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:34:53Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:34:53Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 22:34:54Z] create OK id=tntsvxgy2c44cd costPerHr=$1.49
+[t=    1.0s 22:34:54Z] PROBE: pod created id=tntsvxgy2c44cd; waiting for publicIp+ssh_port
+[t=    1.4s 22:34:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 22:35:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 22:35:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 22:35:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 22:35:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.5s 22:36:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.0s 22:36:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.9s 22:36:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.9s 22:36:58Z] PROBE NO-GO: pod tntsvxgy2c44cd not RUNNING+SSH within 120s; tearing down
+[t=  124.9s 22:36:58Z] DELETE pod tntsvxgy2c44cd
+[t=  125.4s 22:36:58Z] delete returned status=204 resp={}
+[t=  130.7s 22:37:03Z] pod tntsvxgy2c44cd confirmed terminated (404)
+[t=  130.7s 22:37:03Z] PROBE: pod tntsvxgy2c44cd torn down
+[t=    0.0s 22:37:04Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:37:04Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 22:37:04Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 22:37:04Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:37:04Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:37:04Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 22:37:06Z] create OK id=t3vicxmjnllzn9 costPerHr=$3.29
+[t=    1.3s 22:37:06Z] PROBE: pod created id=t3vicxmjnllzn9; waiting for publicIp+ssh_port
+[t=    1.8s 22:37:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 22:37:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 22:37:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.0s 22:37:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.0s 22:38:08Z] PROBE NO-GO: pod t3vicxmjnllzn9 not RUNNING+SSH within 60s; tearing down
+[t=   64.0s 22:38:08Z] DELETE pod t3vicxmjnllzn9
+[t=   64.6s 22:38:09Z] delete returned status=204 resp={}
+[t=   69.9s 22:38:14Z] pod t3vicxmjnllzn9 confirmed terminated (404)
+[t=   69.9s 22:38:14Z] PROBE: pod t3vicxmjnllzn9 torn down
+[t=    0.0s 22:38:15Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:38:15Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:38:16Z] create OK id=6hmi65n5u3xiui costPerHr=$2.89
+[t=    1.1s 22:38:16Z] PROBE: pod created id=6hmi65n5u3xiui; waiting for publicIp+ssh_port
+[t=    1.4s 22:38:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 22:38:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 22:38:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 22:39:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 22:39:17Z] PROBE NO-GO: pod 6hmi65n5u3xiui not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 22:39:17Z] DELETE pod 6hmi65n5u3xiui
+[t=   63.3s 22:39:18Z] delete returned status=204 resp={}
+[t=   68.5s 22:39:23Z] pod 6hmi65n5u3xiui confirmed terminated (404)
+[t=   68.5s 22:39:23Z] PROBE: pod 6hmi65n5u3xiui torn down
+[t=    0.0s 22:39:23Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 22:39:23Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 22:39:24Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 22:39:24Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:39:40Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:39:40Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:39:41Z] create OK id=tpc5j5rkfqrm9o costPerHr=$1.49
+[t=    1.1s 22:39:41Z] PROBE: pod created id=tpc5j5rkfqrm9o; waiting for publicIp+ssh_port
+[t=    1.4s 22:39:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 22:39:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 22:40:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 22:40:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 22:40:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.5s 22:40:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.8s 22:41:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.3s 22:41:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.3s 22:41:45Z] PROBE NO-GO: pod tpc5j5rkfqrm9o not RUNNING+SSH within 120s; tearing down
+[t=  124.3s 22:41:45Z] DELETE pod tpc5j5rkfqrm9o
+[t=  124.8s 22:41:45Z] delete returned status=204 resp={}
+[t=  130.1s 22:41:51Z] pod tpc5j5rkfqrm9o confirmed terminated (404)
+[t=  130.1s 22:41:51Z] PROBE: pod tpc5j5rkfqrm9o torn down
+[t=    0.0s 22:41:51Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:41:51Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 22:41:52Z] create OK id=2ht5gmnpzqm2e2 costPerHr=$1.39
+[t=    1.3s 22:41:52Z] PROBE: pod created id=2ht5gmnpzqm2e2; waiting for publicIp+ssh_port
+[t=    2.1s 22:41:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 22:42:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.4s 22:42:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.0s 22:42:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.0s 22:42:55Z] PROBE NO-GO: pod 2ht5gmnpzqm2e2 not RUNNING+SSH within 60s; tearing down
+[t=   64.0s 22:42:55Z] DELETE pod 2ht5gmnpzqm2e2
+[t=   64.6s 22:42:55Z] delete returned status=204 resp={}
+[t=   69.9s 22:43:01Z] pod 2ht5gmnpzqm2e2 confirmed terminated (404)
+[t=   69.9s 22:43:01Z] PROBE: pod 2ht5gmnpzqm2e2 torn down
+[t=    0.0s 22:43:01Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:43:01Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 22:43:02Z] create OK id=2aemyxh0099g9b costPerHr=$3.29
+[t=    1.4s 22:43:02Z] PROBE: pod created id=2aemyxh0099g9b; waiting for publicIp+ssh_port
+[t=    1.9s 22:43:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.6s 22:43:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.1s 22:43:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.8s 22:43:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.8s 22:44:05Z] PROBE NO-GO: pod 2aemyxh0099g9b not RUNNING+SSH within 60s; tearing down
+[t=   63.8s 22:44:05Z] DELETE pod 2aemyxh0099g9b
+[t=   64.4s 22:44:05Z] delete returned status=204 resp={}
+[t=   69.7s 22:44:11Z] pod 2aemyxh0099g9b confirmed terminated (404)
+[t=   69.7s 22:44:11Z] PROBE: pod 2aemyxh0099g9b torn down
+[t=    0.0s 22:44:11Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:44:11Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:44:12Z] create OK id=9lmf63hmjh7nru costPerHr=$2.89
+[t=    1.1s 22:44:12Z] PROBE: pod created id=9lmf63hmjh7nru; waiting for publicIp+ssh_port
+[t=    1.4s 22:44:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 22:44:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 22:44:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 22:44:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 22:45:13Z] PROBE NO-GO: pod 9lmf63hmjh7nru not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 22:45:13Z] DELETE pod 9lmf63hmjh7nru
+[t=   63.2s 22:45:14Z] delete returned status=204 resp={}
+[t=   68.5s 22:45:19Z] pod 9lmf63hmjh7nru confirmed terminated (404)
+[t=   68.5s 22:45:19Z] PROBE: pod 9lmf63hmjh7nru torn down
+[t=    0.0s 22:45:19Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 22:45:19Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 22:45:20Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 22:45:20Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:45:45Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:45:45Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 22:45:46Z] create OK id=es3630x396xug3 costPerHr=$1.49
+[t=    1.0s 22:45:46Z] PROBE: pod created id=es3630x396xug3; waiting for publicIp+ssh_port
+[t=    1.4s 22:45:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 22:46:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 22:46:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.5s 22:46:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.8s 22:46:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.2s 22:47:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.5s 22:47:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.9s 22:47:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.9s 22:47:50Z] PROBE NO-GO: pod es3630x396xug3 not RUNNING+SSH within 120s; tearing down
+[t=  124.9s 22:47:50Z] DELETE pod es3630x396xug3
+[t=  125.4s 22:47:50Z] delete returned status=204 resp={}
+[t=  130.7s 22:47:55Z] pod es3630x396xug3 confirmed terminated (404)
+[t=  130.7s 22:47:55Z] PROBE: pod es3630x396xug3 torn down
+[t=    0.0s 22:47:56Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:47:56Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.9s 22:47:57Z] create OK id=9odg2g29ccuula costPerHr=$1.39
+[t=    0.9s 22:47:57Z] PROBE: pod created id=9odg2g29ccuula; waiting for publicIp+ssh_port
+[t=    1.3s 22:47:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 22:48:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 22:48:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 22:48:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 22:48:58Z] PROBE NO-GO: pod 9odg2g29ccuula not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 22:48:58Z] DELETE pod 9odg2g29ccuula
+[t=   63.4s 22:48:59Z] delete returned status=204 resp={}
+[t=   68.7s 22:49:04Z] pod 9odg2g29ccuula confirmed terminated (404)
+[t=   68.7s 22:49:04Z] PROBE: pod 9odg2g29ccuula torn down
+[t=    0.0s 22:49:05Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:49:05Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 22:49:06Z] create OK id=mgun5i9aekw6pd costPerHr=$3.29
+[t=    1.5s 22:49:06Z] PROBE: pod created id=mgun5i9aekw6pd; waiting for publicIp+ssh_port
+[t=    2.0s 22:49:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 22:49:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.4s 22:49:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 22:49:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 22:50:09Z] PROBE NO-GO: pod mgun5i9aekw6pd not RUNNING+SSH within 60s; tearing down
+[t=   64.1s 22:50:09Z] DELETE pod mgun5i9aekw6pd
+[t=   64.6s 22:50:09Z] delete returned status=204 resp={}
+[t=   70.0s 22:50:15Z] pod mgun5i9aekw6pd confirmed terminated (404)
+[t=   70.0s 22:50:15Z] PROBE: pod mgun5i9aekw6pd torn down
+[t=    0.0s 22:50:15Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:50:15Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:50:16Z] create OK id=cjiiiapiu78psi costPerHr=$2.89
+[t=    1.1s 22:50:16Z] PROBE: pod created id=cjiiiapiu78psi; waiting for publicIp+ssh_port
+[t=    1.4s 22:50:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 22:50:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 22:50:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.7s 22:51:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.7s 22:51:18Z] PROBE NO-GO: pod cjiiiapiu78psi not RUNNING+SSH within 60s; tearing down
+[t=   63.7s 22:51:18Z] DELETE pod cjiiiapiu78psi
+[t=   64.2s 22:51:19Z] delete returned status=204 resp={}
+[t=   69.5s 22:51:24Z] pod cjiiiapiu78psi confirmed terminated (404)
+[t=   69.5s 22:51:24Z] PROBE: pod cjiiiapiu78psi torn down
+[t=    0.0s 22:51:24Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 22:51:24Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 22:51:25Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 22:51:25Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:51:40Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:51:40Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 22:51:41Z] create OK id=ats7y21cn8dspq costPerHr=$1.49
+[t=    1.0s 22:51:41Z] PROBE: pod created id=ats7y21cn8dspq; waiting for publicIp+ssh_port
+[t=    1.3s 22:51:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 22:51:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 22:52:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 22:52:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 22:52:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.1s 22:52:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.5s 22:53:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  108.8s 22:53:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  123.8s 22:53:44Z] PROBE NO-GO: pod ats7y21cn8dspq not RUNNING+SSH within 120s; tearing down
+[t=  123.8s 22:53:44Z] DELETE pod ats7y21cn8dspq
+[t=  124.4s 22:53:44Z] delete returned status=204 resp={}
+[t=  129.7s 22:53:50Z] pod ats7y21cn8dspq confirmed terminated (404)
+[t=  129.7s 22:53:50Z] PROBE: pod ats7y21cn8dspq torn down
+[t=    0.0s 22:53:50Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:53:50Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 22:53:50Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 22:53:50Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:53:51Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:53:51Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 22:53:52Z] create OK id=uox50gsoe6e3gv costPerHr=$3.29
+[t=    1.5s 22:53:52Z] PROBE: pod created id=uox50gsoe6e3gv; waiting for publicIp+ssh_port
+[t=    2.5s 22:53:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.3s 22:54:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.0s 22:54:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 22:54:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 22:54:55Z] PROBE NO-GO: pod uox50gsoe6e3gv not RUNNING+SSH within 60s; tearing down
+[t=   64.6s 22:54:55Z] DELETE pod uox50gsoe6e3gv
+[t=   65.1s 22:54:56Z] delete returned status=204 resp={}
+[t=   70.5s 22:55:01Z] pod uox50gsoe6e3gv confirmed terminated (404)
+[t=   70.5s 22:55:01Z] PROBE: pod uox50gsoe6e3gv torn down
+[t=    0.0s 22:55:01Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:55:01Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    2.1s 22:55:03Z] create OK id=soffy3lg8g99ja costPerHr=$2.89
+[t=    2.1s 22:55:03Z] PROBE: pod created id=soffy3lg8g99ja; waiting for publicIp+ssh_port
+[t=    2.4s 22:55:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 22:55:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.2s 22:55:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.6s 22:55:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.7s 22:56:05Z] PROBE NO-GO: pod soffy3lg8g99ja not RUNNING+SSH within 60s; tearing down
+[t=   63.7s 22:56:05Z] DELETE pod soffy3lg8g99ja
+[t=   64.2s 22:56:05Z] delete returned status=204 resp={}
+[t=   69.5s 22:56:11Z] pod soffy3lg8g99ja confirmed terminated (404)
+[t=   69.5s 22:56:11Z] PROBE: pod soffy3lg8g99ja torn down
+[t=    0.0s 22:56:11Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 22:56:11Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 22:56:11Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 22:56:11Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:56:28Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 22:56:28Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 22:56:29Z] create OK id=1f5ioz9suheumr costPerHr=$1.49
+[t=    1.1s 22:56:29Z] PROBE: pod created id=1f5ioz9suheumr; waiting for publicIp+ssh_port
+[t=    1.4s 22:56:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 22:56:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 22:57:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 22:57:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 22:57:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.3s 22:57:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.7s 22:58:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.0s 22:58:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.0s 22:58:32Z] PROBE NO-GO: pod 1f5ioz9suheumr not RUNNING+SSH within 120s; tearing down
+[t=  124.0s 22:58:32Z] DELETE pod 1f5ioz9suheumr
+[t=  124.6s 22:58:32Z] delete returned status=204 resp={}
+[t=  129.9s 22:58:38Z] pod 1f5ioz9suheumr confirmed terminated (404)
+[t=  129.9s 22:58:38Z] PROBE: pod 1f5ioz9suheumr torn down
+[t=    0.0s 22:58:38Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:58:38Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 22:58:38Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 22:58:38Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 22:58:39Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:58:39Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 22:58:40Z] create OK id=5pp7gdzzjfefis costPerHr=$3.29
+[t=    1.4s 22:58:40Z] PROBE: pod created id=5pp7gdzzjfefis; waiting for publicIp+ssh_port
+[t=    1.9s 22:58:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 22:58:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.2s 22:59:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.0s 22:59:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.0s 22:59:43Z] PROBE NO-GO: pod 5pp7gdzzjfefis not RUNNING+SSH within 60s; tearing down
+[t=   64.0s 22:59:43Z] DELETE pod 5pp7gdzzjfefis
+[t=   64.6s 22:59:43Z] delete returned status=204 resp={}
+[t=   69.9s 22:59:49Z] pod 5pp7gdzzjfefis confirmed terminated (404)
+[t=   69.9s 22:59:49Z] PROBE: pod 5pp7gdzzjfefis torn down
+[t=    0.0s 22:59:49Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 22:59:49Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 22:59:50Z] create OK id=gct835fzvf24nx costPerHr=$2.89
+[t=    1.0s 22:59:50Z] PROBE: pod created id=gct835fzvf24nx; waiting for publicIp+ssh_port
+[t=    1.3s 22:59:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 23:00:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 23:00:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 23:00:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 23:00:51Z] PROBE NO-GO: pod gct835fzvf24nx not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 23:00:51Z] DELETE pod gct835fzvf24nx
+[t=   63.2s 23:00:52Z] delete returned status=204 resp={}
+[t=   68.5s 23:00:57Z] pod gct835fzvf24nx confirmed terminated (404)
+[t=   68.5s 23:00:57Z] PROBE: pod gct835fzvf24nx torn down
+[t=    0.0s 23:00:57Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 23:00:57Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 23:00:58Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 23:00:58Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:01:17Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 23:01:17Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:01:18Z] create OK id=ty6wqboznj9x5b costPerHr=$1.49
+[t=    1.1s 23:01:18Z] PROBE: pod created id=ty6wqboznj9x5b; waiting for publicIp+ssh_port
+[t=    1.4s 23:01:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 23:01:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 23:01:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 23:02:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 23:02:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.2s 23:02:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.6s 23:02:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.0s 23:03:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.0s 23:03:21Z] PROBE NO-GO: pod ty6wqboznj9x5b not RUNNING+SSH within 120s; tearing down
+[t=  124.0s 23:03:21Z] DELETE pod ty6wqboznj9x5b
+[t=  124.6s 23:03:22Z] delete returned status=204 resp={}
+[t=  129.9s 23:03:27Z] pod ty6wqboznj9x5b confirmed terminated (404)
+[t=  129.9s 23:03:27Z] PROBE: pod ty6wqboznj9x5b torn down
+[t=    0.0s 23:03:27Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:03:27Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 23:03:28Z] create OK id=vhoy764hu0k7tm costPerHr=$1.39
+[t=    1.0s 23:03:28Z] PROBE: pod created id=vhoy764hu0k7tm; waiting for publicIp+ssh_port
+[t=    1.3s 23:03:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 23:03:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 23:04:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 23:04:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.5s 23:04:30Z] PROBE NO-GO: pod vhoy764hu0k7tm not RUNNING+SSH within 60s; tearing down
+[t=   62.5s 23:04:30Z] DELETE pod vhoy764hu0k7tm
+[t=   63.1s 23:04:31Z] delete returned status=204 resp={}
+[t=   68.5s 23:04:36Z] pod vhoy764hu0k7tm confirmed terminated (404)
+[t=   68.5s 23:04:36Z] PROBE: pod vhoy764hu0k7tm torn down
+[t=    0.0s 23:04:36Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:04:36Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 23:04:37Z] create OK id=9qlkstx208hz3t costPerHr=$3.29
+[t=    1.0s 23:04:37Z] PROBE: pod created id=9qlkstx208hz3t; waiting for publicIp+ssh_port
+[t=    1.4s 23:04:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 23:04:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 23:05:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 23:05:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 23:05:39Z] PROBE NO-GO: pod 9qlkstx208hz3t not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 23:05:39Z] DELETE pod 9qlkstx208hz3t
+[t=   63.2s 23:05:39Z] delete returned status=204 resp={}
+[t=   68.5s 23:05:45Z] pod 9qlkstx208hz3t confirmed terminated (404)
+[t=   68.5s 23:05:45Z] PROBE: pod 9qlkstx208hz3t torn down
+[t=    0.0s 23:05:45Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:05:45Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 23:05:46Z] create OK id=maug5y3xy8pu64 costPerHr=$2.89
+[t=    1.0s 23:05:46Z] PROBE: pod created id=maug5y3xy8pu64; waiting for publicIp+ssh_port
+[t=    1.3s 23:05:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 23:06:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 23:06:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 23:06:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 23:06:48Z] PROBE NO-GO: pod maug5y3xy8pu64 not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 23:06:48Z] DELETE pod maug5y3xy8pu64
+[t=   63.3s 23:06:48Z] delete returned status=204 resp={}
+[t=   68.6s 23:06:53Z] pod maug5y3xy8pu64 confirmed terminated (404)
+[t=   68.6s 23:06:53Z] PROBE: pod maug5y3xy8pu64 torn down
+[t=    0.0s 23:06:54Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 23:06:54Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 23:06:54Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 23:06:54Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:07:11Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 23:07:11Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 23:07:12Z] create OK id=ewv4ohuz719nfm costPerHr=$1.49
+[t=    1.0s 23:07:12Z] PROBE: pod created id=ewv4ohuz719nfm; waiting for publicIp+ssh_port
+[t=    1.3s 23:07:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 23:07:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 23:07:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.3s 23:07:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 23:08:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.0s 23:08:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.4s 23:08:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  108.7s 23:08:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  123.7s 23:09:14Z] PROBE NO-GO: pod ewv4ohuz719nfm not RUNNING+SSH within 120s; tearing down
+[t=  123.7s 23:09:14Z] DELETE pod ewv4ohuz719nfm
+[t=  124.4s 23:09:15Z] delete returned status=204 resp={}
+[t=  129.7s 23:09:20Z] pod ewv4ohuz719nfm confirmed terminated (404)
+[t=  129.7s 23:09:20Z] PROBE: pod ewv4ohuz719nfm torn down
+[t=    0.0s 23:09:21Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:09:21Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 23:09:21Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 23:09:21Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:09:21Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:09:21Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.7s 23:09:23Z] create OK id=ysmoy64t14wrgx costPerHr=$3.29
+[t=    1.7s 23:09:23Z] PROBE: pod created id=ysmoy64t14wrgx; waiting for publicIp+ssh_port
+[t=    2.1s 23:09:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 23:09:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 23:09:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.4s 23:10:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.4s 23:10:26Z] PROBE NO-GO: pod ysmoy64t14wrgx not RUNNING+SSH within 60s; tearing down
+[t=   64.4s 23:10:26Z] DELETE pod ysmoy64t14wrgx
+[t=   64.9s 23:10:26Z] delete returned status=204 resp={}
+[t=   70.1s 23:10:31Z] pod ysmoy64t14wrgx confirmed terminated (404)
+[t=   70.1s 23:10:31Z] PROBE: pod ysmoy64t14wrgx torn down
+[t=    0.0s 23:10:32Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:10:32Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 23:10:33Z] create OK id=xxcmmekppktsol costPerHr=$2.89
+[t=    1.0s 23:10:33Z] PROBE: pod created id=xxcmmekppktsol; waiting for publicIp+ssh_port
+[t=    1.3s 23:10:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 23:10:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 23:11:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 23:11:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 23:11:34Z] PROBE NO-GO: pod xxcmmekppktsol not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 23:11:34Z] DELETE pod xxcmmekppktsol
+[t=   63.1s 23:11:35Z] delete returned status=204 resp={}
+[t=   68.4s 23:11:40Z] pod xxcmmekppktsol confirmed terminated (404)
+[t=   68.4s 23:11:40Z] PROBE: pod xxcmmekppktsol torn down
+[t=    0.0s 23:11:40Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 23:11:40Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 23:11:41Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 23:11:41Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:11:56Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 23:11:56Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:11:57Z] create OK id=svusaats9bu8oc costPerHr=$1.49
+[t=    1.1s 23:11:57Z] PROBE: pod created id=svusaats9bu8oc; waiting for publicIp+ssh_port
+[t=    1.4s 23:11:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 23:12:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 23:12:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 23:12:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 23:12:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.1s 23:13:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.4s 23:13:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  108.7s 23:13:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  123.7s 23:14:00Z] PROBE NO-GO: pod svusaats9bu8oc not RUNNING+SSH within 120s; tearing down
+[t=  123.7s 23:14:00Z] DELETE pod svusaats9bu8oc
+[t=  124.3s 23:14:00Z] delete returned status=204 resp={}
+[t=  129.6s 23:14:06Z] pod svusaats9bu8oc confirmed terminated (404)
+[t=  129.6s 23:14:06Z] PROBE: pod svusaats9bu8oc torn down
+[t=    0.0s 23:14:06Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:14:06Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 23:14:07Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 23:14:07Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:14:07Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:14:07Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 23:14:08Z] create OK id=ixlkrfy8sqhsyy costPerHr=$3.29
+[t=    1.3s 23:14:08Z] PROBE: pod created id=ixlkrfy8sqhsyy; waiting for publicIp+ssh_port
+[t=    1.8s 23:14:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 23:14:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 23:14:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.0s 23:14:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.0s 23:15:11Z] PROBE NO-GO: pod ixlkrfy8sqhsyy not RUNNING+SSH within 60s; tearing down
+[t=   64.0s 23:15:11Z] DELETE pod ixlkrfy8sqhsyy
+[t=   64.6s 23:15:11Z] delete returned status=204 resp={}
+[t=   70.0s 23:15:17Z] pod ixlkrfy8sqhsyy confirmed terminated (404)
+[t=   70.0s 23:15:17Z] PROBE: pod ixlkrfy8sqhsyy torn down
+[t=    0.0s 23:15:17Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:15:17Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:15:18Z] create OK id=qu38hsw19qtcfd costPerHr=$2.89
+[t=    1.1s 23:15:18Z] PROBE: pod created id=qu38hsw19qtcfd; waiting for publicIp+ssh_port
+[t=    1.5s 23:15:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 23:15:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 23:15:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 23:16:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 23:16:20Z] PROBE NO-GO: pod qu38hsw19qtcfd not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 23:16:20Z] DELETE pod qu38hsw19qtcfd
+[t=   63.3s 23:16:20Z] delete returned status=204 resp={}
+[t=   68.6s 23:16:26Z] pod qu38hsw19qtcfd confirmed terminated (404)
+[t=   68.6s 23:16:26Z] PROBE: pod qu38hsw19qtcfd torn down
+[t=    0.0s 23:16:26Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 23:16:26Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 23:16:26Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 23:16:26Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:16:49Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 23:16:49Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:16:51Z] create OK id=lj8gqi3wwwn2d6 costPerHr=$1.49
+[t=    1.1s 23:16:51Z] PROBE: pod created id=lj8gqi3wwwn2d6; waiting for publicIp+ssh_port
+[t=    1.4s 23:16:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 23:17:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 23:17:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 23:17:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 23:17:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.5s 23:18:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.8s 23:18:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.2s 23:18:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.2s 23:18:54Z] PROBE NO-GO: pod lj8gqi3wwwn2d6 not RUNNING+SSH within 120s; tearing down
+[t=  124.2s 23:18:54Z] DELETE pod lj8gqi3wwwn2d6
+[t=  124.8s 23:18:54Z] delete returned status=204 resp={}
+[t=  130.1s 23:19:00Z] pod lj8gqi3wwwn2d6 confirmed terminated (404)
+[t=  130.1s 23:19:00Z] PROBE: pod lj8gqi3wwwn2d6 torn down
+[t=    0.0s 23:19:00Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:19:00Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 23:19:00Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 23:19:00Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:19:01Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:19:01Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 23:19:02Z] create OK id=722f1rbtzwu67k costPerHr=$3.29
+[t=    1.3s 23:19:02Z] PROBE: pod created id=722f1rbtzwu67k; waiting for publicIp+ssh_port
+[t=    2.4s 23:19:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.1s 23:19:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.8s 23:19:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 23:19:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.6s 23:20:05Z] PROBE NO-GO: pod 722f1rbtzwu67k not RUNNING+SSH within 60s; tearing down
+[t=   64.6s 23:20:05Z] DELETE pod 722f1rbtzwu67k
+[t=   65.2s 23:20:06Z] delete returned status=204 resp={}
+[t=   70.5s 23:20:11Z] pod 722f1rbtzwu67k confirmed terminated (404)
+[t=   70.5s 23:20:11Z] PROBE: pod 722f1rbtzwu67k torn down
+[t=    0.0s 23:20:11Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:20:11Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.8s 23:20:13Z] create OK id=f42vrw8i8b05cv costPerHr=$2.89
+[t=    1.8s 23:20:13Z] PROBE: pod created id=f42vrw8i8b05cv; waiting for publicIp+ssh_port
+[t=    2.2s 23:20:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 23:20:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.1s 23:20:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.4s 23:21:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.4s 23:21:15Z] PROBE NO-GO: pod f42vrw8i8b05cv not RUNNING+SSH within 60s; tearing down
+[t=   63.4s 23:21:15Z] DELETE pod f42vrw8i8b05cv
+[t=   64.0s 23:21:15Z] delete returned status=204 resp={}
+[t=   69.3s 23:21:20Z] pod f42vrw8i8b05cv confirmed terminated (404)
+[t=   69.3s 23:21:20Z] PROBE: pod f42vrw8i8b05cv torn down
+[t=    0.0s 23:21:21Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 23:21:21Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 23:21:21Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 23:21:21Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:21:39Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 23:21:39Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 23:21:40Z] create OK id=rucy7yicle8dqc costPerHr=$1.49
+[t=    1.2s 23:21:40Z] PROBE: pod created id=rucy7yicle8dqc; waiting for publicIp+ssh_port
+[t=    1.5s 23:21:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 23:21:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 23:22:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 23:22:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.6s 23:22:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.0s 23:22:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.5s 23:23:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.0s 23:23:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.0s 23:23:45Z] PROBE NO-GO: pod rucy7yicle8dqc not RUNNING+SSH within 120s; tearing down
+[t=  126.0s 23:23:45Z] DELETE pod rucy7yicle8dqc
+[t=  126.6s 23:23:45Z] delete returned status=204 resp={}
+[t=  131.9s 23:23:51Z] pod rucy7yicle8dqc confirmed terminated (404)
+[t=  131.9s 23:23:51Z] PROBE: pod rucy7yicle8dqc torn down
+[t=    0.0s 23:23:51Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:23:51Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:23:52Z] create OK id=3llg2uo45o5o4k costPerHr=$1.39
+[t=    1.1s 23:23:52Z] PROBE: pod created id=3llg2uo45o5o4k; waiting for publicIp+ssh_port
+[t=    1.6s 23:23:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 23:24:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 23:24:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 23:24:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 23:24:54Z] PROBE NO-GO: pod 3llg2uo45o5o4k not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 23:24:54Z] DELETE pod 3llg2uo45o5o4k
+[t=   63.4s 23:24:54Z] delete returned status=204 resp={}
+[t=   68.7s 23:25:00Z] pod 3llg2uo45o5o4k confirmed terminated (404)
+[t=   68.7s 23:25:00Z] PROBE: pod 3llg2uo45o5o4k torn down
+[t=    0.0s 23:25:00Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:25:00Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 23:25:01Z] create OK id=bn85ik9s8zgo7v costPerHr=$3.29
+[t=    1.5s 23:25:01Z] PROBE: pod created id=bn85ik9s8zgo7v; waiting for publicIp+ssh_port
+[t=    2.0s 23:25:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.6s 23:25:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.4s 23:25:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.0s 23:25:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.0s 23:26:04Z] PROBE NO-GO: pod bn85ik9s8zgo7v not RUNNING+SSH within 60s; tearing down
+[t=   64.0s 23:26:04Z] DELETE pod bn85ik9s8zgo7v
+[t=   64.6s 23:26:04Z] delete returned status=204 resp={}
+[t=   70.0s 23:26:10Z] pod bn85ik9s8zgo7v confirmed terminated (404)
+[t=   70.0s 23:26:10Z] PROBE: pod bn85ik9s8zgo7v torn down
+[t=    0.0s 23:26:10Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:26:10Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 23:26:11Z] create OK id=jjj2mkg706rmis costPerHr=$2.89
+[t=    1.2s 23:26:11Z] PROBE: pod created id=jjj2mkg706rmis; waiting for publicIp+ssh_port
+[t=    1.5s 23:26:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 23:26:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 23:26:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.1s 23:26:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 23:27:13Z] PROBE NO-GO: pod jjj2mkg706rmis not RUNNING+SSH within 60s; tearing down
+[t=   63.1s 23:27:13Z] DELETE pod jjj2mkg706rmis
+[t=   63.6s 23:27:14Z] delete returned status=204 resp={}
+[t=   68.9s 23:27:19Z] pod jjj2mkg706rmis confirmed terminated (404)
+[t=   68.9s 23:27:19Z] PROBE: pod jjj2mkg706rmis torn down
+[t=    0.0s 23:27:19Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 23:27:19Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 23:27:20Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 23:27:20Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:27:37Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 23:27:37Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 23:27:38Z] create OK id=wydv6sop49dkz4 costPerHr=$1.49
+[t=    1.0s 23:27:38Z] PROBE: pod created id=wydv6sop49dkz4; waiting for publicIp+ssh_port
+[t=    1.3s 23:27:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 23:27:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 23:28:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 23:28:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 23:28:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.1s 23:28:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.5s 23:29:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  108.8s 23:29:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  123.8s 23:29:40Z] PROBE NO-GO: pod wydv6sop49dkz4 not RUNNING+SSH within 120s; tearing down
+[t=  123.8s 23:29:40Z] DELETE pod wydv6sop49dkz4
+[t=  124.4s 23:29:41Z] delete returned status=204 resp={}
+[t=  129.7s 23:29:46Z] pod wydv6sop49dkz4 confirmed terminated (404)
+[t=  129.7s 23:29:46Z] PROBE: pod wydv6sop49dkz4 torn down
+[t=    0.0s 23:29:46Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:29:46Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 23:29:47Z] create OK id=xnj166saaxtv09 costPerHr=$1.39
+[t=    1.0s 23:29:47Z] PROBE: pod created id=xnj166saaxtv09; waiting for publicIp+ssh_port
+[t=    1.3s 23:29:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 23:30:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 23:30:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 23:30:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 23:30:49Z] PROBE NO-GO: pod xnj166saaxtv09 not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 23:30:49Z] DELETE pod xnj166saaxtv09
+[t=   63.4s 23:30:50Z] delete returned status=204 resp={}
+[t=   68.7s 23:30:55Z] pod xnj166saaxtv09 confirmed terminated (404)
+[t=   68.7s 23:30:55Z] PROBE: pod xnj166saaxtv09 torn down
+[t=    0.0s 23:30:55Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:30:55Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 23:30:57Z] create OK id=jlajndag8qjea9 costPerHr=$3.29
+[t=    1.4s 23:30:57Z] PROBE: pod created id=jlajndag8qjea9; waiting for publicIp+ssh_port
+[t=    1.9s 23:30:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.6s 23:31:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.2s 23:31:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.0s 23:31:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.0s 23:31:59Z] PROBE NO-GO: pod jlajndag8qjea9 not RUNNING+SSH within 60s; tearing down
+[t=   64.0s 23:31:59Z] DELETE pod jlajndag8qjea9
+[t=   64.5s 23:32:00Z] delete returned status=204 resp={}
+[t=   69.9s 23:32:05Z] pod jlajndag8qjea9 confirmed terminated (404)
+[t=   69.9s 23:32:05Z] PROBE: pod jlajndag8qjea9 torn down
+[t=    0.0s 23:32:05Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:32:05Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:32:06Z] create OK id=u1argclo10aat8 costPerHr=$2.89
+[t=    1.1s 23:32:06Z] PROBE: pod created id=u1argclo10aat8; waiting for publicIp+ssh_port
+[t=    1.4s 23:32:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 23:32:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 23:32:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 23:32:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 23:33:08Z] PROBE NO-GO: pod u1argclo10aat8 not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 23:33:08Z] DELETE pod u1argclo10aat8
+[t=   63.6s 23:33:09Z] delete returned status=204 resp={}
+[t=   69.0s 23:33:14Z] pod u1argclo10aat8 confirmed terminated (404)
+[t=   69.0s 23:33:14Z] PROBE: pod u1argclo10aat8 torn down
+[t=    0.0s 23:33:15Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 23:33:15Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 23:33:15Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 23:33:15Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:33:41Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 23:33:41Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:33:42Z] create OK id=pv641ze5ogc92z costPerHr=$1.49
+[t=    1.1s 23:33:42Z] PROBE: pod created id=pv641ze5ogc92z; waiting for publicIp+ssh_port
+[t=    1.5s 23:33:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 23:33:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 23:34:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 23:34:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 23:34:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.3s 23:34:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.7s 23:35:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.1s 23:35:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.1s 23:35:45Z] PROBE NO-GO: pod pv641ze5ogc92z not RUNNING+SSH within 120s; tearing down
+[t=  124.1s 23:35:45Z] DELETE pod pv641ze5ogc92z
+[t=  124.7s 23:35:46Z] delete returned status=204 resp={}
+[t=  130.0s 23:35:51Z] pod pv641ze5ogc92z confirmed terminated (404)
+[t=  130.0s 23:35:51Z] PROBE: pod pv641ze5ogc92z torn down
+[t=    0.0s 23:35:51Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:35:51Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 23:35:52Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 23:35:52Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:35:52Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:35:52Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 23:35:53Z] create OK id=zb6a2uu6zda898 costPerHr=$3.29
+[t=    1.0s 23:35:53Z] PROBE: pod created id=zb6a2uu6zda898; waiting for publicIp+ssh_port
+[t=    1.4s 23:35:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 23:36:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 23:36:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 23:36:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 23:36:55Z] PROBE NO-GO: pod zb6a2uu6zda898 not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 23:36:55Z] DELETE pod zb6a2uu6zda898
+[t=   63.2s 23:36:55Z] delete returned status=204 resp={}
+[t=   68.5s 23:37:00Z] pod zb6a2uu6zda898 confirmed terminated (404)
+[t=   68.5s 23:37:00Z] PROBE: pod zb6a2uu6zda898 torn down
+[t=    0.0s 23:37:01Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:37:01Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:37:02Z] create OK id=xt73r9vhltbc1x costPerHr=$2.89
+[t=    1.1s 23:37:02Z] PROBE: pod created id=xt73r9vhltbc1x; waiting for publicIp+ssh_port
+[t=    1.4s 23:37:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 23:37:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 23:37:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 23:37:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 23:38:03Z] PROBE NO-GO: pod xt73r9vhltbc1x not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 23:38:03Z] DELETE pod xt73r9vhltbc1x
+[t=   63.2s 23:38:04Z] delete returned status=204 resp={}
+[t=   68.5s 23:38:09Z] pod xt73r9vhltbc1x confirmed terminated (404)
+[t=   68.5s 23:38:09Z] PROBE: pod xt73r9vhltbc1x torn down
+[t=    0.0s 23:38:09Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 23:38:09Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 23:38:10Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 23:38:10Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:38:29Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 23:38:29Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:38:30Z] create OK id=vx2wgm4aibaae5 costPerHr=$1.49
+[t=    1.1s 23:38:30Z] PROBE: pod created id=vx2wgm4aibaae5; waiting for publicIp+ssh_port
+[t=    1.3s 23:38:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 23:38:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 23:39:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 23:39:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 23:39:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.2s 23:39:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.6s 23:40:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.0s 23:40:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.0s 23:40:34Z] PROBE NO-GO: pod vx2wgm4aibaae5 not RUNNING+SSH within 120s; tearing down
+[t=  125.0s 23:40:34Z] DELETE pod vx2wgm4aibaae5
+[t=  125.5s 23:40:34Z] delete returned status=204 resp={}
+[t=  130.8s 23:40:40Z] pod vx2wgm4aibaae5 confirmed terminated (404)
+[t=  130.8s 23:40:40Z] PROBE: pod vx2wgm4aibaae5 torn down
+[t=    0.0s 23:40:40Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:40:40Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.5s 23:40:40Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.5s 23:40:40Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:40:41Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:40:41Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:40:42Z] create OK id=jq5o2kfudbgqga costPerHr=$3.29
+[t=    1.1s 23:40:42Z] PROBE: pod created id=jq5o2kfudbgqga; waiting for publicIp+ssh_port
+[t=    1.4s 23:40:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 23:40:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 23:41:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 23:41:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 23:41:43Z] PROBE NO-GO: pod jq5o2kfudbgqga not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 23:41:43Z] DELETE pod jq5o2kfudbgqga
+[t=   63.3s 23:41:44Z] delete returned status=204 resp={}
+[t=   68.6s 23:41:49Z] pod jq5o2kfudbgqga confirmed terminated (404)
+[t=   68.6s 23:41:49Z] PROBE: pod jq5o2kfudbgqga torn down
+[t=    0.0s 23:41:49Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:41:49Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:41:51Z] create OK id=yu3k2s82qlgx9f costPerHr=$2.89
+[t=    1.1s 23:41:51Z] PROBE: pod created id=yu3k2s82qlgx9f; waiting for publicIp+ssh_port
+[t=    1.4s 23:41:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 23:42:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 23:42:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 23:42:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 23:42:52Z] PROBE NO-GO: pod yu3k2s82qlgx9f not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 23:42:52Z] DELETE pod yu3k2s82qlgx9f
+[t=   63.3s 23:42:53Z] delete returned status=204 resp={}
+[t=   68.6s 23:42:58Z] pod yu3k2s82qlgx9f confirmed terminated (404)
+[t=   68.6s 23:42:58Z] PROBE: pod yu3k2s82qlgx9f torn down
+[t=    0.0s 23:42:58Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 23:42:58Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 23:42:59Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 23:42:59Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:43:16Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 23:43:16Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:43:18Z] create OK id=7kn6lgbrscc1vb costPerHr=$1.49
+[t=    1.1s 23:43:18Z] PROBE: pod created id=7kn6lgbrscc1vb; waiting for publicIp+ssh_port
+[t=    1.5s 23:43:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 23:43:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 23:43:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 23:44:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 23:44:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.3s 23:44:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.7s 23:44:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.0s 23:45:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.0s 23:45:20Z] PROBE NO-GO: pod 7kn6lgbrscc1vb not RUNNING+SSH within 120s; tearing down
+[t=  124.0s 23:45:20Z] DELETE pod 7kn6lgbrscc1vb
+[t=  124.6s 23:45:21Z] delete returned status=204 resp={}
+[t=  130.0s 23:45:26Z] pod 7kn6lgbrscc1vb confirmed terminated (404)
+[t=  130.0s 23:45:26Z] PROBE: pod 7kn6lgbrscc1vb torn down
+[t=    0.0s 23:45:27Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:45:27Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 23:45:28Z] create OK id=y8m7rbct7ki4ue costPerHr=$1.39
+[t=    1.0s 23:45:28Z] PROBE: pod created id=y8m7rbct7ki4ue; waiting for publicIp+ssh_port
+[t=    1.4s 23:45:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 23:45:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 23:45:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 23:46:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.5s 23:46:29Z] PROBE NO-GO: pod y8m7rbct7ki4ue not RUNNING+SSH within 60s; tearing down
+[t=   62.5s 23:46:29Z] DELETE pod y8m7rbct7ki4ue
+[t=   63.1s 23:46:30Z] delete returned status=204 resp={}
+[t=   68.3s 23:46:35Z] pod y8m7rbct7ki4ue confirmed terminated (404)
+[t=   68.3s 23:46:35Z] PROBE: pod y8m7rbct7ki4ue torn down
+[t=    0.0s 23:46:35Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:46:35Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 23:46:36Z] create OK id=wvqj37dzgk6xf5 costPerHr=$3.29
+[t=    1.2s 23:46:36Z] PROBE: pod created id=wvqj37dzgk6xf5; waiting for publicIp+ssh_port
+[t=    1.7s 23:46:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.0s 23:46:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.8s 23:47:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.4s 23:47:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.4s 23:47:40Z] PROBE NO-GO: pod wvqj37dzgk6xf5 not RUNNING+SSH within 60s; tearing down
+[t=   64.4s 23:47:40Z] DELETE pod wvqj37dzgk6xf5
+[t=   64.9s 23:47:40Z] delete returned status=204 resp={}
+[t=   70.2s 23:47:45Z] pod wvqj37dzgk6xf5 confirmed terminated (404)
+[t=   70.2s 23:47:45Z] PROBE: pod wvqj37dzgk6xf5 torn down
+[t=    0.0s 23:47:46Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:47:46Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 23:47:47Z] create OK id=73hy0l3jrtobtc costPerHr=$2.89
+[t=    1.6s 23:47:47Z] PROBE: pod created id=73hy0l3jrtobtc; waiting for publicIp+ssh_port
+[t=    2.0s 23:47:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 23:48:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 23:48:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   50.2s 23:48:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.3s 23:48:51Z] PROBE NO-GO: pod 73hy0l3jrtobtc not RUNNING+SSH within 60s; tearing down
+[t=   65.3s 23:48:51Z] DELETE pod 73hy0l3jrtobtc
+[t=   65.8s 23:48:51Z] delete returned status=204 resp={}
+[t=   71.1s 23:48:57Z] pod 73hy0l3jrtobtc confirmed terminated (404)
+[t=   71.1s 23:48:57Z] PROBE: pod 73hy0l3jrtobtc torn down
+[t=    0.0s 23:48:57Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 23:48:57Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.6s 23:48:57Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.6s 23:48:57Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:49:17Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 23:49:17Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:49:18Z] create OK id=dk8yt0qmwvlt48 costPerHr=$1.49
+[t=    1.1s 23:49:18Z] PROBE: pod created id=dk8yt0qmwvlt48; waiting for publicIp+ssh_port
+[t=    1.4s 23:49:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 23:49:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 23:49:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 23:50:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 23:50:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.3s 23:50:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.7s 23:50:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.0s 23:51:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.0s 23:51:21Z] PROBE NO-GO: pod dk8yt0qmwvlt48 not RUNNING+SSH within 120s; tearing down
+[t=  124.0s 23:51:21Z] DELETE pod dk8yt0qmwvlt48
+[t=  124.6s 23:51:21Z] delete returned status=204 resp={}
+[t=  129.9s 23:51:27Z] pod dk8yt0qmwvlt48 confirmed terminated (404)
+[t=  129.9s 23:51:27Z] PROBE: pod dk8yt0qmwvlt48 torn down
+[t=    0.0s 23:51:27Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:51:27Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:51:28Z] create OK id=ce3svqnyu3kww0 costPerHr=$1.39
+[t=    1.1s 23:51:28Z] PROBE: pod created id=ce3svqnyu3kww0; waiting for publicIp+ssh_port
+[t=    1.4s 23:51:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 23:51:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 23:51:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 23:52:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 23:52:29Z] PROBE NO-GO: pod ce3svqnyu3kww0 not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 23:52:29Z] DELETE pod ce3svqnyu3kww0
+[t=   63.1s 23:52:30Z] delete returned status=204 resp={}
+[t=   68.4s 23:52:35Z] pod ce3svqnyu3kww0 confirmed terminated (404)
+[t=   68.4s 23:52:35Z] PROBE: pod ce3svqnyu3kww0 torn down
+[t=    0.0s 23:52:35Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:52:35Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 23:52:37Z] create OK id=klkol9zkehn06m costPerHr=$3.29
+[t=    1.3s 23:52:37Z] PROBE: pod created id=klkol9zkehn06m; waiting for publicIp+ssh_port
+[t=    1.8s 23:52:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.6s 23:52:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 23:53:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 23:53:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 23:53:40Z] PROBE NO-GO: pod klkol9zkehn06m not RUNNING+SSH within 60s; tearing down
+[t=   64.1s 23:53:40Z] DELETE pod klkol9zkehn06m
+[t=   64.7s 23:53:40Z] delete returned status=204 resp={}
+[t=   70.0s 23:53:45Z] pod klkol9zkehn06m confirmed terminated (404)
+[t=   70.0s 23:53:45Z] PROBE: pod klkol9zkehn06m torn down
+[t=    0.0s 23:53:46Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:53:46Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 23:53:47Z] create OK id=u3tzsndcybiwo3 costPerHr=$2.89
+[t=    1.3s 23:53:47Z] PROBE: pod created id=u3tzsndcybiwo3; waiting for publicIp+ssh_port
+[t=    1.7s 23:53:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.1s 23:54:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.7s 23:54:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   50.2s 23:54:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.2s 23:54:51Z] PROBE NO-GO: pod u3tzsndcybiwo3 not RUNNING+SSH within 60s; tearing down
+[t=   65.2s 23:54:51Z] DELETE pod u3tzsndcybiwo3
+[t=   65.8s 23:54:52Z] delete returned status=204 resp={}
+[t=   71.1s 23:54:57Z] pod u3tzsndcybiwo3 confirmed terminated (404)
+[t=   71.1s 23:54:57Z] PROBE: pod u3tzsndcybiwo3 torn down
+[t=    0.0s 23:54:57Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 23:54:57Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 23:54:58Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 23:54:58Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:55:14Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 23:55:14Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 23:55:15Z] create OK id=bclu9ykn684j2n costPerHr=$1.49
+[t=    1.1s 23:55:15Z] PROBE: pod created id=bclu9ykn684j2n; waiting for publicIp+ssh_port
+[t=    1.4s 23:55:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 23:55:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 23:55:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 23:56:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 23:56:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.3s 23:56:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   93.6s 23:56:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.0s 23:57:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.0s 23:57:18Z] PROBE NO-GO: pod bclu9ykn684j2n not RUNNING+SSH within 120s; tearing down
+[t=  124.0s 23:57:18Z] DELETE pod bclu9ykn684j2n
+[t=  124.5s 23:57:19Z] delete returned status=204 resp={}
+[t=  129.8s 23:57:24Z] pod bclu9ykn684j2n confirmed terminated (404)
+[t=  129.8s 23:57:24Z] PROBE: pod bclu9ykn684j2n torn down
+[t=    0.0s 23:57:24Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:57:24Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 23:57:25Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 23:57:25Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 23:57:25Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:57:25Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 23:57:27Z] create OK id=5v3ukwi7vbu7n3 costPerHr=$3.29
+[t=    1.4s 23:57:27Z] PROBE: pod created id=5v3ukwi7vbu7n3; waiting for publicIp+ssh_port
+[t=    1.9s 23:57:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 23:57:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 23:57:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.3s 23:58:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.3s 23:58:29Z] PROBE NO-GO: pod 5v3ukwi7vbu7n3 not RUNNING+SSH within 60s; tearing down
+[t=   64.3s 23:58:29Z] DELETE pod 5v3ukwi7vbu7n3
+[t=   64.9s 23:58:30Z] delete returned status=204 resp={}
+[t=   70.2s 23:58:35Z] pod 5v3ukwi7vbu7n3 confirmed terminated (404)
+[t=   70.2s 23:58:35Z] PROBE: pod 5v3ukwi7vbu7n3 torn down
+[t=    0.0s 23:58:36Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 23:58:36Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 23:58:37Z] create OK id=wxcdxl91mzqls4 costPerHr=$2.89
+[t=    1.3s 23:58:37Z] PROBE: pod created id=wxcdxl91mzqls4; waiting for publicIp+ssh_port
+[t=    1.8s 23:58:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 23:58:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 23:59:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.6s 23:59:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.6s 23:59:39Z] PROBE NO-GO: pod wxcdxl91mzqls4 not RUNNING+SSH within 60s; tearing down
+[t=   63.6s 23:59:39Z] DELETE pod wxcdxl91mzqls4
+[t=   64.2s 23:59:40Z] delete returned status=204 resp={}
+[t=   69.5s 23:59:45Z] pod wxcdxl91mzqls4 confirmed terminated (404)
+[t=   69.5s 23:59:45Z] PROBE: pod wxcdxl91mzqls4 torn down
+[t=    0.0s 23:59:45Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 23:59:45Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 23:59:46Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 23:59:46Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500

--- a/results/m4_path_c_probe_20260520/OUTCOME.md
+++ b/results/m4_path_c_probe_20260520/OUTCOME.md
@@ -1,0 +1,89 @@
+# M4 Path C probe — 4-day RunPod retry chain (2026-05-17 → 2026-05-20)
+
+**Verdict:** PROVIDER BLOCKED. RunPod's allocator returned unhealthy hosts on every SKU/cloud combination across 4 calendar days, 512 pod create-attempts, $47.16 in spend, and **zero** `PROBE GO` outcomes. Retry chain stopped 2026-05-20 16:18Z when account balance hit zero (`insufficient funds to bid on this pod`).
+
+## Aggregate stats (from orchestrator.log line-counts across `m4_path_c_probe_2026051{7,8,9}` and `…_20260520`)
+
+| Metric | Value |
+|---|---|
+| Pods created and torn down | **512** |
+| 500 "no instances currently available" responses | 289 |
+| Total pod-hours billed | 23.48 |
+| **Estimated RunPod spend** | **~$47.16** |
+| Pods that ran > 5 min (orchestrator suspension hangs) | 33 |
+| Single worst hang | H100 80GB HBM3 `mjbne6krm2i7ax`, ran 61 min, billed $3.03 |
+| `PROBE GO` outcomes | **0** |
+| `PROBE NO-GO` outcomes | 512 |
+
+## Per-day breakdown
+
+| Date | Pods created | 500s | First / last log entry | Notes |
+|---|---|---|---|---|
+| 2026-05-17 | 13 | 23 | 19:21Z → 22:46Z | Initial probe + first 6 cron ticks (manual + first cron `19ee4a48`) |
+| 2026-05-18 | 67 | 83 | 00:00Z → 23:20Z | Full day on cron `13,43 * * * *`; first multi-minute hangs (48-min, 32-min). Orchestrator hardened mid-day with httpx thread-timeout patch and `caffeinate -is` wrapper. Neither eliminated hangs. |
+| 2026-05-19 | **302** | 153 | 00:55Z → 23:59Z | User shifted from cron-only to back-to-back retry chain ("until fixed - keep that retries"). ~12 retries/hour for 23 hours. Worst single hang 61 min on H100 HBM3 ($3.03). |
+| 2026-05-20 | 130 | 30 | 00:00Z → 16:18Z | Continued back-to-back chain. Account balance ran out around 16:18Z; final 500 was COMMUNITY-spot `insufficient funds to bid`. Cron `19ee4a48` deleted by user. |
+| **Total** | **512** | **289** | | |
+
+## Failure mode (load-bearing finding)
+
+Every successful `create OK` was followed by polls reporting `desiredStatus=RUNNING publicIp= ssh_port=None` until the orchestrator's 60–120s deadline fired. Pods that polled cleanly never published a `publicIp`. This held across:
+- A100-SXM4 80GB SECURE (`$1.49/hr`)
+- A100 80GB PCIe SECURE (`$1.39/hr`)
+- H100 80GB HBM3 SECURE (`$2.99/hr`)
+- H100 PCIe SECURE (`$3.29/hr` when available; mostly 500)
+- A100-SXM4 80GB COMMUNITY-spot (`$1.39/hr`)
+
+Conclusion: not an SKU-specific capacity issue; RunPod's host orchestration layer is returning hosts that boot the OS but never finalize the network attach. The 60–120s deadline is generous (Gate 2-FAIRNESS 2026-04-19 saw publicIp populate in 15–40s on the same SKU on the same orchestrator).
+
+## Orchestrator behavior under macOS process suspension
+
+The `wait_for_running()` poll loop hung 33 times for 5–61 minutes between `time.sleep(15)` polls. Pattern: poll at t=1.5s, poll at t=17.5s, then a single poll line at t=2887s. Wall-clock advances but the process didn't execute. This is macOS suspending the Python process when the laptop's lid closes / system idles / Claude Code harness throttles. Mitigations attempted:
+- **httpx 30s client timeout** — present in original code, did not fire (suspension freezes httpx)
+- **ThreadPoolExecutor + outer `fut.result(timeout=N+5)` patch** — landed 2026-05-17 22:30Z, doesn't help (suspension freezes both worker thread and the orchestrator's main thread together)
+- **`caffeinate -is` wrapper** — prevents idle and system sleep but doesn't cover all suspension paths the harness uses
+Real fix is `signal.alarm()` for deadline enforcement OR a watchdog process outside the suspended Python orchestrator.
+
+## Decision gate state — unchanged
+
+The locked threshold table from issue #103 still applies:
+
+| Arm 2 vs Arm 1 quiet-p99-TTFT delta | v0.2.0 ship |
+|---|---|
+| ≥ 1.5× | GA — default-on, README hero |
+| 1.2 – 1.5× | Experimental — flag-gated |
+| < 1.2× | Disconfirm + publish null — ship LRU as default |
+
+Could not be evaluated. No Arm data captured.
+
+## What ships next
+
+The 4-day chain proved RunPod is unusable for M4 at this allocator state. Two paths forward:
+
+- **(A) Port orchestrator to Lambda Labs** — `m4_path_c_orchestrator.py` is ~600 LOC, mostly RunPod REST shape. Estimated 4–6h to port. Lambda Labs A100 SXM4 has been consistently available historically; their on-demand API doesn't have the same allocator-returns-unhealthy-hosts failure mode.
+- **(B) Ship v0.2.0 disconfirm-by-default** — treat "could not measure" as equivalent to <1.2× and ship LRU per locked threshold. Faster but weaker public claim and forecloses M5 implementation work.
+
+Provider switch is the cleaner call. Lambda port → resume Path C → if Arm 2 vs Arm 1 ≥ 1.5×, GA-track per locked plan.
+
+## Operational artifacts preserved on this branch
+
+- `results/m4_path_c_probe_20260517/orchestrator.log` (289 lines) — already on PR #136
+- `results/m4_path_c_probe_20260517/OUTCOME.md` — initial 3-tick abort writeup (already on PR #136)
+- `results/m4_path_c_probe_20260518/orchestrator.log` (1231 lines)
+- `results/m4_path_c_probe_20260519/orchestrator.log` (4836 lines) — peak retry day
+- `results/m4_path_c_probe_20260520/orchestrator.log` (1909 lines) — including final `insufficient funds` line
+- `scripts/m4_path_c_orchestrator.py` — patched mid-chain with ThreadPoolExecutor timeout shim (concurrent.futures-based `api()` wrapper). Doesn't fix the actual suspension hangs but documents the attempted fix.
+
+## RunPod-side cleanup
+
+All 5 visible EXITED pods deleted via REST `DELETE /v1/pods/{id}` on 2026-05-20 ~16:30Z: `9mihjj4sr2956r`, `6vd2l2avzr6zq4`, `u6ehpz6ubowmq1`, `ho7iockhd3tyoh`, `7zg8oaj64rirmy`. No alive pods leaked compute throughout the chain — orchestrator teardown was reliable; only the polling-stage hangs ran up the bill.
+
+## What does NOT change
+
+- `kvwarden==0.1.5` on PyPI, repo public on `coconut-labs/kvwarden`, BibTeX cite-as bumped via PR #134.
+- Show HN body at `docs/launch/show_hn.md` still final, still not clicked (8 days past locked 2026-05-12 ship date). Independent of M4.
+- mlxd G2 cool-off ended 2026-05-19 — execution unblocked but no work landed this window.
+
+## Pause point
+
+User declared "stop" at 2026-05-20 ~16:30Z after balance exhausted. Cron `19ee4a48` deleted. No retries scheduled. Resuming requires either (a) RunPod top-up + acceptance that the same allocator state will keep burning, or (b) Lambda Labs port. User explicit: "wait until we refresh the budget."

--- a/results/m4_path_c_probe_20260520/orchestrator.log
+++ b/results/m4_path_c_probe_20260520/orchestrator.log
@@ -1,0 +1,1909 @@
+[t=    0.0s 00:00:06Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 00:00:06Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 00:00:07Z] create OK id=8aaj5wrqguqgjk costPerHr=$1.49
+[t=    1.2s 00:00:07Z] PROBE: pod created id=8aaj5wrqguqgjk; waiting for publicIp+ssh_port
+[t=    1.6s 00:00:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 00:00:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 00:00:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 00:00:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 00:01:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.8s 00:01:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.2s 00:01:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.6s 00:01:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.6s 00:02:11Z] PROBE NO-GO: pod 8aaj5wrqguqgjk not RUNNING+SSH within 120s; tearing down
+[t=  124.6s 00:02:11Z] DELETE pod 8aaj5wrqguqgjk
+[t=  125.1s 00:02:11Z] delete returned status=204 resp={}
+[t=  147.6s 00:02:34Z] pod 8aaj5wrqguqgjk confirmed terminated (404)
+[t=  147.6s 00:02:34Z] PROBE: pod 8aaj5wrqguqgjk torn down
+[t=    0.0s 00:02:34Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:02:34Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 00:02:34Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 00:02:34Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 00:02:35Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:02:35Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 00:02:36Z] create OK id=e5b572uie3yiov costPerHr=$3.29
+[t=    1.3s 00:02:36Z] PROBE: pod created id=e5b572uie3yiov; waiting for publicIp+ssh_port
+[t=    1.8s 00:02:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  172.0s 00:05:27Z] PROBE NO-GO: pod e5b572uie3yiov not RUNNING+SSH within 60s; tearing down
+[t=  172.0s 00:05:27Z] DELETE pod e5b572uie3yiov
+[t=  172.6s 00:05:27Z] delete returned status=204 resp={}
+[t=  177.9s 00:05:32Z] pod e5b572uie3yiov confirmed terminated (404)
+[t=  177.9s 00:05:32Z] PROBE: pod e5b572uie3yiov torn down
+[t=    0.0s 00:05:33Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:05:33Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 00:05:34Z] create OK id=1r1h8uehcx2018 costPerHr=$2.89
+[t=    1.1s 00:05:34Z] PROBE: pod created id=1r1h8uehcx2018; waiting for publicIp+ssh_port
+[t=    1.5s 00:05:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 00:05:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 00:06:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  200.2s 00:08:53Z] PROBE NO-GO: pod 1r1h8uehcx2018 not RUNNING+SSH within 60s; tearing down
+[t=  200.2s 00:08:53Z] DELETE pod 1r1h8uehcx2018
+[t=  200.8s 00:08:53Z] delete returned status=204 resp={}
+[t=  206.1s 00:08:59Z] pod 1r1h8uehcx2018 confirmed terminated (404)
+[t=  206.1s 00:08:59Z] PROBE: pod 1r1h8uehcx2018 torn down
+[t=    0.0s 00:08:59Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 00:08:59Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 00:08:59Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 00:08:59Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 00:09:16Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 00:09:16Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 00:09:18Z] create OK id=k922w5zedgflak costPerHr=$1.49
+[t=    1.2s 00:09:18Z] PROBE: pod created id=k922w5zedgflak; waiting for publicIp+ssh_port
+[t=    1.5s 00:09:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  574.7s 00:18:51Z] PROBE NO-GO: pod k922w5zedgflak not RUNNING+SSH within 120s; tearing down
+[t=  574.7s 00:18:51Z] DELETE pod k922w5zedgflak
+[t=  575.3s 00:18:52Z] delete returned status=204 resp={}
+[t=  580.7s 00:18:57Z] pod k922w5zedgflak confirmed terminated (404)
+[t=  580.7s 00:18:57Z] PROBE: pod k922w5zedgflak torn down
+[t=    0.0s 00:18:57Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:18:57Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 00:18:58Z] create OK id=0a5f5trd9wb0ks costPerHr=$1.39
+[t=    1.2s 00:18:58Z] PROBE: pod created id=0a5f5trd9wb0ks; waiting for publicIp+ssh_port
+[t=    1.6s 00:18:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 00:19:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  913.5s 00:34:11Z] PROBE NO-GO: pod 0a5f5trd9wb0ks not RUNNING+SSH within 60s; tearing down
+[t=  913.5s 00:34:11Z] DELETE pod 0a5f5trd9wb0ks
+[t=  914.2s 00:34:12Z] delete returned status=204 resp={}
+[t=  919.7s 00:34:17Z] pod 0a5f5trd9wb0ks confirmed terminated (404)
+[t=  919.7s 00:34:17Z] PROBE: pod 0a5f5trd9wb0ks torn down
+[t=    0.0s 00:34:17Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:34:17Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    2.1s 00:34:19Z] create OK id=kj6sabf5gefu36 costPerHr=$3.29
+[t=    2.1s 00:34:19Z] PROBE: pod created id=kj6sabf5gefu36; waiting for publicIp+ssh_port
+[t=    2.6s 00:34:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.4s 00:34:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.1s 00:34:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.8s 00:35:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.8s 00:35:22Z] PROBE NO-GO: pod kj6sabf5gefu36 not RUNNING+SSH within 60s; tearing down
+[t=   64.8s 00:35:22Z] DELETE pod kj6sabf5gefu36
+[t=   65.4s 00:35:23Z] delete returned status=204 resp={}
+[t=   70.7s 00:35:28Z] pod kj6sabf5gefu36 confirmed terminated (404)
+[t=   70.7s 00:35:28Z] PROBE: pod kj6sabf5gefu36 torn down
+[t=    0.0s 00:35:28Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:35:28Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 00:35:29Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 00:35:29Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 00:35:29Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 00:35:29Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 00:35:29Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 00:35:29Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 00:41:48Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 00:41:48Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 00:41:49Z] create OK id=ho7iockhd3tyoh costPerHr=$1.49
+[t=    1.1s 00:41:49Z] PROBE: pod created id=ho7iockhd3tyoh; waiting for publicIp+ssh_port
+[t=    1.4s 00:41:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 00:42:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 00:42:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 00:42:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.5s 00:43:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  200.5s 00:45:09Z] PROBE NO-GO: pod ho7iockhd3tyoh not RUNNING+SSH within 120s; tearing down
+[t=  200.5s 00:45:09Z] DELETE pod ho7iockhd3tyoh
+[t=  200.5s 00:45:09Z] delete returned status=-1 resp=transport_error: ConnectError('[Errno 8] nodename nor servname provided, or not known')
+[t=  205.5s 00:45:14Z] post-delete GET status=-1 (waiting for 404)
+[t=  210.5s 00:45:19Z] post-delete GET status=-1 (waiting for 404)
+[t=  215.5s 00:45:24Z] post-delete GET status=-1 (waiting for 404)
+[t=  220.5s 00:45:29Z] post-delete GET status=-1 (waiting for 404)
+[t=  225.5s 00:45:34Z] post-delete GET status=-1 (waiting for 404)
+[t=  230.5s 00:45:39Z] post-delete GET status=-1 (waiting for 404)
+[t=  230.5s 00:45:39Z] WARN: pod ho7iockhd3tyoh did not return 404 after delete; check console
+[t=  230.5s 00:45:39Z] PROBE: pod ho7iockhd3tyoh torn down
+[t=    0.0s 00:45:39Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:45:39Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.1s 00:45:39Z] create FAIL status=-1 resp=transport_error: ConnectError('[Errno 8] nodename nor servname provided, or not known')
+[t=    0.1s 00:45:39Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=-1
+[t=    0.0s 00:45:39Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:45:39Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.0s 00:45:39Z] create FAIL status=-1 resp=transport_error: ConnectError('[Errno 8] nodename nor servname provided, or not known')
+[t=    0.0s 00:45:39Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=-1
+[t=    0.0s 00:45:39Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:45:39Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.0s 00:45:39Z] create FAIL status=-1 resp=transport_error: ConnectError('[Errno 8] nodename nor servname provided, or not known')
+[t=    0.0s 00:45:39Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=-1
+[t=    0.0s 00:45:40Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 00:45:40Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.1s 00:45:40Z] create FAIL status=-1 resp=transport_error: ConnectError('[Errno 8] nodename nor servname provided, or not known')
+[t=    0.1s 00:45:40Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=-1
+[t=    0.0s 00:55:13Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 00:55:13Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 00:55:14Z] create OK id=l9y1ap20uodgnh costPerHr=$1.49
+[t=    1.4s 00:55:14Z] PROBE: pod created id=l9y1ap20uodgnh; waiting for publicIp+ssh_port
+[t=    1.7s 00:55:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 00:55:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 00:55:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 00:56:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.4s 00:56:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.9s 00:56:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.4s 00:56:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.8s 00:57:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.8s 00:57:18Z] PROBE NO-GO: pod l9y1ap20uodgnh not RUNNING+SSH within 120s; tearing down
+[t=  124.8s 00:57:18Z] DELETE pod l9y1ap20uodgnh
+[t=  125.4s 00:57:18Z] delete returned status=204 resp={}
+[t=  130.8s 00:57:24Z] pod l9y1ap20uodgnh confirmed terminated (404)
+[t=  130.8s 00:57:24Z] PROBE: pod l9y1ap20uodgnh torn down
+[t=    0.0s 00:57:24Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:57:24Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 00:57:25Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 00:57:25Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 00:57:25Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:57:25Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 00:57:26Z] create OK id=wu8vdyv0t3z5f2 costPerHr=$3.29
+[t=    1.5s 00:57:26Z] PROBE: pod created id=wu8vdyv0t3z5f2; waiting for publicIp+ssh_port
+[t=    1.9s 00:57:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.3s 00:57:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.0s 00:57:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.8s 00:58:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.8s 00:58:29Z] PROBE NO-GO: pod wu8vdyv0t3z5f2 not RUNNING+SSH within 60s; tearing down
+[t=   64.8s 00:58:29Z] DELETE pod wu8vdyv0t3z5f2
+[t=   65.5s 00:58:30Z] delete returned status=204 resp={}
+[t=   70.9s 00:58:36Z] pod wu8vdyv0t3z5f2 confirmed terminated (404)
+[t=   70.9s 00:58:36Z] PROBE: pod wu8vdyv0t3z5f2 torn down
+[t=    0.0s 00:58:36Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 00:58:36Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 00:58:37Z] create OK id=le7d7lglgunnr6 costPerHr=$2.89
+[t=    1.1s 00:58:37Z] PROBE: pod created id=le7d7lglgunnr6; waiting for publicIp+ssh_port
+[t=    1.5s 00:58:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 00:58:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 00:59:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 00:59:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 00:59:39Z] PROBE NO-GO: pod le7d7lglgunnr6 not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 00:59:39Z] DELETE pod le7d7lglgunnr6
+[t=   63.7s 00:59:39Z] delete returned status=204 resp={}
+[t=   69.0s 00:59:45Z] pod le7d7lglgunnr6 confirmed terminated (404)
+[t=   69.0s 00:59:45Z] PROBE: pod le7d7lglgunnr6 torn down
+[t=    0.0s 00:59:45Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 00:59:45Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.1s 00:59:46Z] create OK id=46owqgoleot7tk costPerHr=$1.39
+[t=    1.1s 00:59:46Z] PROBE: pod created id=46owqgoleot7tk; waiting for publicIp+ssh_port
+[t=    1.5s 00:59:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 01:00:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 01:00:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 01:00:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 01:00:48Z] PROBE NO-GO: pod 46owqgoleot7tk not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 01:00:48Z] DELETE pod 46owqgoleot7tk
+[t=   63.4s 01:00:48Z] delete returned status=204 resp={}
+[t=   68.8s 01:00:54Z] pod 46owqgoleot7tk confirmed terminated (404)
+[t=   68.8s 01:00:54Z] PROBE: pod 46owqgoleot7tk torn down
+[t=    0.0s 01:01:24Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 01:01:24Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 01:01:25Z] create OK id=rtalqjzsm9zzjw costPerHr=$1.49
+[t=    1.2s 01:01:25Z] PROBE: pod created id=rtalqjzsm9zzjw; waiting for publicIp+ssh_port
+[t=    1.5s 01:01:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 01:01:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 01:01:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 01:02:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 01:02:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.6s 01:02:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.0s 01:02:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.4s 01:03:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.4s 01:03:29Z] PROBE NO-GO: pod rtalqjzsm9zzjw not RUNNING+SSH within 120s; tearing down
+[t=  124.4s 01:03:29Z] DELETE pod rtalqjzsm9zzjw
+[t=  125.1s 01:03:29Z] delete returned status=204 resp={}
+[t=  130.4s 01:03:35Z] pod rtalqjzsm9zzjw confirmed terminated (404)
+[t=  130.4s 01:03:35Z] PROBE: pod rtalqjzsm9zzjw torn down
+[t=    0.0s 01:03:35Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:03:35Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 01:03:36Z] create OK id=uj91d1sr0layc0 costPerHr=$1.39
+[t=    1.5s 01:03:36Z] PROBE: pod created id=uj91d1sr0layc0; waiting for publicIp+ssh_port
+[t=    1.9s 01:03:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 01:03:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.4s 01:04:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 01:04:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 01:04:39Z] PROBE NO-GO: pod uj91d1sr0layc0 not RUNNING+SSH within 60s; tearing down
+[t=   64.1s 01:04:39Z] DELETE pod uj91d1sr0layc0
+[t=   64.9s 01:04:40Z] delete returned status=204 resp={}
+[t=   70.3s 01:04:45Z] pod uj91d1sr0layc0 confirmed terminated (404)
+[t=   70.3s 01:04:45Z] PROBE: pod uj91d1sr0layc0 torn down
+[t=    0.0s 01:04:45Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:04:45Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 01:04:47Z] create OK id=mg1tzfl0w6h3oc costPerHr=$3.29
+[t=    1.5s 01:04:47Z] PROBE: pod created id=mg1tzfl0w6h3oc; waiting for publicIp+ssh_port
+[t=    1.9s 01:04:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 01:05:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.5s 01:05:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.3s 01:05:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.3s 01:05:50Z] PROBE NO-GO: pod mg1tzfl0w6h3oc not RUNNING+SSH within 60s; tearing down
+[t=   64.3s 01:05:50Z] DELETE pod mg1tzfl0w6h3oc
+[t=   64.9s 01:05:50Z] delete returned status=204 resp={}
+[t=   70.4s 01:05:56Z] pod mg1tzfl0w6h3oc confirmed terminated (404)
+[t=   70.4s 01:05:56Z] PROBE: pod mg1tzfl0w6h3oc torn down
+[t=    0.0s 01:05:56Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:05:56Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 01:05:57Z] create OK id=glgmnnrw9a26pi costPerHr=$2.89
+[t=    1.1s 01:05:57Z] PROBE: pod created id=glgmnnrw9a26pi; waiting for publicIp+ssh_port
+[t=    1.4s 01:05:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 01:06:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 01:06:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 01:06:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 01:06:59Z] PROBE NO-GO: pod glgmnnrw9a26pi not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 01:06:59Z] DELETE pod glgmnnrw9a26pi
+[t=   63.6s 01:07:00Z] delete returned status=204 resp={}
+[t=   69.0s 01:07:05Z] pod glgmnnrw9a26pi confirmed terminated (404)
+[t=   69.0s 01:07:05Z] PROBE: pod glgmnnrw9a26pi torn down
+[t=    0.0s 01:07:05Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 01:07:05Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 01:07:06Z] create OK id=8b6valrr0w5py1 costPerHr=$1.39
+[t=    1.0s 01:07:06Z] PROBE: pod created id=8b6valrr0w5py1; waiting for publicIp+ssh_port
+[t=    1.3s 01:07:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 01:07:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 01:07:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 01:07:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 01:08:08Z] PROBE NO-GO: pod 8b6valrr0w5py1 not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 01:08:08Z] DELETE pod 8b6valrr0w5py1
+[t=   63.6s 01:08:09Z] delete returned status=204 resp={}
+[t=   69.0s 01:08:14Z] pod 8b6valrr0w5py1 confirmed terminated (404)
+[t=   69.0s 01:08:14Z] PROBE: pod 8b6valrr0w5py1 torn down
+[t=    0.0s 01:08:38Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 01:08:38Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 01:08:39Z] create OK id=p1mto31g66kog9 costPerHr=$1.49
+[t=    1.2s 01:08:39Z] PROBE: pod created id=p1mto31g66kog9; waiting for publicIp+ssh_port
+[t=    1.6s 01:08:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 01:08:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 01:09:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 01:09:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 01:09:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.7s 01:09:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.5s 01:10:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.9s 01:10:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.9s 01:10:43Z] PROBE NO-GO: pod p1mto31g66kog9 not RUNNING+SSH within 120s; tearing down
+[t=  124.9s 01:10:43Z] DELETE pod p1mto31g66kog9
+[t=  125.6s 01:10:44Z] delete returned status=204 resp={}
+[t=  131.0s 01:10:49Z] pod p1mto31g66kog9 confirmed terminated (404)
+[t=  131.0s 01:10:49Z] PROBE: pod p1mto31g66kog9 torn down
+[t=    0.0s 01:10:49Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:10:49Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 01:10:50Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 01:10:50Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 01:10:50Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:10:50Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 01:10:51Z] create OK id=ltjzifrzjcsydb costPerHr=$3.29
+[t=    1.6s 01:10:51Z] PROBE: pod created id=ltjzifrzjcsydb; waiting for publicIp+ssh_port
+[t=    2.1s 01:10:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.1s 01:11:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.8s 01:11:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.7s 01:11:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.7s 01:11:55Z] PROBE NO-GO: pod ltjzifrzjcsydb not RUNNING+SSH within 60s; tearing down
+[t=   64.7s 01:11:55Z] DELETE pod ltjzifrzjcsydb
+[t=   65.3s 01:11:55Z] delete returned status=204 resp={}
+[t=   70.7s 01:12:01Z] pod ltjzifrzjcsydb confirmed terminated (404)
+[t=   70.7s 01:12:01Z] PROBE: pod ltjzifrzjcsydb torn down
+[t=    0.0s 01:12:01Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:12:01Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 01:12:02Z] create OK id=vjbanfqw5eml1e costPerHr=$2.89
+[t=    1.2s 01:12:02Z] PROBE: pod created id=vjbanfqw5eml1e; waiting for publicIp+ssh_port
+[t=    1.8s 01:12:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 01:12:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 01:12:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 01:12:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 01:13:04Z] PROBE NO-GO: pod vjbanfqw5eml1e not RUNNING+SSH within 60s; tearing down
+[t=   63.2s 01:13:04Z] DELETE pod vjbanfqw5eml1e
+[t=   63.9s 01:13:05Z] delete returned status=204 resp={}
+[t=   69.2s 01:13:10Z] pod vjbanfqw5eml1e confirmed terminated (404)
+[t=   69.2s 01:13:10Z] PROBE: pod vjbanfqw5eml1e torn down
+[t=    0.0s 01:13:10Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 01:13:10Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 01:13:11Z] create OK id=gc7zi27ozcj1tb costPerHr=$1.39
+[t=    0.9s 01:13:11Z] PROBE: pod created id=gc7zi27ozcj1tb; waiting for publicIp+ssh_port
+[t=    1.2s 01:13:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 01:13:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 01:13:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 01:13:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 01:14:13Z] PROBE NO-GO: pod gc7zi27ozcj1tb not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 01:14:13Z] DELETE pod gc7zi27ozcj1tb
+[t=   63.6s 01:14:14Z] delete returned status=204 resp={}
+[t=   69.0s 01:14:19Z] pod gc7zi27ozcj1tb confirmed terminated (404)
+[t=   69.0s 01:14:19Z] PROBE: pod gc7zi27ozcj1tb torn down
+[t=    0.0s 01:14:43Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 01:14:43Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 01:14:44Z] create OK id=y4p8bc8pkk8og5 costPerHr=$1.49
+[t=    1.2s 01:14:44Z] PROBE: pod created id=y4p8bc8pkk8og5; waiting for publicIp+ssh_port
+[t=    1.6s 01:14:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 01:15:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 01:15:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 01:15:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.5s 01:15:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  127.7s 01:16:50Z] PROBE NO-GO: pod y4p8bc8pkk8og5 not RUNNING+SSH within 120s; tearing down
+[t=  127.7s 01:16:50Z] DELETE pod y4p8bc8pkk8og5
+[t=  128.8s 01:16:51Z] delete returned status=204 resp={}
+[t=  134.2s 01:16:57Z] pod y4p8bc8pkk8og5 confirmed terminated (404)
+[t=  134.2s 01:16:57Z] PROBE: pod y4p8bc8pkk8og5 torn down
+[t=    0.0s 01:16:57Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:16:57Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 01:16:58Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 01:16:58Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 01:16:58Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:16:58Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.9s 01:17:00Z] create OK id=u6ehpz6ubowmq1 costPerHr=$3.29
+[t=    1.9s 01:17:00Z] PROBE: pod created id=u6ehpz6ubowmq1; waiting for publicIp+ssh_port
+[t=    2.4s 01:17:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.5s 01:17:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  437.6s 01:24:15Z] PROBE NO-GO: pod u6ehpz6ubowmq1 not RUNNING+SSH within 60s; tearing down
+[t=  437.6s 01:24:15Z] DELETE pod u6ehpz6ubowmq1
+[t=  437.6s 01:24:15Z] delete returned status=-1 resp=transport_error: ConnectError('[Errno 8] nodename nor servname provided, or not known')
+[t=  444.0s 01:24:22Z] post-delete GET status=200 (waiting for 404)
+[t=  449.9s 01:24:28Z] post-delete GET status=200 (waiting for 404)
+[t=  455.6s 01:24:33Z] post-delete GET status=200 (waiting for 404)
+[t=  461.6s 01:24:39Z] post-delete GET status=200 (waiting for 404)
+[t=  467.5s 01:24:45Z] post-delete GET status=200 (waiting for 404)
+[t=  473.3s 01:24:51Z] post-delete GET status=200 (waiting for 404)
+[t=  473.3s 01:24:51Z] WARN: pod u6ehpz6ubowmq1 did not return 404 after delete; check console
+[t=  473.3s 01:24:51Z] PROBE: pod u6ehpz6ubowmq1 torn down
+[t=    0.0s 01:24:51Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:24:51Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 01:24:53Z] create OK id=a61rho5e8ibpqw costPerHr=$2.89
+[t=    1.3s 01:24:53Z] PROBE: pod created id=a61rho5e8ibpqw; waiting for publicIp+ssh_port
+[t=    1.7s 01:24:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   61.5s 01:25:53Z] PROBE NO-GO: pod a61rho5e8ibpqw not RUNNING+SSH within 60s; tearing down
+[t=   61.5s 01:25:53Z] DELETE pod a61rho5e8ibpqw
+[t=   62.2s 01:25:53Z] delete returned status=204 resp={}
+[t=   67.5s 01:25:59Z] pod a61rho5e8ibpqw confirmed terminated (404)
+[t=   67.5s 01:25:59Z] PROBE: pod a61rho5e8ibpqw torn down
+[t=    0.0s 01:25:59Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 01:25:59Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 01:26:00Z] create OK id=k0whzqsujzngl4 costPerHr=$1.39
+[t=    0.9s 01:26:00Z] PROBE: pod created id=k0whzqsujzngl4; waiting for publicIp+ssh_port
+[t=    1.3s 01:26:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   76.2s 01:27:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   91.2s 01:27:30Z] PROBE NO-GO: pod k0whzqsujzngl4 not RUNNING+SSH within 60s; tearing down
+[t=   91.2s 01:27:30Z] DELETE pod k0whzqsujzngl4
+[t=   91.8s 01:27:31Z] delete returned status=204 resp={}
+[t=   97.2s 01:27:36Z] pod k0whzqsujzngl4 confirmed terminated (404)
+[t=   97.2s 01:27:36Z] PROBE: pod k0whzqsujzngl4 torn down
+[t=    0.0s 01:28:03Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 01:28:03Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 01:28:04Z] create OK id=cxlj0tit9mcu8i costPerHr=$1.49
+[t=    1.2s 01:28:04Z] PROBE: pod created id=cxlj0tit9mcu8i; waiting for publicIp+ssh_port
+[t=    1.5s 01:28:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 01:28:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 01:28:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 01:28:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.8s 01:29:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.6s 01:29:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.1s 01:29:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.6s 01:29:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.6s 01:30:09Z] PROBE NO-GO: pod cxlj0tit9mcu8i not RUNNING+SSH within 120s; tearing down
+[t=  125.6s 01:30:09Z] DELETE pod cxlj0tit9mcu8i
+[t=  126.3s 01:30:09Z] delete returned status=204 resp={}
+[t=  131.9s 01:30:15Z] pod cxlj0tit9mcu8i confirmed terminated (404)
+[t=  131.9s 01:30:15Z] PROBE: pod cxlj0tit9mcu8i torn down
+[t=    0.0s 01:30:16Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:30:16Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 01:30:17Z] create OK id=ok60fk779egsed costPerHr=$1.39
+[t=    1.1s 01:30:17Z] PROBE: pod created id=ok60fk779egsed; waiting for publicIp+ssh_port
+[t=    1.5s 01:30:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 01:30:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 01:30:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 01:31:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 01:31:19Z] PROBE NO-GO: pod ok60fk779egsed not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 01:31:19Z] DELETE pod ok60fk779egsed
+[t=   63.4s 01:31:20Z] delete returned status=204 resp={}
+[t=   69.0s 01:31:25Z] pod ok60fk779egsed confirmed terminated (404)
+[t=   69.0s 01:31:25Z] PROBE: pod ok60fk779egsed torn down
+[t=    0.0s 01:31:25Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:31:25Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 01:31:27Z] create OK id=ip4b1106xxdnxb costPerHr=$3.29
+[t=    1.3s 01:31:27Z] PROBE: pod created id=ip4b1106xxdnxb; waiting for publicIp+ssh_port
+[t=    1.7s 01:31:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 01:31:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 01:31:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 01:32:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 01:32:29Z] PROBE NO-GO: pod ip4b1106xxdnxb not RUNNING+SSH within 60s; tearing down
+[t=   63.2s 01:32:29Z] DELETE pod ip4b1106xxdnxb
+[t=   63.8s 01:32:29Z] delete returned status=204 resp={}
+[t=   69.3s 01:32:35Z] pod ip4b1106xxdnxb confirmed terminated (404)
+[t=   69.3s 01:32:35Z] PROBE: pod ip4b1106xxdnxb torn down
+[t=    0.0s 01:32:35Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:32:35Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 01:32:36Z] create OK id=ufw4a80837gtb7 costPerHr=$2.89
+[t=    1.2s 01:32:36Z] PROBE: pod created id=ufw4a80837gtb7; waiting for publicIp+ssh_port
+[t=    1.7s 01:32:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 01:32:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 01:33:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 01:33:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 01:33:38Z] PROBE NO-GO: pod ufw4a80837gtb7 not RUNNING+SSH within 60s; tearing down
+[t=   63.3s 01:33:38Z] DELETE pod ufw4a80837gtb7
+[t=   63.9s 01:33:39Z] delete returned status=204 resp={}
+[t=   69.3s 01:33:44Z] pod ufw4a80837gtb7 confirmed terminated (404)
+[t=   69.3s 01:33:44Z] PROBE: pod ufw4a80837gtb7 torn down
+[t=    0.0s 01:33:45Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 01:33:45Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.2s 01:33:46Z] create OK id=wsbm79fu5fs7e5 costPerHr=$1.39
+[t=    1.2s 01:33:46Z] PROBE: pod created id=wsbm79fu5fs7e5; waiting for publicIp+ssh_port
+[t=    1.5s 01:33:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 01:34:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 01:34:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 01:34:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 01:34:48Z] PROBE NO-GO: pod wsbm79fu5fs7e5 not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 01:34:48Z] DELETE pod wsbm79fu5fs7e5
+[t=   63.6s 01:34:48Z] delete returned status=204 resp={}
+[t=   69.0s 01:34:54Z] pod wsbm79fu5fs7e5 confirmed terminated (404)
+[t=   69.0s 01:34:54Z] PROBE: pod wsbm79fu5fs7e5 torn down
+[t=    0.0s 01:35:10Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 01:35:10Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 01:35:12Z] create OK id=dend6uxsks8qsh costPerHr=$1.49
+[t=    1.3s 01:35:12Z] PROBE: pod created id=dend6uxsks8qsh; waiting for publicIp+ssh_port
+[t=    1.7s 01:35:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 01:35:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 01:35:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 01:35:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.6s 01:36:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.1s 01:36:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.5s 01:36:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.3s 01:37:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.3s 01:37:16Z] PROBE NO-GO: pod dend6uxsks8qsh not RUNNING+SSH within 120s; tearing down
+[t=  125.3s 01:37:16Z] DELETE pod dend6uxsks8qsh
+[t=  126.2s 01:37:17Z] delete returned status=204 resp={}
+[t=  131.5s 01:37:22Z] pod dend6uxsks8qsh confirmed terminated (404)
+[t=  131.5s 01:37:22Z] PROBE: pod dend6uxsks8qsh torn down
+[t=    0.0s 01:37:22Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:37:22Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 01:37:23Z] create OK id=owvy5ukxk6fs76 costPerHr=$1.39
+[t=    1.2s 01:37:23Z] PROBE: pod created id=owvy5ukxk6fs76; waiting for publicIp+ssh_port
+[t=    1.6s 01:37:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 01:37:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 01:37:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.8s 01:38:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.8s 01:38:26Z] PROBE NO-GO: pod owvy5ukxk6fs76 not RUNNING+SSH within 60s; tearing down
+[t=   63.8s 01:38:26Z] DELETE pod owvy5ukxk6fs76
+[t=   64.7s 01:38:27Z] delete returned status=204 resp={}
+[t=   70.0s 01:38:32Z] pod owvy5ukxk6fs76 confirmed terminated (404)
+[t=   70.0s 01:38:32Z] PROBE: pod owvy5ukxk6fs76 torn down
+[t=    0.0s 01:38:32Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:38:32Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 01:38:34Z] create OK id=e50u6fciehyaty costPerHr=$3.29
+[t=    1.4s 01:38:34Z] PROBE: pod created id=e50u6fciehyaty; waiting for publicIp+ssh_port
+[t=    2.1s 01:38:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 01:38:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 01:39:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 01:39:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 01:39:37Z] PROBE NO-GO: pod e50u6fciehyaty not RUNNING+SSH within 60s; tearing down
+[t=   64.6s 01:39:37Z] DELETE pod e50u6fciehyaty
+[t=   65.2s 01:39:38Z] delete returned status=204 resp={}
+[t=   70.5s 01:39:43Z] pod e50u6fciehyaty confirmed terminated (404)
+[t=   70.5s 01:39:43Z] PROBE: pod e50u6fciehyaty torn down
+[t=    0.0s 01:39:43Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:39:43Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 01:39:44Z] create OK id=ds89ydx6jkp8xu costPerHr=$2.89
+[t=    1.1s 01:39:44Z] PROBE: pod created id=ds89ydx6jkp8xu; waiting for publicIp+ssh_port
+[t=    1.6s 01:39:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 01:40:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 01:40:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 01:40:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 01:40:46Z] PROBE NO-GO: pod ds89ydx6jkp8xu not RUNNING+SSH within 60s; tearing down
+[t=   63.2s 01:40:46Z] DELETE pod ds89ydx6jkp8xu
+[t=   63.8s 01:40:47Z] delete returned status=204 resp={}
+[t=   69.2s 01:40:52Z] pod ds89ydx6jkp8xu confirmed terminated (404)
+[t=   69.2s 01:40:52Z] PROBE: pod ds89ydx6jkp8xu torn down
+[t=    0.0s 01:40:53Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 01:40:53Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 01:40:53Z] create OK id=bftgmpswhzj2wf costPerHr=$1.39
+[t=    0.9s 01:40:53Z] PROBE: pod created id=bftgmpswhzj2wf; waiting for publicIp+ssh_port
+[t=    1.3s 01:40:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 01:41:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 01:41:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 01:41:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 01:41:55Z] PROBE NO-GO: pod bftgmpswhzj2wf not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 01:41:55Z] DELETE pod bftgmpswhzj2wf
+[t=   63.9s 01:41:56Z] delete returned status=204 resp={}
+[t=   69.2s 01:42:02Z] pod bftgmpswhzj2wf confirmed terminated (404)
+[t=   69.2s 01:42:02Z] PROBE: pod bftgmpswhzj2wf torn down
+[t=    0.0s 01:42:23Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 01:42:23Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 01:42:25Z] create OK id=zgw08s8fguk33x costPerHr=$1.49
+[t=    1.4s 01:42:25Z] PROBE: pod created id=zgw08s8fguk33x; waiting for publicIp+ssh_port
+[t=    1.8s 01:42:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 01:42:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 01:42:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 01:43:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.4s 01:43:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.9s 01:43:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.3s 01:43:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.7s 01:44:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.7s 01:44:28Z] PROBE NO-GO: pod zgw08s8fguk33x not RUNNING+SSH within 120s; tearing down
+[t=  124.7s 01:44:28Z] DELETE pod zgw08s8fguk33x
+[t=  125.5s 01:44:29Z] delete returned status=204 resp={}
+[t=  130.9s 01:44:34Z] pod zgw08s8fguk33x confirmed terminated (404)
+[t=  130.9s 01:44:34Z] PROBE: pod zgw08s8fguk33x torn down
+[t=    0.0s 01:44:35Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:44:35Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 01:44:36Z] create OK id=ul3b7mn2ti5o9w costPerHr=$1.39
+[t=    1.3s 01:44:36Z] PROBE: pod created id=ul3b7mn2ti5o9w; waiting for publicIp+ssh_port
+[t=    1.8s 01:44:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.4s 01:44:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 01:45:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.0s 01:45:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.0s 01:45:39Z] PROBE NO-GO: pod ul3b7mn2ti5o9w not RUNNING+SSH within 60s; tearing down
+[t=   64.0s 01:45:39Z] DELETE pod ul3b7mn2ti5o9w
+[t=   64.8s 01:45:39Z] delete returned status=204 resp={}
+[t=   70.1s 01:45:45Z] pod ul3b7mn2ti5o9w confirmed terminated (404)
+[t=   70.1s 01:45:45Z] PROBE: pod ul3b7mn2ti5o9w torn down
+[t=    0.0s 01:45:45Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:45:45Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 01:45:46Z] create OK id=th8au8sbdmnod9 costPerHr=$3.29
+[t=    1.5s 01:45:46Z] PROBE: pod created id=th8au8sbdmnod9; waiting for publicIp+ssh_port
+[t=    2.1s 01:45:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 01:46:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 01:46:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.8s 01:46:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.8s 01:46:50Z] PROBE NO-GO: pod th8au8sbdmnod9 not RUNNING+SSH within 60s; tearing down
+[t=   64.8s 01:46:50Z] DELETE pod th8au8sbdmnod9
+[t=   65.5s 01:46:51Z] delete returned status=204 resp={}
+[t=   70.9s 01:46:56Z] pod th8au8sbdmnod9 confirmed terminated (404)
+[t=   70.9s 01:46:56Z] PROBE: pod th8au8sbdmnod9 torn down
+[t=    0.0s 01:46:56Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:46:56Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 01:46:57Z] create OK id=7qzyrou8xjn0y3 costPerHr=$2.89
+[t=    1.2s 01:46:57Z] PROBE: pod created id=7qzyrou8xjn0y3; waiting for publicIp+ssh_port
+[t=    1.5s 01:46:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 01:47:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 01:47:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 01:47:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 01:47:59Z] PROBE NO-GO: pod 7qzyrou8xjn0y3 not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 01:47:59Z] DELETE pod 7qzyrou8xjn0y3
+[t=   63.8s 01:48:00Z] delete returned status=204 resp={}
+[t=   69.2s 01:48:05Z] pod 7qzyrou8xjn0y3 confirmed terminated (404)
+[t=   69.2s 01:48:05Z] PROBE: pod 7qzyrou8xjn0y3 torn down
+[t=    0.0s 01:48:06Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 01:48:06Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 01:48:06Z] create OK id=lywtysywpkroh7 costPerHr=$1.39
+[t=    0.9s 01:48:06Z] PROBE: pod created id=lywtysywpkroh7; waiting for publicIp+ssh_port
+[t=    1.2s 01:48:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 01:48:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 01:48:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 01:48:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 01:49:09Z] PROBE NO-GO: pod lywtysywpkroh7 not RUNNING+SSH within 60s; tearing down
+[t=   63.2s 01:49:09Z] DELETE pod lywtysywpkroh7
+[t=   64.1s 01:49:10Z] delete returned status=204 resp={}
+[t=   69.5s 01:49:15Z] pod lywtysywpkroh7 confirmed terminated (404)
+[t=   69.5s 01:49:15Z] PROBE: pod lywtysywpkroh7 torn down
+[t=    0.0s 01:49:36Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 01:49:36Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 01:49:37Z] create OK id=1cbqqf2wcu6x7a costPerHr=$1.49
+[t=    1.4s 01:49:37Z] PROBE: pod created id=1cbqqf2wcu6x7a; waiting for publicIp+ssh_port
+[t=    2.0s 01:49:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 01:49:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.0s 01:50:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.5s 01:50:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 01:50:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.7s 01:50:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.2s 01:51:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.6s 01:51:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.6s 01:51:41Z] PROBE NO-GO: pod 1cbqqf2wcu6x7a not RUNNING+SSH within 120s; tearing down
+[t=  125.6s 01:51:41Z] DELETE pod 1cbqqf2wcu6x7a
+[t=  126.3s 01:51:42Z] delete returned status=204 resp={}
+[t=  131.7s 01:51:47Z] pod 1cbqqf2wcu6x7a confirmed terminated (404)
+[t=  131.7s 01:51:47Z] PROBE: pod 1cbqqf2wcu6x7a torn down
+[t=    0.0s 01:51:48Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:51:48Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 01:51:49Z] create OK id=amaflk1vqcgyb5 costPerHr=$1.39
+[t=    1.2s 01:51:49Z] PROBE: pod created id=amaflk1vqcgyb5; waiting for publicIp+ssh_port
+[t=    1.6s 01:51:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 01:52:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 01:52:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 01:52:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 01:52:51Z] PROBE NO-GO: pod amaflk1vqcgyb5 not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 01:52:51Z] DELETE pod amaflk1vqcgyb5
+[t=   63.5s 01:52:51Z] delete returned status=204 resp={}
+[t=   68.9s 01:52:57Z] pod amaflk1vqcgyb5 confirmed terminated (404)
+[t=   68.9s 01:52:57Z] PROBE: pod amaflk1vqcgyb5 torn down
+[t=    0.0s 01:52:57Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:52:57Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 01:52:58Z] create OK id=0xuhniwv792oz8 costPerHr=$3.29
+[t=    1.5s 01:52:58Z] PROBE: pod created id=0xuhniwv792oz8; waiting for publicIp+ssh_port
+[t=    2.0s 01:52:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 01:53:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.8s 01:53:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 01:53:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 01:54:01Z] PROBE NO-GO: pod 0xuhniwv792oz8 not RUNNING+SSH within 60s; tearing down
+[t=   64.5s 01:54:01Z] DELETE pod 0xuhniwv792oz8
+[t=   65.4s 01:54:02Z] delete returned status=204 resp={}
+[t=   70.7s 01:54:07Z] pod 0xuhniwv792oz8 confirmed terminated (404)
+[t=   70.7s 01:54:07Z] PROBE: pod 0xuhniwv792oz8 torn down
+[t=    0.0s 01:54:08Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:54:08Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 01:54:09Z] create OK id=dlp9rjqetwemmw costPerHr=$2.89
+[t=    1.1s 01:54:09Z] PROBE: pod created id=dlp9rjqetwemmw; waiting for publicIp+ssh_port
+[t=    1.5s 01:54:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 01:54:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 01:54:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 01:54:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 01:55:11Z] PROBE NO-GO: pod dlp9rjqetwemmw not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 01:55:11Z] DELETE pod dlp9rjqetwemmw
+[t=   63.5s 01:55:11Z] delete returned status=204 resp={}
+[t=   68.9s 01:55:17Z] pod dlp9rjqetwemmw confirmed terminated (404)
+[t=   68.9s 01:55:17Z] PROBE: pod dlp9rjqetwemmw torn down
+[t=    0.0s 01:55:17Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 01:55:17Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 01:55:18Z] create OK id=a3zek44ltak92n costPerHr=$1.39
+[t=    1.0s 01:55:18Z] PROBE: pod created id=a3zek44ltak92n; waiting for publicIp+ssh_port
+[t=    1.4s 01:55:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 01:55:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 01:55:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 01:56:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 01:56:20Z] PROBE NO-GO: pod a3zek44ltak92n not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 01:56:20Z] DELETE pod a3zek44ltak92n
+[t=   63.5s 01:56:20Z] delete returned status=204 resp={}
+[t=   68.8s 01:56:26Z] pod a3zek44ltak92n confirmed terminated (404)
+[t=   68.8s 01:56:26Z] PROBE: pod a3zek44ltak92n torn down
+[t=    0.0s 01:56:44Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 01:56:44Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 01:56:45Z] create OK id=lfp4p3zwjbd4im costPerHr=$1.49
+[t=    1.2s 01:56:45Z] PROBE: pod created id=lfp4p3zwjbd4im; waiting for publicIp+ssh_port
+[t=    1.6s 01:56:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 01:57:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 01:57:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.4s 01:57:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 01:57:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.7s 01:58:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.2s 01:58:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.7s 01:58:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.8s 01:58:50Z] PROBE NO-GO: pod lfp4p3zwjbd4im not RUNNING+SSH within 120s; tearing down
+[t=  125.8s 01:58:50Z] DELETE pod lfp4p3zwjbd4im
+[t=  126.4s 01:58:50Z] delete returned status=204 resp={}
+[t=  131.8s 01:58:56Z] pod lfp4p3zwjbd4im confirmed terminated (404)
+[t=  131.8s 01:58:56Z] PROBE: pod lfp4p3zwjbd4im torn down
+[t=    0.0s 01:58:56Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 01:58:56Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 01:58:57Z] create OK id=otu8rgj3etzq62 costPerHr=$1.39
+[t=    1.4s 01:58:57Z] PROBE: pod created id=otu8rgj3etzq62; waiting for publicIp+ssh_port
+[t=    1.9s 01:58:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.6s 01:59:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.2s 01:59:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.8s 01:59:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.8s 02:00:00Z] PROBE NO-GO: pod otu8rgj3etzq62 not RUNNING+SSH within 60s; tearing down
+[t=   63.8s 02:00:00Z] DELETE pod otu8rgj3etzq62
+[t=   64.4s 02:00:00Z] delete returned status=204 resp={}
+[t=   69.7s 02:00:05Z] pod otu8rgj3etzq62 confirmed terminated (404)
+[t=   69.7s 02:00:05Z] PROBE: pod otu8rgj3etzq62 torn down
+[t=    0.0s 02:00:06Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:00:06Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.8s 02:00:07Z] create OK id=l6yrk0ipnm1ad6 costPerHr=$3.29
+[t=    1.8s 02:00:07Z] PROBE: pod created id=l6yrk0ipnm1ad6; waiting for publicIp+ssh_port
+[t=    2.3s 02:00:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.2s 02:00:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.8s 02:00:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.6s 02:00:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.7s 02:01:10Z] PROBE NO-GO: pod l6yrk0ipnm1ad6 not RUNNING+SSH within 60s; tearing down
+[t=   64.7s 02:01:10Z] DELETE pod l6yrk0ipnm1ad6
+[t=   65.3s 02:01:11Z] delete returned status=204 resp={}
+[t=   70.8s 02:01:16Z] pod l6yrk0ipnm1ad6 confirmed terminated (404)
+[t=   70.8s 02:01:16Z] PROBE: pod l6yrk0ipnm1ad6 torn down
+[t=    0.0s 02:01:17Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:01:17Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 02:01:18Z] create OK id=1j4fpo25iui01x costPerHr=$2.89
+[t=    1.4s 02:01:18Z] PROBE: pod created id=1j4fpo25iui01x; waiting for publicIp+ssh_port
+[t=    1.7s 02:01:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 02:01:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 02:01:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 02:02:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 02:02:20Z] PROBE NO-GO: pod 1j4fpo25iui01x not RUNNING+SSH within 60s; tearing down
+[t=   63.3s 02:02:20Z] DELETE pod 1j4fpo25iui01x
+[t=   64.0s 02:02:21Z] delete returned status=204 resp={}
+[t=   69.3s 02:02:26Z] pod 1j4fpo25iui01x confirmed terminated (404)
+[t=   69.3s 02:02:26Z] PROBE: pod 1j4fpo25iui01x torn down
+[t=    0.0s 02:02:26Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 02:02:26Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.2s 02:02:27Z] create OK id=nh2s33e856d17h costPerHr=$1.39
+[t=    1.2s 02:02:27Z] PROBE: pod created id=nh2s33e856d17h; waiting for publicIp+ssh_port
+[t=    1.5s 02:02:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 02:02:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 02:02:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.1s 02:03:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 02:03:29Z] PROBE NO-GO: pod nh2s33e856d17h not RUNNING+SSH within 60s; tearing down
+[t=   63.1s 02:03:29Z] DELETE pod nh2s33e856d17h
+[t=   63.8s 02:03:30Z] delete returned status=204 resp={}
+[t=   69.1s 02:03:35Z] pod nh2s33e856d17h confirmed terminated (404)
+[t=   69.2s 02:03:35Z] PROBE: pod nh2s33e856d17h torn down
+[t=    0.0s 02:04:17Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 02:04:17Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 02:04:18Z] create OK id=81cb42r0kzu91b costPerHr=$1.49
+[t=    1.4s 02:04:18Z] PROBE: pod created id=81cb42r0kzu91b; waiting for publicIp+ssh_port
+[t=    1.8s 02:04:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 02:04:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.2s 02:04:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.7s 02:05:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.2s 02:05:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.7s 02:05:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.1s 02:05:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.6s 02:06:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.6s 02:06:22Z] PROBE NO-GO: pod 81cb42r0kzu91b not RUNNING+SSH within 120s; tearing down
+[t=  125.6s 02:06:22Z] DELETE pod 81cb42r0kzu91b
+[t=  126.2s 02:06:23Z] delete returned status=204 resp={}
+[t=  131.7s 02:06:28Z] pod 81cb42r0kzu91b confirmed terminated (404)
+[t=  131.7s 02:06:28Z] PROBE: pod 81cb42r0kzu91b torn down
+[t=    0.0s 02:06:29Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:06:29Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 02:06:30Z] create OK id=pn3yr62udomsvu costPerHr=$1.39
+[t=    1.1s 02:06:30Z] PROBE: pod created id=pn3yr62udomsvu; waiting for publicIp+ssh_port
+[t=    1.4s 02:06:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 02:06:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 02:07:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 02:07:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 02:07:31Z] PROBE NO-GO: pod pn3yr62udomsvu not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 02:07:31Z] DELETE pod pn3yr62udomsvu
+[t=   63.3s 02:07:32Z] delete returned status=204 resp={}
+[t=   68.8s 02:07:37Z] pod pn3yr62udomsvu confirmed terminated (404)
+[t=   68.8s 02:07:37Z] PROBE: pod pn3yr62udomsvu torn down
+[t=    0.0s 02:07:38Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:07:38Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.7s 02:07:39Z] create OK id=8avee2g0ptod2e costPerHr=$3.29
+[t=    1.7s 02:07:39Z] PROBE: pod created id=8avee2g0ptod2e; waiting for publicIp+ssh_port
+[t=    2.1s 02:07:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 02:07:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 02:08:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.0s 02:08:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.0s 02:08:42Z] PROBE NO-GO: pod 8avee2g0ptod2e not RUNNING+SSH within 60s; tearing down
+[t=   64.0s 02:08:42Z] DELETE pod 8avee2g0ptod2e
+[t=   64.5s 02:08:42Z] delete returned status=204 resp={}
+[t=   70.1s 02:08:48Z] pod 8avee2g0ptod2e confirmed terminated (404)
+[t=   70.1s 02:08:48Z] PROBE: pod 8avee2g0ptod2e torn down
+[t=    0.0s 02:08:48Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:08:48Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 02:08:49Z] create OK id=11q8qe7596931t costPerHr=$2.89
+[t=    1.3s 02:08:49Z] PROBE: pod created id=11q8qe7596931t; waiting for publicIp+ssh_port
+[t=    1.6s 02:08:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 02:09:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 02:09:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.1s 02:09:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 02:09:51Z] PROBE NO-GO: pod 11q8qe7596931t not RUNNING+SSH within 60s; tearing down
+[t=   63.1s 02:09:51Z] DELETE pod 11q8qe7596931t
+[t=   63.7s 02:09:52Z] delete returned status=204 resp={}
+[t=   69.0s 02:09:57Z] pod 11q8qe7596931t confirmed terminated (404)
+[t=   69.0s 02:09:57Z] PROBE: pod 11q8qe7596931t torn down
+[t=    0.0s 02:09:57Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 02:09:57Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 02:09:58Z] create OK id=pio6zmpwfhjgq6 costPerHr=$1.39
+[t=    1.0s 02:09:58Z] PROBE: pod created id=pio6zmpwfhjgq6; waiting for publicIp+ssh_port
+[t=    1.3s 02:09:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 02:10:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 02:10:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 02:10:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 02:11:00Z] PROBE NO-GO: pod pio6zmpwfhjgq6 not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 02:11:00Z] DELETE pod pio6zmpwfhjgq6
+[t=   63.3s 02:11:00Z] delete returned status=204 resp={}
+[t=   68.7s 02:11:06Z] pod pio6zmpwfhjgq6 confirmed terminated (404)
+[t=   68.7s 02:11:06Z] PROBE: pod pio6zmpwfhjgq6 torn down
+[t=    0.0s 02:11:24Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 02:11:24Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 02:11:26Z] create OK id=uobewgudb2o1zd costPerHr=$1.49
+[t=    1.4s 02:11:26Z] PROBE: pod created id=uobewgudb2o1zd; waiting for publicIp+ssh_port
+[t=    1.7s 02:11:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 02:11:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 02:11:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.4s 02:12:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.0s 02:12:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.5s 02:12:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.2s 02:12:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.0s 02:13:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.0s 02:13:30Z] PROBE NO-GO: pod uobewgudb2o1zd not RUNNING+SSH within 120s; tearing down
+[t=  126.0s 02:13:30Z] DELETE pod uobewgudb2o1zd
+[t=  126.6s 02:13:31Z] delete returned status=204 resp={}
+[t=  132.0s 02:13:36Z] pod uobewgudb2o1zd confirmed terminated (404)
+[t=  132.0s 02:13:36Z] PROBE: pod uobewgudb2o1zd torn down
+[t=    0.0s 02:13:36Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:13:36Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 02:13:37Z] create OK id=0j9d3swkejseo0 costPerHr=$1.39
+[t=    1.0s 02:13:37Z] PROBE: pod created id=0j9d3swkejseo0; waiting for publicIp+ssh_port
+[t=    1.4s 02:13:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 02:13:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 02:14:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 02:14:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 02:14:39Z] PROBE NO-GO: pod 0j9d3swkejseo0 not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 02:14:39Z] DELETE pod 0j9d3swkejseo0
+[t=   63.5s 02:14:40Z] delete returned status=204 resp={}
+[t=   68.9s 02:14:45Z] pod 0j9d3swkejseo0 confirmed terminated (404)
+[t=   68.9s 02:14:45Z] PROBE: pod 0j9d3swkejseo0 torn down
+[t=    0.0s 02:14:45Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:14:45Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 02:14:47Z] create OK id=2nqxw7o3mbegp6 costPerHr=$3.29
+[t=    1.2s 02:14:47Z] PROBE: pod created id=2nqxw7o3mbegp6; waiting for publicIp+ssh_port
+[t=    1.6s 02:14:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 02:15:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.5s 02:15:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.3s 02:15:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.3s 02:15:50Z] PROBE NO-GO: pod 2nqxw7o3mbegp6 not RUNNING+SSH within 60s; tearing down
+[t=   64.3s 02:15:50Z] DELETE pod 2nqxw7o3mbegp6
+[t=   65.0s 02:15:50Z] delete returned status=204 resp={}
+[t=   70.4s 02:15:56Z] pod 2nqxw7o3mbegp6 confirmed terminated (404)
+[t=   70.4s 02:15:56Z] PROBE: pod 2nqxw7o3mbegp6 torn down
+[t=    0.0s 02:15:56Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:15:56Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 02:15:57Z] create OK id=hytaz8hdc57b33 costPerHr=$2.89
+[t=    1.0s 02:15:57Z] PROBE: pod created id=hytaz8hdc57b33; waiting for publicIp+ssh_port
+[t=    1.3s 02:15:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 02:16:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 02:16:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 02:16:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 02:16:59Z] PROBE NO-GO: pod hytaz8hdc57b33 not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 02:16:59Z] DELETE pod hytaz8hdc57b33
+[t=   63.5s 02:17:00Z] delete returned status=204 resp={}
+[t=   68.9s 02:17:05Z] pod hytaz8hdc57b33 confirmed terminated (404)
+[t=   68.9s 02:17:05Z] PROBE: pod hytaz8hdc57b33 torn down
+[t=    0.0s 02:17:05Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 02:17:05Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 02:17:06Z] create OK id=lfeyfiov33r0dj costPerHr=$1.39
+[t=    0.9s 02:17:06Z] PROBE: pod created id=lfeyfiov33r0dj; waiting for publicIp+ssh_port
+[t=    1.3s 02:17:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 02:17:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 02:17:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 02:17:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 02:18:08Z] PROBE NO-GO: pod lfeyfiov33r0dj not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 02:18:08Z] DELETE pod lfeyfiov33r0dj
+[t=   63.2s 02:18:08Z] delete returned status=204 resp={}
+[t=   68.6s 02:18:14Z] pod lfeyfiov33r0dj confirmed terminated (404)
+[t=   68.6s 02:18:14Z] PROBE: pod lfeyfiov33r0dj torn down
+[t=    0.0s 02:18:37Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 02:18:37Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.7s 02:18:39Z] create OK id=xwpgsri76oahsp costPerHr=$1.49
+[t=    1.7s 02:18:39Z] PROBE: pod created id=xwpgsri76oahsp; waiting for publicIp+ssh_port
+[t=    2.0s 02:18:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 02:18:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.9s 02:19:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 02:19:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.7s 02:19:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.1s 02:19:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.5s 02:20:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.8s 02:20:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.9s 02:20:42Z] PROBE NO-GO: pod xwpgsri76oahsp not RUNNING+SSH within 120s; tearing down
+[t=  124.9s 02:20:42Z] DELETE pod xwpgsri76oahsp
+[t=  125.5s 02:20:43Z] delete returned status=204 resp={}
+[t=  130.9s 02:20:48Z] pod xwpgsri76oahsp confirmed terminated (404)
+[t=  130.9s 02:20:48Z] PROBE: pod xwpgsri76oahsp torn down
+[t=    0.0s 02:20:48Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:20:48Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 02:20:49Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 02:20:49Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 02:20:49Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:20:49Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 02:20:50Z] create OK id=dlfnnaai7ib5mm costPerHr=$3.29
+[t=    1.2s 02:20:50Z] PROBE: pod created id=dlfnnaai7ib5mm; waiting for publicIp+ssh_port
+[t=    1.6s 02:20:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 02:21:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.0s 02:21:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.6s 02:21:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.6s 02:21:53Z] PROBE NO-GO: pod dlfnnaai7ib5mm not RUNNING+SSH within 60s; tearing down
+[t=   63.6s 02:21:53Z] DELETE pod dlfnnaai7ib5mm
+[t=   64.5s 02:21:54Z] delete returned status=204 resp={}
+[t=   69.9s 02:21:59Z] pod dlfnnaai7ib5mm confirmed terminated (404)
+[t=   69.9s 02:21:59Z] PROBE: pod dlfnnaai7ib5mm torn down
+[t=    0.0s 02:21:59Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:21:59Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 02:22:00Z] create OK id=adw7vtw9p738fu costPerHr=$2.89
+[t=    1.1s 02:22:00Z] PROBE: pod created id=adw7vtw9p738fu; waiting for publicIp+ssh_port
+[t=    1.5s 02:22:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 02:22:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 02:22:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.1s 02:22:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 02:23:02Z] PROBE NO-GO: pod adw7vtw9p738fu not RUNNING+SSH within 60s; tearing down
+[t=   63.1s 02:23:02Z] DELETE pod adw7vtw9p738fu
+[t=   63.8s 02:23:03Z] delete returned status=204 resp={}
+[t=   69.2s 02:23:08Z] pod adw7vtw9p738fu confirmed terminated (404)
+[t=   69.2s 02:23:08Z] PROBE: pod adw7vtw9p738fu torn down
+[t=    0.0s 02:23:09Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 02:23:09Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 02:23:09Z] create OK id=qgqkbkpvvcfu01 costPerHr=$1.39
+[t=    0.9s 02:23:09Z] PROBE: pod created id=qgqkbkpvvcfu01; waiting for publicIp+ssh_port
+[t=    1.2s 02:23:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 02:23:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 02:23:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 02:23:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 02:24:11Z] PROBE NO-GO: pod qgqkbkpvvcfu01 not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 02:24:11Z] DELETE pod qgqkbkpvvcfu01
+[t=   63.2s 02:24:12Z] delete returned status=204 resp={}
+[t=   68.6s 02:24:17Z] pod qgqkbkpvvcfu01 confirmed terminated (404)
+[t=   68.6s 02:24:17Z] PROBE: pod qgqkbkpvvcfu01 torn down
+[t=    0.0s 02:24:34Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 02:24:34Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 02:24:35Z] create OK id=thuqycz18dja16 costPerHr=$1.49
+[t=    1.2s 02:24:35Z] PROBE: pod created id=thuqycz18dja16; waiting for publicIp+ssh_port
+[t=    1.5s 02:24:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 02:24:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 02:25:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 02:25:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 02:25:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.6s 02:25:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.2s 02:26:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  109.8s 02:26:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  124.8s 02:26:38Z] PROBE NO-GO: pod thuqycz18dja16 not RUNNING+SSH within 120s; tearing down
+[t=  124.8s 02:26:38Z] DELETE pod thuqycz18dja16
+[t=  125.3s 02:26:39Z] delete returned status=204 resp={}
+[t=  130.7s 02:26:44Z] pod thuqycz18dja16 confirmed terminated (404)
+[t=  130.7s 02:26:44Z] PROBE: pod thuqycz18dja16 torn down
+[t=    0.0s 02:26:44Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:26:44Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 02:26:46Z] create OK id=e4i9h7i57a0rqw costPerHr=$1.39
+[t=    1.3s 02:26:46Z] PROBE: pod created id=e4i9h7i57a0rqw; waiting for publicIp+ssh_port
+[t=    1.7s 02:26:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 02:27:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 02:27:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 02:27:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 02:27:48Z] PROBE NO-GO: pod e4i9h7i57a0rqw not RUNNING+SSH within 60s; tearing down
+[t=   63.2s 02:27:48Z] DELETE pod e4i9h7i57a0rqw
+[t=   64.2s 02:27:49Z] delete returned status=204 resp={}
+[t=   69.6s 02:27:54Z] pod e4i9h7i57a0rqw confirmed terminated (404)
+[t=   69.6s 02:27:54Z] PROBE: pod e4i9h7i57a0rqw torn down
+[t=    0.0s 02:27:54Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:27:54Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 02:27:56Z] create OK id=va01ksj9wy0d10 costPerHr=$3.29
+[t=    1.5s 02:27:56Z] PROBE: pod created id=va01ksj9wy0d10; waiting for publicIp+ssh_port
+[t=    2.1s 02:27:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 02:28:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 02:28:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 02:28:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 02:28:59Z] PROBE NO-GO: pod va01ksj9wy0d10 not RUNNING+SSH within 60s; tearing down
+[t=   64.5s 02:28:59Z] DELETE pod va01ksj9wy0d10
+[t=   65.3s 02:28:59Z] delete returned status=204 resp={}
+[t=   70.7s 02:29:05Z] pod va01ksj9wy0d10 confirmed terminated (404)
+[t=   70.7s 02:29:05Z] PROBE: pod va01ksj9wy0d10 torn down
+[t=    0.0s 02:29:05Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:29:05Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 02:29:06Z] create OK id=7aprzgbk35m0rg costPerHr=$2.89
+[t=    1.3s 02:29:06Z] PROBE: pod created id=7aprzgbk35m0rg; waiting for publicIp+ssh_port
+[t=    1.6s 02:29:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 02:29:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 02:29:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 02:29:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 02:30:08Z] PROBE NO-GO: pod 7aprzgbk35m0rg not RUNNING+SSH within 60s; tearing down
+[t=   63.3s 02:30:08Z] DELETE pod 7aprzgbk35m0rg
+[t=   64.3s 02:30:09Z] delete returned status=204 resp={}
+[t=   69.6s 02:30:15Z] pod 7aprzgbk35m0rg confirmed terminated (404)
+[t=   69.6s 02:30:15Z] PROBE: pod 7aprzgbk35m0rg torn down
+[t=    0.0s 02:30:15Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 02:30:15Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 02:30:16Z] create OK id=j9o7frrgx61qzy costPerHr=$1.39
+[t=    1.0s 02:30:16Z] PROBE: pod created id=j9o7frrgx61qzy; waiting for publicIp+ssh_port
+[t=    1.4s 02:30:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 02:30:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 02:30:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 02:31:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 02:31:18Z] PROBE NO-GO: pod j9o7frrgx61qzy not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 02:31:18Z] DELETE pod j9o7frrgx61qzy
+[t=   63.4s 02:31:18Z] delete returned status=204 resp={}
+[t=   68.8s 02:31:24Z] pod j9o7frrgx61qzy confirmed terminated (404)
+[t=   68.8s 02:31:24Z] PROBE: pod j9o7frrgx61qzy torn down
+[t=    0.0s 02:31:44Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 02:31:44Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 02:31:46Z] create OK id=1zzptsixdpattp costPerHr=$1.49
+[t=    1.2s 02:31:46Z] PROBE: pod created id=1zzptsixdpattp; waiting for publicIp+ssh_port
+[t=    1.7s 02:31:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 02:32:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 02:32:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 02:32:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.8s 02:32:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.2s 02:33:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.7s 02:33:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.1s 02:33:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.1s 02:33:49Z] PROBE NO-GO: pod 1zzptsixdpattp not RUNNING+SSH within 120s; tearing down
+[t=  125.1s 02:33:49Z] DELETE pod 1zzptsixdpattp
+[t=  125.8s 02:33:50Z] delete returned status=204 resp={}
+[t=  131.1s 02:33:55Z] pod 1zzptsixdpattp confirmed terminated (404)
+[t=  131.1s 02:33:55Z] PROBE: pod 1zzptsixdpattp torn down
+[t=    0.0s 02:33:56Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:33:56Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 02:33:57Z] create OK id=mw7x78vy8o07q1 costPerHr=$1.39
+[t=    1.1s 02:33:57Z] PROBE: pod created id=mw7x78vy8o07q1; waiting for publicIp+ssh_port
+[t=    1.3s 02:33:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 02:34:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 02:34:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 02:34:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 02:34:58Z] PROBE NO-GO: pod mw7x78vy8o07q1 not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 02:34:58Z] DELETE pod mw7x78vy8o07q1
+[t=   63.4s 02:34:59Z] delete returned status=204 resp={}
+[t=   68.9s 02:35:05Z] pod mw7x78vy8o07q1 confirmed terminated (404)
+[t=   68.9s 02:35:05Z] PROBE: pod mw7x78vy8o07q1 torn down
+[t=    0.0s 02:35:05Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:35:05Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 02:35:06Z] create OK id=r994rs4b8aixiq costPerHr=$3.29
+[t=    1.5s 02:35:06Z] PROBE: pod created id=r994rs4b8aixiq; waiting for publicIp+ssh_port
+[t=    2.0s 02:35:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.1s 02:35:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.9s 02:35:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.6s 02:35:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.6s 02:36:09Z] PROBE NO-GO: pod r994rs4b8aixiq not RUNNING+SSH within 60s; tearing down
+[t=   64.6s 02:36:09Z] DELETE pod r994rs4b8aixiq
+[t=   65.2s 02:36:10Z] delete returned status=204 resp={}
+[t=   70.8s 02:36:16Z] pod r994rs4b8aixiq confirmed terminated (404)
+[t=   70.8s 02:36:16Z] PROBE: pod r994rs4b8aixiq torn down
+[t=    0.0s 02:36:16Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:36:16Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 02:36:17Z] create OK id=afjooa3pjj36ks costPerHr=$2.89
+[t=    1.4s 02:36:17Z] PROBE: pod created id=afjooa3pjj36ks; waiting for publicIp+ssh_port
+[t=    1.7s 02:36:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.3s 02:36:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.7s 02:36:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 02:37:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.2s 02:37:20Z] PROBE NO-GO: pod afjooa3pjj36ks not RUNNING+SSH within 60s; tearing down
+[t=   64.2s 02:37:20Z] DELETE pod afjooa3pjj36ks
+[t=   64.8s 02:37:21Z] delete returned status=204 resp={}
+[t=   70.2s 02:37:26Z] pod afjooa3pjj36ks confirmed terminated (404)
+[t=   70.2s 02:37:26Z] PROBE: pod afjooa3pjj36ks torn down
+[t=    0.0s 02:37:26Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 02:37:26Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 02:37:27Z] create OK id=y5bu2uyi37zwao costPerHr=$1.39
+[t=    0.9s 02:37:27Z] PROBE: pod created id=y5bu2uyi37zwao; waiting for publicIp+ssh_port
+[t=    1.2s 02:37:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 02:37:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 02:37:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.6s 02:38:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.6s 02:38:29Z] PROBE NO-GO: pod y5bu2uyi37zwao not RUNNING+SSH within 60s; tearing down
+[t=   62.6s 02:38:29Z] DELETE pod y5bu2uyi37zwao
+[t=   63.3s 02:38:30Z] delete returned status=204 resp={}
+[t=   68.9s 02:38:35Z] pod y5bu2uyi37zwao confirmed terminated (404)
+[t=   68.9s 02:38:35Z] PROBE: pod y5bu2uyi37zwao torn down
+[t=    0.0s 02:43:30Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 02:43:30Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 02:43:31Z] create OK id=zsn681hevfgygp costPerHr=$1.49
+[t=    1.4s 02:43:31Z] PROBE: pod created id=zsn681hevfgygp; waiting for publicIp+ssh_port
+[t=    2.0s 02:43:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 02:43:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  310.6s 02:48:41Z] PROBE NO-GO: pod zsn681hevfgygp not RUNNING+SSH within 120s; tearing down
+[t=  310.6s 02:48:41Z] DELETE pod zsn681hevfgygp
+[t=  311.2s 02:48:41Z] delete returned status=204 resp={}
+[t=  316.6s 02:48:47Z] pod zsn681hevfgygp confirmed terminated (404)
+[t=  316.6s 02:48:47Z] PROBE: pod zsn681hevfgygp torn down
+[t=    0.0s 02:48:47Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:48:47Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 02:48:48Z] create OK id=n2q7scxr40tc8r costPerHr=$1.39
+[t=    1.1s 02:48:48Z] PROBE: pod created id=n2q7scxr40tc8r; waiting for publicIp+ssh_port
+[t=    1.4s 02:48:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 02:49:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   96.7s 02:50:24Z] PROBE NO-GO: pod n2q7scxr40tc8r not RUNNING+SSH within 60s; tearing down
+[t=   96.7s 02:50:24Z] DELETE pod n2q7scxr40tc8r
+[t=   97.4s 02:50:24Z] delete returned status=204 resp={}
+[t=  102.7s 02:50:30Z] pod n2q7scxr40tc8r confirmed terminated (404)
+[t=  102.7s 02:50:30Z] PROBE: pod n2q7scxr40tc8r torn down
+[t=    0.0s 02:50:30Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:50:30Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 02:50:31Z] create OK id=dikr6q93gshdf8 costPerHr=$3.29
+[t=    1.2s 02:50:31Z] PROBE: pod created id=dikr6q93gshdf8; waiting for publicIp+ssh_port
+[t=    1.6s 02:50:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 02:50:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  272.7s 02:55:02Z] PROBE NO-GO: pod dikr6q93gshdf8 not RUNNING+SSH within 60s; tearing down
+[t=  272.7s 02:55:02Z] DELETE pod dikr6q93gshdf8
+[t=  273.5s 02:55:03Z] delete returned status=204 resp={}
+[t=  278.9s 02:55:09Z] pod dikr6q93gshdf8 confirmed terminated (404)
+[t=  278.9s 02:55:09Z] PROBE: pod dikr6q93gshdf8 torn down
+[t=    0.0s 02:55:09Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 02:55:09Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 02:55:09Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 02:55:09Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 02:55:10Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 02:55:10Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 02:55:11Z] create OK id=j9r8jxy9hyumis costPerHr=$1.39
+[t=    0.9s 02:55:11Z] PROBE: pod created id=j9r8jxy9hyumis; waiting for publicIp+ssh_port
+[t=    1.2s 02:55:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 02:55:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  134.2s 02:57:24Z] PROBE NO-GO: pod j9r8jxy9hyumis not RUNNING+SSH within 60s; tearing down
+[t=  134.2s 02:57:24Z] DELETE pod j9r8jxy9hyumis
+[t=  134.9s 02:57:24Z] delete returned status=204 resp={}
+[t=  140.4s 02:57:30Z] pod j9r8jxy9hyumis confirmed terminated (404)
+[t=  140.4s 02:57:30Z] PROBE: pod j9r8jxy9hyumis torn down
+[t=    0.0s 02:57:52Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 02:57:52Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 02:57:53Z] create OK id=veg48889qh9j29 costPerHr=$1.49
+[t=    1.2s 02:57:53Z] PROBE: pod created id=veg48889qh9j29; waiting for publicIp+ssh_port
+[t=    1.6s 02:57:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  205.8s 03:01:18Z] PROBE NO-GO: pod veg48889qh9j29 not RUNNING+SSH within 120s; tearing down
+[t=  205.8s 03:01:18Z] DELETE pod veg48889qh9j29
+[t=  206.6s 03:01:19Z] delete returned status=204 resp={}
+[t=  212.0s 03:01:24Z] pod veg48889qh9j29 confirmed terminated (404)
+[t=  212.0s 03:01:24Z] PROBE: pod veg48889qh9j29 torn down
+[t=    0.0s 03:01:24Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 03:01:24Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 03:01:25Z] create OK id=rqvndwzajs5ew4 costPerHr=$1.39
+[t=    1.3s 03:01:25Z] PROBE: pod created id=rqvndwzajs5ew4; waiting for publicIp+ssh_port
+[t=    1.7s 03:01:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 03:01:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.2s 03:01:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   66.6s 03:02:31Z] PROBE NO-GO: pod rqvndwzajs5ew4 not RUNNING+SSH within 60s; tearing down
+[t=   66.6s 03:02:31Z] DELETE pod rqvndwzajs5ew4
+[t=   67.2s 03:02:31Z] delete returned status=204 resp={}
+[t=   72.5s 03:02:37Z] pod rqvndwzajs5ew4 confirmed terminated (404)
+[t=   72.5s 03:02:37Z] PROBE: pod rqvndwzajs5ew4 torn down
+[t=    0.0s 03:02:37Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 03:02:37Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 03:02:38Z] create OK id=jkl1tg1lgmw19m costPerHr=$3.29
+[t=    1.3s 03:02:38Z] PROBE: pod created id=jkl1tg1lgmw19m; waiting for publicIp+ssh_port
+[t=    1.8s 03:02:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  180.9s 03:05:38Z] PROBE NO-GO: pod jkl1tg1lgmw19m not RUNNING+SSH within 60s; tearing down
+[t=  180.9s 03:05:38Z] DELETE pod jkl1tg1lgmw19m
+[t=  181.6s 03:05:38Z] delete returned status=204 resp={}
+[t=  187.2s 03:05:44Z] pod jkl1tg1lgmw19m confirmed terminated (404)
+[t=  187.2s 03:05:44Z] PROBE: pod jkl1tg1lgmw19m torn down
+[t=    0.0s 03:05:44Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 03:05:44Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 03:05:45Z] create OK id=h7wn25qh8gj8o4 costPerHr=$2.89
+[t=    1.4s 03:05:45Z] PROBE: pod created id=h7wn25qh8gj8o4; waiting for publicIp+ssh_port
+[t=    1.7s 03:05:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 03:06:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 03:06:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 03:06:47Z] PROBE NO-GO: pod h7wn25qh8gj8o4 not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 03:06:47Z] DELETE pod h7wn25qh8gj8o4
+[t=   63.8s 03:06:48Z] delete returned status=204 resp={}
+[t=   69.4s 03:06:54Z] pod h7wn25qh8gj8o4 confirmed terminated (404)
+[t=   69.4s 03:06:54Z] PROBE: pod h7wn25qh8gj8o4 torn down
+[t=    0.0s 03:06:54Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 03:06:54Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.1s 03:06:55Z] create OK id=6vd2l2avzr6zq4 costPerHr=$1.39
+[t=    1.1s 03:06:55Z] PROBE: pod created id=6vd2l2avzr6zq4; waiting for publicIp+ssh_port
+[t=    1.4s 03:06:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  104.5s 03:08:38Z] PROBE NO-GO: pod 6vd2l2avzr6zq4 not RUNNING+SSH within 60s; tearing down
+[t=  104.5s 03:08:38Z] DELETE pod 6vd2l2avzr6zq4
+[t=  104.5s 03:08:38Z] delete returned status=-1 resp=transport_error: ConnectError('[Errno 8] nodename nor servname provided, or not known')
+[t=  109.5s 03:08:43Z] post-delete GET status=-1 (waiting for 404)
+[t=  114.5s 03:08:48Z] post-delete GET status=-1 (waiting for 404)
+[t=  119.5s 03:08:53Z] post-delete GET status=-1 (waiting for 404)
+[t=  124.5s 03:08:58Z] post-delete GET status=-1 (waiting for 404)
+[t=  129.6s 03:09:03Z] post-delete GET status=-1 (waiting for 404)
+[t=  134.6s 03:09:08Z] post-delete GET status=-1 (waiting for 404)
+[t=  134.6s 03:09:08Z] WARN: pod 6vd2l2avzr6zq4 did not return 404 after delete; check console
+[t=  134.6s 03:09:08Z] PROBE: pod 6vd2l2avzr6zq4 torn down
+[t=    0.0s 04:46:16Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 04:46:16Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 04:46:18Z] create OK id=tgx2fe0uwsxf6w costPerHr=$1.49
+[t=    1.6s 04:46:18Z] PROBE: pod created id=tgx2fe0uwsxf6w; waiting for publicIp+ssh_port
+[t=    1.9s 04:46:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 04:46:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.4s 04:46:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.9s 04:47:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.4s 04:47:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.1s 04:47:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.6s 04:47:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.1s 04:48:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.1s 04:48:22Z] PROBE NO-GO: pod tgx2fe0uwsxf6w not RUNNING+SSH within 120s; tearing down
+[t=  126.1s 04:48:22Z] DELETE pod tgx2fe0uwsxf6w
+[t=  126.7s 04:48:23Z] delete returned status=204 resp={}
+[t=  132.1s 04:48:28Z] pod tgx2fe0uwsxf6w confirmed terminated (404)
+[t=  132.1s 04:48:28Z] PROBE: pod tgx2fe0uwsxf6w torn down
+[t=    0.0s 04:48:28Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:48:28Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 04:48:30Z] create OK id=oi7jhsue9j4wgf costPerHr=$1.39
+[t=    1.4s 04:48:30Z] PROBE: pod created id=oi7jhsue9j4wgf; waiting for publicIp+ssh_port
+[t=    1.7s 04:48:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 04:48:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 04:49:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 04:49:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 04:49:31Z] PROBE NO-GO: pod oi7jhsue9j4wgf not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 04:49:31Z] DELETE pod oi7jhsue9j4wgf
+[t=   63.7s 04:49:32Z] delete returned status=204 resp={}
+[t=   69.3s 04:49:38Z] pod oi7jhsue9j4wgf confirmed terminated (404)
+[t=   69.3s 04:49:38Z] PROBE: pod oi7jhsue9j4wgf torn down
+[t=    0.0s 04:49:38Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:49:38Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 04:49:39Z] create OK id=kffkh0ubqkqn8p costPerHr=$3.29
+[t=    1.4s 04:49:39Z] PROBE: pod created id=kffkh0ubqkqn8p; waiting for publicIp+ssh_port
+[t=    1.8s 04:49:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 04:49:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 04:50:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 04:50:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.3s 04:50:41Z] PROBE NO-GO: pod kffkh0ubqkqn8p not RUNNING+SSH within 60s; tearing down
+[t=   63.3s 04:50:41Z] DELETE pod kffkh0ubqkqn8p
+[t=   63.9s 04:50:42Z] delete returned status=204 resp={}
+[t=   69.3s 04:50:47Z] pod kffkh0ubqkqn8p confirmed terminated (404)
+[t=   69.3s 04:50:47Z] PROBE: pod kffkh0ubqkqn8p torn down
+[t=    0.0s 04:50:47Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:50:47Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.8s 04:50:48Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.8s 04:50:48Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 04:50:48Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 04:50:48Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.3s 04:50:50Z] create OK id=34kqeo49wb4znx costPerHr=$1.39
+[t=    1.3s 04:50:50Z] PROBE: pod created id=34kqeo49wb4znx; waiting for publicIp+ssh_port
+[t=    1.7s 04:50:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.2s 04:51:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 04:51:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 04:51:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 04:51:51Z] PROBE NO-GO: pod 34kqeo49wb4znx not RUNNING+SSH within 60s; tearing down
+[t=   63.2s 04:51:51Z] DELETE pod 34kqeo49wb4znx
+[t=   63.9s 04:51:52Z] delete returned status=204 resp={}
+[t=   69.3s 04:51:58Z] pod 34kqeo49wb4znx confirmed terminated (404)
+[t=   69.3s 04:51:58Z] PROBE: pod 34kqeo49wb4znx torn down
+[t=    0.0s 04:52:14Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 04:52:14Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    2.1s 04:52:16Z] create OK id=ay3b4mg4gkt9j2 costPerHr=$1.49
+[t=    2.1s 04:52:16Z] PROBE: pod created id=ay3b4mg4gkt9j2; waiting for publicIp+ssh_port
+[t=    2.7s 04:52:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.3s 04:52:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.9s 04:52:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.4s 04:53:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.9s 04:53:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.5s 04:53:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   96.0s 04:53:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.5s 04:54:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.5s 04:54:20Z] PROBE NO-GO: pod ay3b4mg4gkt9j2 not RUNNING+SSH within 120s; tearing down
+[t=  126.5s 04:54:20Z] DELETE pod ay3b4mg4gkt9j2
+[t=  127.3s 04:54:21Z] delete returned status=204 resp={}
+[t=  132.8s 04:54:27Z] pod ay3b4mg4gkt9j2 confirmed terminated (404)
+[t=  132.9s 04:54:27Z] PROBE: pod ay3b4mg4gkt9j2 torn down
+[t=    0.0s 04:54:27Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:54:27Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 04:54:28Z] create OK id=bc59u8z5kixayh costPerHr=$1.39
+[t=    1.1s 04:54:28Z] PROBE: pod created id=bc59u8z5kixayh; waiting for publicIp+ssh_port
+[t=    1.4s 04:54:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 04:54:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 04:54:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 04:55:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 04:55:30Z] PROBE NO-GO: pod bc59u8z5kixayh not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 04:55:30Z] DELETE pod bc59u8z5kixayh
+[t=   63.6s 04:55:31Z] delete returned status=204 resp={}
+[t=   69.3s 04:55:36Z] pod bc59u8z5kixayh confirmed terminated (404)
+[t=   69.3s 04:55:36Z] PROBE: pod bc59u8z5kixayh torn down
+[t=    0.0s 04:55:36Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:55:36Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 04:55:38Z] create OK id=aq6qvfh5bi5blm costPerHr=$3.29
+[t=    1.6s 04:55:38Z] PROBE: pod created id=aq6qvfh5bi5blm; waiting for publicIp+ssh_port
+[t=    2.0s 04:55:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 04:55:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 04:56:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.2s 04:56:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.2s 04:56:41Z] PROBE NO-GO: pod aq6qvfh5bi5blm not RUNNING+SSH within 60s; tearing down
+[t=   64.2s 04:56:41Z] DELETE pod aq6qvfh5bi5blm
+[t=   64.9s 04:56:41Z] delete returned status=204 resp={}
+[t=   70.5s 04:56:47Z] pod aq6qvfh5bi5blm confirmed terminated (404)
+[t=   70.5s 04:56:47Z] PROBE: pod aq6qvfh5bi5blm torn down
+[t=    0.0s 04:56:47Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 04:56:47Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.9s 04:56:48Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.9s 04:56:48Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 04:56:48Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 04:56:48Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.1s 04:56:49Z] create OK id=056avu5iwbhfat costPerHr=$1.39
+[t=    1.1s 04:56:49Z] PROBE: pod created id=056avu5iwbhfat; waiting for publicIp+ssh_port
+[t=    1.4s 04:56:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.4s 04:57:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.3s 04:57:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.8s 04:57:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.8s 04:57:53Z] PROBE NO-GO: pod 056avu5iwbhfat not RUNNING+SSH within 60s; tearing down
+[t=   64.8s 04:57:53Z] DELETE pod 056avu5iwbhfat
+[t=   65.5s 04:57:54Z] delete returned status=204 resp={}
+[t=   71.1s 04:57:59Z] pod 056avu5iwbhfat confirmed terminated (404)
+[t=   71.1s 04:57:59Z] PROBE: pod 056avu5iwbhfat torn down
+[t=    0.0s 04:58:17Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 04:58:17Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 04:58:19Z] create OK id=0vspkwk9ful8z2 costPerHr=$1.49
+[t=    1.6s 04:58:19Z] PROBE: pod created id=0vspkwk9ful8z2; waiting for publicIp+ssh_port
+[t=    1.9s 04:58:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 04:58:35Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 04:58:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.3s 04:59:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.7s 04:59:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.1s 04:59:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   95.9s 04:59:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.8s 05:00:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.8s 05:00:24Z] PROBE NO-GO: pod 0vspkwk9ful8z2 not RUNNING+SSH within 120s; tearing down
+[t=  126.8s 05:00:24Z] DELETE pod 0vspkwk9ful8z2
+[t=  127.8s 05:00:25Z] delete returned status=204 resp={}
+[t=  133.2s 05:00:31Z] pod 0vspkwk9ful8z2 confirmed terminated (404)
+[t=  133.2s 05:00:31Z] PROBE: pod 0vspkwk9ful8z2 torn down
+[t=    0.0s 05:00:31Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:00:31Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 05:00:32Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 05:00:32Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 05:00:32Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:00:32Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 05:00:33Z] create OK id=v0n00sfwl6j91x costPerHr=$3.29
+[t=    1.6s 05:00:33Z] PROBE: pod created id=v0n00sfwl6j91x; waiting for publicIp+ssh_port
+[t=    2.3s 05:00:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.4s 05:00:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   34.1s 05:01:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   50.5s 05:01:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.5s 05:01:37Z] PROBE NO-GO: pod v0n00sfwl6j91x not RUNNING+SSH within 60s; tearing down
+[t=   65.5s 05:01:37Z] DELETE pod v0n00sfwl6j91x
+[t=   66.4s 05:01:38Z] delete returned status=204 resp={}
+[t=   71.9s 05:01:44Z] pod v0n00sfwl6j91x confirmed terminated (404)
+[t=   71.9s 05:01:44Z] PROBE: pod v0n00sfwl6j91x torn down
+[t=    0.0s 05:01:44Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:01:44Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 05:01:45Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 05:01:45Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 05:01:45Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 05:01:45Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 05:01:46Z] create OK id=xzdmdr448to26x costPerHr=$1.39
+[t=    0.9s 05:01:46Z] PROBE: pod created id=xzdmdr448to26x; waiting for publicIp+ssh_port
+[t=    1.2s 05:01:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.6s 05:02:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 05:02:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 05:02:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 05:02:47Z] PROBE NO-GO: pod xzdmdr448to26x not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 05:02:47Z] DELETE pod xzdmdr448to26x
+[t=   63.6s 05:02:48Z] delete returned status=204 resp={}
+[t=   69.0s 05:02:54Z] pod xzdmdr448to26x confirmed terminated (404)
+[t=   69.0s 05:02:54Z] PROBE: pod xzdmdr448to26x torn down
+[t=    0.0s 05:03:11Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 05:03:11Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 05:03:13Z] create OK id=n0un645n0vu4b9 costPerHr=$1.49
+[t=    1.5s 05:03:13Z] PROBE: pod created id=n0un645n0vu4b9; waiting for publicIp+ssh_port
+[t=    2.0s 05:03:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.6s 05:03:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.6s 05:03:45Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 05:04:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.2s 05:04:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.8s 05:04:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   96.4s 05:04:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  112.1s 05:05:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  127.1s 05:05:18Z] PROBE NO-GO: pod n0un645n0vu4b9 not RUNNING+SSH within 120s; tearing down
+[t=  127.1s 05:05:18Z] DELETE pod n0un645n0vu4b9
+[t=  127.8s 05:05:19Z] delete returned status=204 resp={}
+[t=  133.5s 05:05:25Z] pod n0un645n0vu4b9 confirmed terminated (404)
+[t=  133.5s 05:05:25Z] PROBE: pod n0un645n0vu4b9 torn down
+[t=    0.0s 05:05:25Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:05:25Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 05:05:26Z] create OK id=gxxhskdfsu87ba costPerHr=$1.39
+[t=    1.3s 05:05:26Z] PROBE: pod created id=gxxhskdfsu87ba; waiting for publicIp+ssh_port
+[t=    1.6s 05:05:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 05:05:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 05:05:58Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 05:06:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 05:06:28Z] PROBE NO-GO: pod gxxhskdfsu87ba not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 05:06:28Z] DELETE pod gxxhskdfsu87ba
+[t=   63.6s 05:06:29Z] delete returned status=204 resp={}
+[t=   68.9s 05:06:34Z] pod gxxhskdfsu87ba confirmed terminated (404)
+[t=   68.9s 05:06:34Z] PROBE: pod gxxhskdfsu87ba torn down
+[t=    0.0s 05:06:34Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:06:34Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 05:06:35Z] create OK id=ubeu985vb6ywlj costPerHr=$3.29
+[t=    1.3s 05:06:35Z] PROBE: pod created id=ubeu985vb6ywlj; waiting for publicIp+ssh_port
+[t=    1.7s 05:06:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.7s 05:06:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.7s 05:07:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.3s 05:07:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.3s 05:07:38Z] PROBE NO-GO: pod ubeu985vb6ywlj not RUNNING+SSH within 60s; tearing down
+[t=   64.3s 05:07:38Z] DELETE pod ubeu985vb6ywlj
+[t=   64.9s 05:07:39Z] delete returned status=204 resp={}
+[t=   70.2s 05:07:44Z] pod ubeu985vb6ywlj confirmed terminated (404)
+[t=   70.2s 05:07:44Z] PROBE: pod ubeu985vb6ywlj torn down
+[t=    0.0s 05:07:45Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:07:45Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.8s 05:07:45Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.8s 05:07:45Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 05:07:46Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 05:07:46Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.1s 05:07:47Z] create OK id=8lrewchr7cfqkx costPerHr=$1.39
+[t=    1.1s 05:07:47Z] PROBE: pod created id=8lrewchr7cfqkx; waiting for publicIp+ssh_port
+[t=    1.4s 05:07:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 05:08:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 05:08:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.6s 05:08:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.6s 05:08:49Z] PROBE NO-GO: pod 8lrewchr7cfqkx not RUNNING+SSH within 60s; tearing down
+[t=   63.6s 05:08:49Z] DELETE pod 8lrewchr7cfqkx
+[t=   64.3s 05:08:50Z] delete returned status=204 resp={}
+[t=   69.7s 05:08:55Z] pod 8lrewchr7cfqkx confirmed terminated (404)
+[t=   69.7s 05:08:55Z] PROBE: pod 8lrewchr7cfqkx torn down
+[t=    0.0s 05:09:13Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 05:09:13Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.7s 05:09:15Z] create OK id=v6pg5ktz0grav8 costPerHr=$1.49
+[t=    1.7s 05:09:15Z] PROBE: pod created id=v6pg5ktz0grav8; waiting for publicIp+ssh_port
+[t=    2.5s 05:09:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.3s 05:09:32Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.7s 05:09:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   50.1s 05:10:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.6s 05:10:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   81.1s 05:10:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   96.5s 05:10:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  111.9s 05:11:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  126.9s 05:11:20Z] PROBE NO-GO: pod v6pg5ktz0grav8 not RUNNING+SSH within 120s; tearing down
+[t=  126.9s 05:11:20Z] DELETE pod v6pg5ktz0grav8
+[t=  127.5s 05:11:21Z] delete returned status=204 resp={}
+[t=  133.3s 05:11:27Z] pod v6pg5ktz0grav8 confirmed terminated (404)
+[t=  133.3s 05:11:27Z] PROBE: pod v6pg5ktz0grav8 torn down
+[t=    0.0s 05:11:27Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:11:27Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 05:11:28Z] create OK id=lx55t625skko1w costPerHr=$1.39
+[t=    1.3s 05:11:28Z] PROBE: pod created id=lx55t625skko1w; waiting for publicIp+ssh_port
+[t=    1.6s 05:11:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 05:11:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 05:12:00Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 05:12:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 05:12:30Z] PROBE NO-GO: pod lx55t625skko1w not RUNNING+SSH within 60s; tearing down
+[t=   63.2s 05:12:30Z] DELETE pod lx55t625skko1w
+[t=   63.9s 05:12:31Z] delete returned status=204 resp={}
+[t=   69.5s 05:12:36Z] pod lx55t625skko1w confirmed terminated (404)
+[t=   69.5s 05:12:36Z] PROBE: pod lx55t625skko1w torn down
+[t=    0.0s 05:12:37Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:12:37Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 05:12:38Z] create OK id=tfioknaxzokgiw costPerHr=$3.29
+[t=    1.6s 05:12:38Z] PROBE: pod created id=tfioknaxzokgiw; waiting for publicIp+ssh_port
+[t=    2.2s 05:12:39Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.0s 05:12:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.9s 05:13:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.7s 05:13:26Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.7s 05:13:41Z] PROBE NO-GO: pod tfioknaxzokgiw not RUNNING+SSH within 60s; tearing down
+[t=   64.7s 05:13:41Z] DELETE pod tfioknaxzokgiw
+[t=   65.3s 05:13:42Z] delete returned status=204 resp={}
+[t=   70.7s 05:13:47Z] pod tfioknaxzokgiw confirmed terminated (404)
+[t=   70.7s 05:13:47Z] PROBE: pod tfioknaxzokgiw torn down
+[t=    0.0s 05:13:47Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:13:47Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 05:13:48Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 05:13:48Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 05:13:48Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 05:13:48Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 05:13:49Z] create OK id=3p234jxtafyphy costPerHr=$1.39
+[t=    0.9s 05:13:49Z] PROBE: pod created id=3p234jxtafyphy; waiting for publicIp+ssh_port
+[t=    1.3s 05:13:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 05:14:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 05:14:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 05:14:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.2s 05:14:51Z] PROBE NO-GO: pod 3p234jxtafyphy not RUNNING+SSH within 60s; tearing down
+[t=   63.2s 05:14:51Z] DELETE pod 3p234jxtafyphy
+[t=   63.8s 05:14:52Z] delete returned status=204 resp={}
+[t=   69.2s 05:14:57Z] pod 3p234jxtafyphy confirmed terminated (404)
+[t=   69.2s 05:14:57Z] PROBE: pod 3p234jxtafyphy torn down
+[t=    0.0s 05:15:20Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 05:15:20Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 05:15:22Z] create OK id=nx264lh3f6ljrw costPerHr=$1.49
+[t=    1.1s 05:15:22Z] PROBE: pod created id=nx264lh3f6ljrw; waiting for publicIp+ssh_port
+[t=    1.5s 05:15:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 05:15:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.7s 05:15:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 05:16:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.1s 05:16:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.5s 05:16:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.9s 05:16:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.4s 05:17:11Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.4s 05:17:26Z] PROBE NO-GO: pod nx264lh3f6ljrw not RUNNING+SSH within 120s; tearing down
+[t=  125.4s 05:17:26Z] DELETE pod nx264lh3f6ljrw
+[t=  126.4s 05:17:27Z] delete returned status=204 resp={}
+[t=  131.8s 05:17:32Z] pod nx264lh3f6ljrw confirmed terminated (404)
+[t=  131.8s 05:17:32Z] PROBE: pod nx264lh3f6ljrw torn down
+[t=    0.0s 05:17:33Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:17:33Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 05:17:34Z] create OK id=e3jrjdvtpw15qn costPerHr=$1.39
+[t=    1.1s 05:17:34Z] PROBE: pod created id=e3jrjdvtpw15qn; waiting for publicIp+ssh_port
+[t=    1.5s 05:17:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 05:17:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.3s 05:18:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 05:18:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 05:18:35Z] PROBE NO-GO: pod e3jrjdvtpw15qn not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 05:18:35Z] DELETE pod e3jrjdvtpw15qn
+[t=   63.5s 05:18:36Z] delete returned status=204 resp={}
+[t=   68.9s 05:18:41Z] pod e3jrjdvtpw15qn confirmed terminated (404)
+[t=   68.9s 05:18:41Z] PROBE: pod e3jrjdvtpw15qn torn down
+[t=    0.0s 05:18:42Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:18:42Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 05:18:43Z] create OK id=5z6fch21jj0p1g costPerHr=$3.29
+[t=    1.1s 05:18:43Z] PROBE: pod created id=5z6fch21jj0p1g; waiting for publicIp+ssh_port
+[t=    1.5s 05:18:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 05:18:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 05:19:14Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.1s 05:19:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.1s 05:19:45Z] PROBE NO-GO: pod 5z6fch21jj0p1g not RUNNING+SSH within 60s; tearing down
+[t=   63.1s 05:19:45Z] DELETE pod 5z6fch21jj0p1g
+[t=   63.7s 05:19:45Z] delete returned status=204 resp={}
+[t=   69.0s 05:19:51Z] pod 5z6fch21jj0p1g confirmed terminated (404)
+[t=   69.0s 05:19:51Z] PROBE: pod 5z6fch21jj0p1g torn down
+[t=    0.0s 05:19:51Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:19:51Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 05:19:52Z] create OK id=pazt3nyhv23fbf costPerHr=$2.89
+[t=    1.1s 05:19:52Z] PROBE: pod created id=pazt3nyhv23fbf; waiting for publicIp+ssh_port
+[t=    2.4s 05:19:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 05:20:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 05:20:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.8s 05:20:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.8s 05:20:55Z] PROBE NO-GO: pod pazt3nyhv23fbf not RUNNING+SSH within 60s; tearing down
+[t=   63.8s 05:20:55Z] DELETE pod pazt3nyhv23fbf
+[t=   64.3s 05:20:55Z] delete returned status=204 resp={}
+[t=   69.7s 05:21:01Z] pod pazt3nyhv23fbf confirmed terminated (404)
+[t=   69.7s 05:21:01Z] PROBE: pod pazt3nyhv23fbf torn down
+[t=    0.0s 05:21:01Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 05:21:01Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 05:21:02Z] create OK id=b8vj5slooqg2a6 costPerHr=$1.39
+[t=    1.0s 05:21:02Z] PROBE: pod created id=b8vj5slooqg2a6; waiting for publicIp+ssh_port
+[t=    1.3s 05:21:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 05:21:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.1s 05:21:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 05:21:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 05:22:03Z] PROBE NO-GO: pod b8vj5slooqg2a6 not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 05:22:03Z] DELETE pod b8vj5slooqg2a6
+[t=   63.2s 05:22:04Z] delete returned status=204 resp={}
+[t=   68.9s 05:22:10Z] pod b8vj5slooqg2a6 confirmed terminated (404)
+[t=   68.9s 05:22:10Z] PROBE: pod b8vj5slooqg2a6 torn down
+[t=    0.0s 05:22:29Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 05:22:29Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 05:22:30Z] create OK id=hwqqrg1ert1i4x costPerHr=$1.49
+[t=    1.0s 05:22:30Z] PROBE: pod created id=hwqqrg1ert1i4x; waiting for publicIp+ssh_port
+[t=    1.4s 05:22:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 05:22:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 05:23:02Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.1s 05:23:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.5s 05:23:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.0s 05:23:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.5s 05:24:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.1s 05:24:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.1s 05:24:34Z] PROBE NO-GO: pod hwqqrg1ert1i4x not RUNNING+SSH within 120s; tearing down
+[t=  125.1s 05:24:34Z] DELETE pod hwqqrg1ert1i4x
+[t=  125.7s 05:24:35Z] delete returned status=204 resp={}
+[t=  131.0s 05:24:40Z] pod hwqqrg1ert1i4x confirmed terminated (404)
+[t=  131.0s 05:24:40Z] PROBE: pod hwqqrg1ert1i4x torn down
+[t=    0.0s 05:24:40Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:24:40Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 05:24:42Z] create OK id=4l58gx8hwxcbk1 costPerHr=$1.39
+[t=    1.1s 05:24:42Z] PROBE: pod created id=4l58gx8hwxcbk1; waiting for publicIp+ssh_port
+[t=    1.5s 05:24:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.8s 05:24:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 05:25:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 05:25:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 05:25:43Z] PROBE NO-GO: pod 4l58gx8hwxcbk1 not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 05:25:43Z] DELETE pod 4l58gx8hwxcbk1
+[t=   63.5s 05:25:44Z] delete returned status=204 resp={}
+[t=   68.9s 05:25:49Z] pod 4l58gx8hwxcbk1 confirmed terminated (404)
+[t=   68.9s 05:25:49Z] PROBE: pod 4l58gx8hwxcbk1 torn down
+[t=    0.0s 05:25:49Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:25:49Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 05:25:51Z] create OK id=cc0q3tywjxu6bj costPerHr=$3.29
+[t=    1.2s 05:25:51Z] PROBE: pod created id=cc0q3tywjxu6bj; waiting for publicIp+ssh_port
+[t=    1.5s 05:25:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 05:26:06Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 05:26:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 05:26:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 05:26:53Z] PROBE NO-GO: pod cc0q3tywjxu6bj not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 05:26:53Z] DELETE pod cc0q3tywjxu6bj
+[t=   64.0s 05:26:53Z] delete returned status=204 resp={}
+[t=   69.3s 05:26:59Z] pod cc0q3tywjxu6bj confirmed terminated (404)
+[t=   69.3s 05:26:59Z] PROBE: pod cc0q3tywjxu6bj torn down
+[t=    0.0s 05:26:59Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:26:59Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 05:27:00Z] create OK id=zwaa40jqejom27 costPerHr=$2.89
+[t=    1.2s 05:27:00Z] PROBE: pod created id=zwaa40jqejom27; waiting for publicIp+ssh_port
+[t=    1.5s 05:27:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.9s 05:27:16Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 05:27:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 05:27:47Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 05:28:02Z] PROBE NO-GO: pod zwaa40jqejom27 not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 05:28:02Z] DELETE pod zwaa40jqejom27
+[t=   63.7s 05:28:03Z] delete returned status=204 resp={}
+[t=   69.1s 05:28:08Z] pod zwaa40jqejom27 confirmed terminated (404)
+[t=   69.1s 05:28:08Z] PROBE: pod zwaa40jqejom27 torn down
+[t=    0.0s 05:28:08Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 05:28:08Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 05:28:09Z] create OK id=vok61cbcfh94tj costPerHr=$1.39
+[t=    0.9s 05:28:09Z] PROBE: pod created id=vok61cbcfh94tj; waiting for publicIp+ssh_port
+[t=    1.2s 05:28:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.5s 05:28:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 05:28:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.4s 05:28:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.4s 05:29:11Z] PROBE NO-GO: pod vok61cbcfh94tj not RUNNING+SSH within 60s; tearing down
+[t=   62.4s 05:29:11Z] DELETE pod vok61cbcfh94tj
+[t=   63.1s 05:29:11Z] delete returned status=204 resp={}
+[t=   68.4s 05:29:17Z] pod vok61cbcfh94tj confirmed terminated (404)
+[t=   68.4s 05:29:17Z] PROBE: pod vok61cbcfh94tj torn down
+[t=    0.0s 05:29:48Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 05:29:48Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 05:29:49Z] create OK id=40jxjk7nzydaun costPerHr=$1.49
+[t=    1.3s 05:29:49Z] PROBE: pod created id=40jxjk7nzydaun; waiting for publicIp+ssh_port
+[t=    1.6s 05:29:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 05:30:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 05:30:20Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.1s 05:30:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.9s 05:30:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.4s 05:31:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.9s 05:31:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.7s 05:31:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.7s 05:31:53Z] PROBE NO-GO: pod 40jxjk7nzydaun not RUNNING+SSH within 120s; tearing down
+[t=  125.7s 05:31:53Z] DELETE pod 40jxjk7nzydaun
+[t=  126.7s 05:31:54Z] delete returned status=204 resp={}
+[t=  132.1s 05:32:00Z] pod 40jxjk7nzydaun confirmed terminated (404)
+[t=  132.1s 05:32:00Z] PROBE: pod 40jxjk7nzydaun torn down
+[t=    0.0s 05:32:00Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:32:00Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 05:32:01Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 05:32:01Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 05:32:01Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:32:01Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 05:32:02Z] create OK id=1zek1bb14w5v5i costPerHr=$3.29
+[t=    1.5s 05:32:02Z] PROBE: pod created id=1zek1bb14w5v5i; waiting for publicIp+ssh_port
+[t=    1.9s 05:32:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 05:32:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.8s 05:32:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.5s 05:32:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 05:33:05Z] PROBE NO-GO: pod 1zek1bb14w5v5i not RUNNING+SSH within 60s; tearing down
+[t=   64.6s 05:33:05Z] DELETE pod 1zek1bb14w5v5i
+[t=   65.2s 05:33:06Z] delete returned status=204 resp={}
+[t=   70.5s 05:33:11Z] pod 1zek1bb14w5v5i confirmed terminated (404)
+[t=   70.5s 05:33:11Z] PROBE: pod 1zek1bb14w5v5i torn down
+[t=    0.0s 05:33:11Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:33:11Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 05:33:13Z] create OK id=mvcr4a6bazishu costPerHr=$2.89
+[t=    1.2s 05:33:13Z] PROBE: pod created id=mvcr4a6bazishu; waiting for publicIp+ssh_port
+[t=    1.6s 05:33:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 05:33:28Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 05:33:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 05:33:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 05:34:14Z] PROBE NO-GO: pod mvcr4a6bazishu not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 05:34:14Z] DELETE pod mvcr4a6bazishu
+[t=   63.7s 05:34:15Z] delete returned status=204 resp={}
+[t=   69.1s 05:34:20Z] pod mvcr4a6bazishu confirmed terminated (404)
+[t=   69.1s 05:34:20Z] PROBE: pod mvcr4a6bazishu torn down
+[t=    0.0s 05:34:21Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 05:34:21Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.9s 05:34:22Z] create OK id=u5b29m3fm13miq costPerHr=$1.39
+[t=    0.9s 05:34:22Z] PROBE: pod created id=u5b29m3fm13miq; waiting for publicIp+ssh_port
+[t=    1.2s 05:34:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 05:34:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.0s 05:34:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.5s 05:35:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.5s 05:35:23Z] PROBE NO-GO: pod u5b29m3fm13miq not RUNNING+SSH within 60s; tearing down
+[t=   62.5s 05:35:23Z] DELETE pod u5b29m3fm13miq
+[t=   63.2s 05:35:24Z] delete returned status=204 resp={}
+[t=   68.6s 05:35:29Z] pod u5b29m3fm13miq confirmed terminated (404)
+[t=   68.6s 05:35:29Z] PROBE: pod u5b29m3fm13miq torn down
+[t=    0.0s 05:35:46Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 05:35:46Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.3s 05:35:47Z] create OK id=1lj1ctsalg65ii costPerHr=$1.49
+[t=    1.3s 05:35:47Z] PROBE: pod created id=1lj1ctsalg65ii; waiting for publicIp+ssh_port
+[t=    1.7s 05:35:48Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 05:36:03Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.6s 05:36:19Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.2s 05:36:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.7s 05:36:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   79.2s 05:37:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.6s 05:37:21Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.0s 05:37:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.0s 05:37:51Z] PROBE NO-GO: pod 1lj1ctsalg65ii not RUNNING+SSH within 120s; tearing down
+[t=  125.0s 05:37:51Z] DELETE pod 1lj1ctsalg65ii
+[t=  125.7s 05:37:52Z] delete returned status=204 resp={}
+[t=  130.9s 05:37:57Z] pod 1lj1ctsalg65ii confirmed terminated (404)
+[t=  130.9s 05:37:57Z] PROBE: pod 1lj1ctsalg65ii torn down
+[t=    0.0s 05:37:57Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:37:57Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 05:37:58Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 05:37:58Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 05:37:58Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:37:58Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 05:37:59Z] create OK id=al6qk34eiemnhe costPerHr=$3.29
+[t=    1.1s 05:37:59Z] PROBE: pod created id=al6qk34eiemnhe; waiting for publicIp+ssh_port
+[t=    1.5s 05:37:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 05:38:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 05:38:30Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.8s 05:38:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.8s 05:39:01Z] PROBE NO-GO: pod al6qk34eiemnhe not RUNNING+SSH within 60s; tearing down
+[t=   62.8s 05:39:01Z] DELETE pod al6qk34eiemnhe
+[t=   63.4s 05:39:01Z] delete returned status=204 resp={}
+[t=   68.7s 05:39:07Z] pod al6qk34eiemnhe confirmed terminated (404)
+[t=   68.7s 05:39:07Z] PROBE: pod al6qk34eiemnhe torn down
+[t=    0.0s 05:39:07Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:39:07Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 05:39:08Z] create OK id=j8qg9er078ut51 costPerHr=$2.89
+[t=    1.2s 05:39:08Z] PROBE: pod created id=j8qg9er078ut51; waiting for publicIp+ssh_port
+[t=    1.5s 05:39:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.5s 05:39:24Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.0s 05:39:40Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.4s 05:39:55Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.4s 05:40:10Z] PROBE NO-GO: pod j8qg9er078ut51 not RUNNING+SSH within 60s; tearing down
+[t=   63.4s 05:40:10Z] DELETE pod j8qg9er078ut51
+[t=   64.1s 05:40:11Z] delete returned status=204 resp={}
+[t=   69.5s 05:40:16Z] pod j8qg9er078ut51 confirmed terminated (404)
+[t=   69.5s 05:40:16Z] PROBE: pod j8qg9er078ut51 torn down
+[t=    0.0s 05:40:17Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 05:40:17Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.0s 05:40:18Z] create OK id=5vvotak8eyajta costPerHr=$1.39
+[t=    1.0s 05:40:18Z] PROBE: pod created id=5vvotak8eyajta; waiting for publicIp+ssh_port
+[t=    1.3s 05:40:18Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   16.7s 05:40:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.2s 05:40:49Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.7s 05:41:04Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.7s 05:41:19Z] PROBE NO-GO: pod 5vvotak8eyajta not RUNNING+SSH within 60s; tearing down
+[t=   62.7s 05:41:19Z] DELETE pod 5vvotak8eyajta
+[t=   63.3s 05:41:20Z] delete returned status=204 resp={}
+[t=   68.8s 05:41:25Z] pod 5vvotak8eyajta confirmed terminated (404)
+[t=   68.8s 05:41:25Z] PROBE: pod 5vvotak8eyajta torn down
+[t=    0.0s 05:41:43Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 05:41:43Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 05:41:44Z] create OK id=7hnkzbak6xjxto costPerHr=$1.49
+[t=    1.2s 05:41:44Z] PROBE: pod created id=7hnkzbak6xjxto; waiting for publicIp+ssh_port
+[t=    1.5s 05:41:44Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 05:41:59Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.4s 05:42:15Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 05:42:31Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.5s 05:42:46Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   78.9s 05:43:01Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   94.3s 05:43:17Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  110.0s 05:43:33Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  125.0s 05:43:48Z] PROBE NO-GO: pod 7hnkzbak6xjxto not RUNNING+SSH within 120s; tearing down
+[t=  125.0s 05:43:48Z] DELETE pod 7hnkzbak6xjxto
+[t=  125.6s 05:43:48Z] delete returned status=204 resp={}
+[t=  131.2s 05:43:54Z] pod 7hnkzbak6xjxto confirmed terminated (404)
+[t=  131.2s 05:43:54Z] PROBE: pod 7hnkzbak6xjxto torn down
+[t=    0.0s 05:43:54Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:43:54Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 05:43:55Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 05:43:55Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 05:43:55Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:43:55Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.1s 05:43:56Z] create OK id=gbb8pt16zuoqbh costPerHr=$3.29
+[t=    1.1s 05:43:56Z] PROBE: pod created id=gbb8pt16zuoqbh; waiting for publicIp+ssh_port
+[t=    1.5s 05:43:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 05:44:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 05:44:27Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   47.9s 05:44:43Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   62.9s 05:44:58Z] PROBE NO-GO: pod gbb8pt16zuoqbh not RUNNING+SSH within 60s; tearing down
+[t=   62.9s 05:44:58Z] DELETE pod gbb8pt16zuoqbh
+[t=   63.6s 05:44:58Z] delete returned status=204 resp={}
+[t=   69.1s 05:45:04Z] pod gbb8pt16zuoqbh confirmed terminated (404)
+[t=   69.1s 05:45:04Z] PROBE: pod gbb8pt16zuoqbh torn down
+[t=    0.0s 05:45:04Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 05:45:04Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.8s 05:45:05Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.8s 05:45:05Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 05:45:05Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 05:45:05Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.2s 05:45:06Z] create OK id=jb1gfxwj3splgy costPerHr=$1.39
+[t=    1.2s 05:45:06Z] PROBE: pod created id=jb1gfxwj3splgy; waiting for publicIp+ssh_port
+[t=    1.6s 05:45:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.1s 05:45:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 05:45:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.0s 05:45:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   63.0s 05:46:08Z] PROBE NO-GO: pod jb1gfxwj3splgy not RUNNING+SSH within 60s; tearing down
+[t=   63.0s 05:46:08Z] DELETE pod jb1gfxwj3splgy
+[t=   63.7s 05:46:09Z] delete returned status=204 resp={}
+[t=   69.1s 05:46:14Z] pod jb1gfxwj3splgy confirmed terminated (404)
+[t=   69.1s 05:46:14Z] PROBE: pod jb1gfxwj3splgy torn down
+[t=    0.0s 05:46:34Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 05:46:34Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 05:46:35Z] create OK id=4k1q069ux0k6jr costPerHr=$1.49
+[t=    1.5s 05:46:35Z] PROBE: pod created id=4k1q069ux0k6jr; waiting for publicIp+ssh_port
+[t=    2.0s 05:46:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.6s 05:46:51Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.3s 05:47:07Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   48.9s 05:47:23Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   64.5s 05:47:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.2s 05:47:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   96.0s 05:48:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t= 1048.8s 06:04:03Z] PROBE NO-GO: pod 4k1q069ux0k6jr not RUNNING+SSH within 120s; tearing down
+[t= 1048.8s 06:04:03Z] DELETE pod 4k1q069ux0k6jr
+[t= 1050.0s 06:04:04Z] delete returned status=204 resp={}
+[t= 1055.3s 06:04:09Z] pod 4k1q069ux0k6jr confirmed terminated (404)
+[t= 1055.3s 06:04:09Z] PROBE: pod 4k1q069ux0k6jr torn down
+[t=    0.0s 06:04:10Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 06:04:10Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 06:04:11Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 06:04:11Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 06:04:11Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 06:04:11Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 06:04:12Z] create OK id=w3pjsdssfa0hjt costPerHr=$3.29
+[t=    1.6s 06:04:12Z] PROBE: pod created id=w3pjsdssfa0hjt; waiting for publicIp+ssh_port
+[t=    2.1s 06:04:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.9s 06:04:29Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t= 1095.6s 06:22:26Z] PROBE NO-GO: pod w3pjsdssfa0hjt not RUNNING+SSH within 60s; tearing down
+[t= 1095.6s 06:22:26Z] DELETE pod w3pjsdssfa0hjt
+[t= 1096.3s 06:22:27Z] delete returned status=204 resp={}
+[t= 2001.8s 06:37:33Z] pod w3pjsdssfa0hjt confirmed terminated (404)
+[t= 2001.8s 06:37:33Z] PROBE: pod w3pjsdssfa0hjt torn down
+[t=    0.0s 06:37:33Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 06:37:33Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.0s 06:37:34Z] create OK id=2gbmtxm5z0whn5 costPerHr=$2.89
+[t=    1.0s 06:37:34Z] PROBE: pod created id=2gbmtxm5z0whn5; waiting for publicIp+ssh_port
+[t=    1.4s 06:37:34Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.0s 06:37:50Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.5s 06:38:05Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t= 1078.3s 06:55:31Z] PROBE NO-GO: pod 2gbmtxm5z0whn5 not RUNNING+SSH within 60s; tearing down
+[t= 1078.3s 06:55:31Z] DELETE pod 2gbmtxm5z0whn5
+[t= 1980.3s 07:10:33Z] delete returned status=204 resp={}
+[t= 1985.9s 07:10:39Z] pod 2gbmtxm5z0whn5 confirmed terminated (404)
+[t= 1985.9s 07:10:39Z] PROBE: pod 2gbmtxm5z0whn5 torn down
+[t=    0.0s 07:10:40Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 07:10:40Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    1.5s 07:10:41Z] create OK id=vome3jaoc9h5fp costPerHr=$1.39
+[t=    1.5s 07:10:41Z] PROBE: pod created id=vome3jaoc9h5fp; waiting for publicIp+ssh_port
+[t=    1.8s 07:10:42Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.3s 07:10:57Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   32.8s 07:11:13Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t= 2075.1s 07:45:15Z] PROBE NO-GO: pod vome3jaoc9h5fp not RUNNING+SSH within 60s; tearing down
+[t= 2075.1s 07:45:15Z] DELETE pod vome3jaoc9h5fp
+[t= 2075.8s 07:45:16Z] delete returned status=204 resp={}
+[t= 2312.2s 07:49:12Z] pod vome3jaoc9h5fp confirmed terminated (404)
+[t= 2312.2s 07:49:12Z] PROBE: pod vome3jaoc9h5fp torn down
+[t=    0.0s 08:40:34Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 08:40:34Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.2s 08:40:35Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    1.2s 08:40:35Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 08:40:35Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 08:40:35Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.9s 08:40:36Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.9s 08:40:36Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 08:40:36Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 08:40:36Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.5s 08:40:38Z] create OK id=z9nhkvy52j7l17 costPerHr=$3.29
+[t=    1.5s 08:40:38Z] PROBE: pod created id=z9nhkvy52j7l17; waiting for publicIp+ssh_port
+[t=    2.0s 08:40:38Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 08:40:54Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  583.4s 08:50:20Z] PROBE NO-GO: pod z9nhkvy52j7l17 not RUNNING+SSH within 60s; tearing down
+[t=  583.4s 08:50:20Z] DELETE pod z9nhkvy52j7l17
+[t=  584.1s 08:50:20Z] delete returned status=204 resp={}
+[t=  589.7s 08:50:26Z] pod z9nhkvy52j7l17 confirmed terminated (404)
+[t=  589.7s 08:50:26Z] PROBE: pod z9nhkvy52j7l17 torn down
+[t=    0.0s 08:50:26Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 08:50:26Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.9s 08:50:27Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.9s 08:50:27Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 08:50:27Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 08:50:27Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 08:50:28Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 08:50:28Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 08:50:54Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 08:50:54Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t= 1988.6s 09:24:02Z] create FAIL status=-1 resp=transport_error: ReadTimeout('The read operation timed out')
+[t= 1988.7s 09:24:02Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=-1
+[t=    0.0s 09:24:03Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 09:24:03Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.9s 09:24:04Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.9s 09:24:04Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 09:24:04Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 09:24:04Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    3.2s 09:24:07Z] create OK id=9d8m2ys7tx9crg costPerHr=$3.29
+[t=    3.2s 09:24:07Z] PROBE: pod created id=9d8m2ys7tx9crg; waiting for publicIp+ssh_port
+[t=    5.5s 09:24:10Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  140.6s 09:26:25Z] PROBE NO-GO: pod 9d8m2ys7tx9crg not RUNNING+SSH within 60s; tearing down
+[t=  140.6s 09:26:25Z] DELETE pod 9d8m2ys7tx9crg
+[t=  141.7s 09:26:26Z] delete returned status=204 resp={}
+[t=  147.1s 09:26:31Z] pod 9d8m2ys7tx9crg confirmed terminated (404)
+[t=  147.1s 09:26:31Z] PROBE: pod 9d8m2ys7tx9crg torn down
+[t=    0.0s 09:26:31Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 09:26:31Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 09:26:32Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 09:26:32Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 09:26:32Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 09:26:32Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 09:26:33Z] create FAIL status=500 resp={'error': 'create pod: There are no longer any instances available with the request specifications. Please try again later.', 'status': 500}
+[t=    0.5s 09:26:33Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 16:15:20Z] PROBE: spinning NVIDIA A100-SXM4-80GB SECURE/interruptible=False with 120s deadline
+[t=    0.0s 16:15:20Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.6s 16:15:21Z] create OK id=22brpndelxl7b5 costPerHr=$1.49
+[t=    1.6s 16:15:21Z] PROBE: pod created id=22brpndelxl7b5; waiting for publicIp+ssh_port
+[t=    2.1s 16:15:22Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   17.8s 16:15:37Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.4s 16:15:53Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.1s 16:16:09Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   65.1s 16:16:25Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   80.9s 16:16:41Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   96.6s 16:16:56Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  112.2s 16:17:12Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=  127.2s 16:17:27Z] PROBE NO-GO: pod 22brpndelxl7b5 not RUNNING+SSH within 120s; tearing down
+[t=  127.2s 16:17:27Z] DELETE pod 22brpndelxl7b5
+[t=  127.8s 16:17:28Z] delete returned status=204 resp={}
+[t=  133.2s 16:17:33Z] pod 22brpndelxl7b5 confirmed terminated (404)
+[t=  133.2s 16:17:33Z] PROBE: pod 22brpndelxl7b5 torn down
+[t=    0.0s 16:17:33Z] PROBE: spinning NVIDIA A100 80GB PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 16:17:33Z] create_pod request: gpu=NVIDIA A100 80GB PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.7s 16:17:34Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.7s 16:17:34Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 16:17:34Z] PROBE: spinning NVIDIA H100 80GB HBM3 SECURE/interruptible=False with 60s deadline
+[t=    0.0s 16:17:34Z] create_pod request: gpu=NVIDIA H100 80GB HBM3 image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    1.4s 16:17:35Z] create OK id=4hlqwbq57q3duo costPerHr=$3.29
+[t=    1.4s 16:17:35Z] PROBE: pod created id=4hlqwbq57q3duo; waiting for publicIp+ssh_port
+[t=    2.0s 16:17:36Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   18.0s 16:17:52Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   33.8s 16:18:08Z] poll desiredStatus=RUNNING publicIp= ssh_port=None
+[t=   49.6s 16:18:24Z] poll desiredStatus=EXITED publicIp= ssh_port=None
+[t=   64.7s 16:18:39Z] PROBE NO-GO: pod 4hlqwbq57q3duo not RUNNING+SSH within 60s; tearing down
+[t=   64.7s 16:18:39Z] DELETE pod 4hlqwbq57q3duo
+[t=   65.3s 16:18:39Z] delete returned status=204 resp={}
+[t=   70.7s 16:18:45Z] pod 4hlqwbq57q3duo confirmed terminated (404)
+[t=   70.7s 16:18:45Z] PROBE: pod 4hlqwbq57q3duo torn down
+[t=    0.0s 16:18:45Z] PROBE: spinning NVIDIA H100 PCIe SECURE/interruptible=False with 60s deadline
+[t=    0.0s 16:18:45Z] create_pod request: gpu=NVIDIA H100 PCIe image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=SECURE/interruptible=False
+[t=    0.6s 16:18:45Z] create FAIL status=500 resp={'error': 'create pod: There are no instances currently available', 'status': 500}
+[t=    0.6s 16:18:45Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500
+[t=    0.0s 16:18:46Z] PROBE: spinning NVIDIA A100-SXM4-80GB COMMUNITY/interruptible=True with 60s deadline
+[t=    0.0s 16:18:46Z] create_pod request: gpu=NVIDIA A100-SXM4-80GB image=runpod/pytorch:2.1.0-py3.10-cuda12.1.1-devel-ubuntu22.04 cloud=COMMUNITY/interruptible=True
+[t=    0.5s 16:18:46Z] create FAIL status=500 resp={'error': 'create pod: You have insufficient funds to bid on this pod. Please add funds to your account.', 'status': 500}
+[t=    0.5s 16:18:46Z] PROBE EXCEPTION: RuntimeError: pod create failed: status=500

--- a/scripts/m4_path_c_orchestrator.py
+++ b/scripts/m4_path_c_orchestrator.py
@@ -24,6 +24,7 @@ DELETEd and verified 404.
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import json
 import os
 import signal
@@ -33,6 +34,14 @@ import time
 from pathlib import Path
 
 import httpx
+
+# Single worker that survives api() hangs. Observed twice on 2026-05-17/18:
+# wait_for_running poll loops hung for 32-48 min on a single api() call,
+# burning $0.75-$1.20 per hang on idle stuck-provisioning pods. httpx's
+# 30s client timeout didn't fire — suspected client-side DNS / TCP wedge
+# on macOS that the user-space httpx timeout can't preempt. Worker-thread
+# timeout returns control even if the underlying socket call leaks.
+_API_TIMEOUT_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=4)
 
 # Strip proxy env vars before httpx instantiates a client — local shell
 # may export ALL_PROXY=socks5h://... which forces httpx to require the
@@ -110,7 +119,7 @@ def _client() -> httpx.Client:
     return _HTTP
 
 
-def api(method: str, path: str, body: dict | None = None, timeout: int = 30):
+def _api_inner(method: str, path: str, body: dict | None, timeout: int):
     try:
         resp = _client().request(method, path, json=body, timeout=timeout)
     except httpx.RequestError as exc:
@@ -120,6 +129,18 @@ def api(method: str, path: str, body: dict | None = None, timeout: int = 30):
         return resp.status_code, json.loads(raw) if raw else {}
     except json.JSONDecodeError:
         return resp.status_code, raw
+
+
+def api(method: str, path: str, body: dict | None = None, timeout: int = 30):
+    # Outer thread-based timeout: httpx's 30s client timeout has missed
+    # twice (32-min and 48-min hangs in M4 probe). Outer cap = inner + 5s
+    # so we only fire if httpx is the one wedged, not the network.
+    fut = _API_TIMEOUT_POOL.submit(_api_inner, method, path, body, timeout)
+    try:
+        return fut.result(timeout=timeout + 5)
+    except concurrent.futures.TimeoutError:
+        # Worker leaks (bounded by pool size 4) but we get control back.
+        return -1, "outer_thread_timeout"
 
 
 def create_pod(pubkey: str, cloud_type: str = "SECURE", interruptible: bool = False) -> dict:


### PR DESCRIPTION
Audit-trail PR for the M4 Path C probe retry chain that ran 2026-05-17 18:34Z through 2026-05-20 16:18Z. Chain stopped when RunPod account balance hit zero (`insufficient funds to bid on this pod`).

## Numbers

| Metric | Value |
|---|---|
| Pods created and torn down | **512** |
| 500 "no instances" responses | 289 |
| Pod-hours billed | 23.48 |
| RunPod spend | **~\$47.16** |
| Hangs > 5 min | 33 |
| Worst hang | H100 HBM3 ran 61 min, \$3.03 |
| `PROBE GO` outcomes | **0** |

## Verdict

RunPod's allocator is structurally broken across A100-SXM4 SECURE, A100 PCIe SECURE, H100 80GB HBM3 SECURE, H100 PCIe SECURE, and A100-SXM4 COMMUNITY-spot. Pods create at \$1.39–\$2.99/hr but never publish `publicIp` within the deadline. Not a capacity issue (`create OK` succeeded 512 times); not SKU-specific (held across 5 distinct SKU/cloud combos). The retry chain paid ~\$47 to empirically confirm the provider is unusable for M4 right now.

## Orchestrator patch + suspension behavior

`scripts/m4_path_c_orchestrator.py` was hardened mid-chain with a `concurrent.futures` ThreadPoolExecutor timeout around `api()`. Doesn't fix the actual hangs — macOS / Claude Code harness suspends the Python process, freezing both worker thread and main thread together. Documented in `OUTCOME.md` for future readers.

## Decision implications for v0.2.0

- Path C measure-first probe was a no-op. Arm 2 vs Arm 1 quiet-p99-TTFT delta could not be evaluated.
- Locked threshold table from #103 still applies.
- Two next-step options, see `OUTCOME.md` § "What ships next":
  - (A) Port `m4_path_c_orchestrator.py` to Lambda Labs (~4–6h)
  - (B) Ship v0.2.0 disconfirm-by-default

Provider-switch (A) is the cleaner call.

## Operational hygiene

- Cron `19ee4a48` deleted 2026-05-20 16:19Z. No retries scheduled.
- 5 EXITED pods cleaned up via REST DELETE post-chain. No alive pods leaked.
- This branch carries the 05-17 `orchestrator.log` too (PR #136 has the same blob from a different branch); whichever lands first wins.

Refs #103. Supersedes #136 if landed first (identical blob for 05-17 log; #136 also has 05-17 `OUTCOME.md` which this branch doesn't).